### PR TITLE
Integrate transaction manager into graph mutate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,310 +1,469 @@
-Remet à zero le fichier AGENTS.md et importe la liste des taches fournit ci dessous ainsi que les informations (au mot près) dans le fichier. Une fois effectué, commence l'implementation, et prend ton temps. 
-
 ----------  
-Voilà le **contrôle exhaustif** de la version actuelle du dépôt (j’ai dézippé et audité l’archive que tu viens d’envoyer), en recoupant **toutes** les tâches de nos précédentes check-lists (pas seulement la dernière). Je te donne d’abord un brief clair, puis une **check-list à cocher** ultra-précise, fichier par fichier, avec sous-étapes et attentes tests/build.
+Voici ta **liste de tâches à cocher** (adressée directement à toi, l’agent) pour intégrer — finement et intelligemment — les innovations de mes deux dernières recherches dans la **version actuelle** du dépôt.
+Elle précise **objectifs**, **correctifs attendus**, **fichiers à créer/modifier**, **sous-étapes** (avec sous-sous-étapes), ainsi que ce qu’il faut **respecter pour les tests et le build**.
+Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex par enfant, pas d’auth, CI Node 18/20/22.
 
 ---
 
-# BRIEF (à toi l’agent)
+## BRIEF (lis-moi d’abord)
 
-* Tu dois valider que l’orchestrateur multi-agent est **complet & robuste** (enfants + planification + graphes), et que les **innovations** sont bien en place (mémoire partagée, méta-critique, graphes adaptatifs, sandbox, dashboard, router multi-modèles, hypothèses, etc.).
-* D’après mon audit statique du dépôt dézippé :
+**Objectif général**
+Élever la puissance d’**utilisation/implémentation** des graphes et du système multi-agent, sans dépendre d’infra externe :
 
-  * ✅ **Modules et outils** : presque tout est **présent et câblé** (y compris les nouveautés).
-  * ✅ **Outils enregistrés** : tous les tools attendus sont bien référencés dans `src/server.ts` (child_*, plan_*, graph_*, simulate/optimize, export…).
-  * ✅ **Tests** : large couverture présente (enfants, plan, memory, dashboard, sandbox, router, hypotheses, etc.).
-  * ✅ **Build/CI** : scripts npm corrects, CI matrice Node 18/20/22 configurée.
-  * ⚠️ **Deux briques manquantes** vs. la feuille de route innovation :
+* Graphes **hiérarchiques/adaptatifs** (sous-graphes, hyper-arêtes ciblées, réécriture transactionnelle).
+* Exécution **réactive/itérative** (interpréteur Behavior Tree + scheduler réactif à événements).
+* **Coordination** avancée (blackboard, stigmergie, Contract-Net, consensus) et **auto-organisation** (autoscaling d’enfants, superviseur “global workspace”).
+* **Mémoire structurée** d’implémentation (graphe de connaissance interne + mémoire causale d’événements) pour *réutiliser* et *reconfigurer* les plans en direct.
+* **Filtrage par valeurs** (graphe de valeurs → garde-fous éthiques/fonctionnels).
+* Intégration serveur (nouvelles tools MCP) + visualisations temps réel.
 
-    * `src/agents/selfReflect.ts` **absent**
-    * `src/quality/scoring.ts` **absent**
-    * …et, logiquement, **pas** de tests associés (`tests/agents.selfReflect.test.ts`, `tests/quality.scoring.test.ts`).
-* Objectifs immédiats :
+**Correctifs attendus**
 
-  1. Implémenter **Self-Reflection** et **Scoring** (modules + tools si exposés + tests).
-  2. Faire une **passe QA** rapide sur les modules ajoutés récemment (memory/attention, adaptive graph, hypotheses, sandbox, dashboard, loopDetector, router) pour vérifier leurs assertions & tests.
-  3. Vérifier **l’étanchéité FS** et les **time-outs** des enfants (déjà testés, mais renforcer les cas négatifs).
+* Zod pour *toute* nouvelle tool, erreurs codifiées, timeouts contrôlés.
+* Aucune écriture dans le repo, uniquement `children/<id>/` et répertoires de run.
+* Tests **offline** déterministes (fake timers), CI **verte** 18/20/22.
+* Feature flags *off* par défaut, activables via `serverOptions`.
 
----
+**Critères d’acceptation**
 
-# Ce que j’ai vérifié (preuves)
-
-* **Dézippage et inventaire statique** faits dans mon environnement (listings complets + introspection des fichiers clés et des tests).
-* **Présence modules (innovation)** :
-
-  * OK : `src/memory/store.ts`, `src/memory/attention.ts`, `src/graph/adaptive.ts`, `src/strategies/hypotheses.ts`, `src/sim/sandbox.ts`, `src/router/modelRouter.ts`, `src/audit/planBias.ts`, `src/monitor/dashboard.ts`, `src/guard/loopDetector.ts`, `src/viz/mermaid.ts`, `src/viz/dot.ts`, `graph-forge/src/algorithms/{yen,brandes,constraints}.ts`, etc.
-  * **Manquent** : `src/agents/selfReflect.ts`, `src/quality/scoring.ts`.
-* **Enregistrement tools** dans `src/server.ts` : présents pour `child_*`, `plan_*`, `graph_*`, `graph_simulate`, `graph_optimize`, `graph_optimize_moo`, `graph_export`, etc.
-* **Scripts & CI** :
-
-  * `build`: `tsc && tsc -p graph-forge/tsconfig.json`
-  * `start` (STDIO), `start:http` (isolé), `dev` (ts-node ESM), `lint` (double `tsc --noEmit`), `test` (build → mocha/ts-node).
-  * `engines.node >= 18.17`, `type: "module"`.
-  * CI workflow : matrice Node **18/20/22**, étapes install → build → lint → test.
-
-> NB : je n’exécute pas les tests ici (pas de Node exécutable dans mon runtime), mais l’inventaire montre une **batterie complète** de tests : `tests/child.lifecycle.test.ts`, `plan.fanout-join.test.ts`, `plan.reduce.test.ts`, `memory.*.test.ts`, `monitor.dashboard.test.ts`, `sim.sandbox.test.ts`, `router.modelRouter.test.ts`, `strategies.hypotheses.test.ts`, `graphforge.*.test.ts`, `graph.*.test.ts`, `paths/prompts/serverOptions/*.test.ts`, etc.
+* Plans hiérarchiques exécutables, réécriture sûre (snapshot/rollback).
+* Moteur BT fonctionnel (Sequence/Selector/Parallel/Decorator) + scheduler réactif.
+* Blackboard, stigmergie, contract-net et consensus **opérationnels** + tests.
+* Autoscaler et Superviseur débloquent les impasses sans fuite de processus.
+* Mémoire (KG + causal) branchée à la planification, exportable.
+* Graphe de valeurs filtrant réellement les plans.
+* Dashboard : heatmaps stigmergiques + statut BT en temps réel.
 
 ---
 
-# Liste de tâches à cocher (fichier par fichier, avec sous-étapes)
+## RÈGLES BUILD/TEST (à respecter partout)
 
-## 0) Règles d’exécution (à respecter pour toute la passe)
+* **Install**
 
-* [x] **Install** : s’il y a un lockfile → `npm ci` ; sinon `npm install --omit=dev --no-save --no-package-lock`.
-* [x] **Build** : `npm run build` (racine + graph-forge).
-* [x] **Lint** : `npm run lint` (double `tsc --noEmit`).
-* [x] **Tests** : offline & déterministes, `npm test`.
-* [x] **I/O** : aucune écriture dans le repo ; uniquement `children/<id>/` ou répertoire de run.
-* [x] **Zod** : messages d’erreur courts + codes stables.
-* [x] **FS** : pas de traversal (`..`), chemins normalisés.
-
----
-
-## A) Implémenter la **Self-Reflection** (manquante)
-
-**Fichiers à créer**
-
-* [x] `src/agents/selfReflect.ts`
-
-  * [x] Exporter `reflect({ kind, input, output, meta }): Promise<{ insights: string[]; nextSteps: string[]; risks: string[] }>`
-  * [x] Heuristiques basiques par `kind` :
-
-    * code → regarder patterns d’erreurs courants, suggestions tests/lint
-    * texte → clarté, cohérence, contre-exemples
-    * plan → dépendances manquantes, alternatives à explorer
-  * [x] Param `meta` pour injecter contexte (p. ex. scores, délais).
-* [x] `src/agents/__tests__/selfReflect.fixtures.ts` (petits cas)
-
-**Intégration**
-
-* [x] `src/server.ts`
-
-  * [x] Hook post-outil : si `options.enableReflection` ou `kind` ∈ {code, plan, text} → appeler `reflect(...)`
-  * [x] Ajouter ces **insights** dans les logs (sans données lourdes)
-
-**Tests**
-
-* [x] `tests/agents.selfReflect.test.ts`
-
-  * [x] 3 cas (code/texte/plan) → insights non vides et pertinents
-  * [x] Cas d’entrée minimal (robustesse)
-  * [x] Seed fixée pour tout aléatoire
+  * Si lockfile : `npm ci`
+  * Sinon : `npm install --omit=dev --no-save --no-package-lock`
+* **Build** : `npm run build` (racine + `graph-forge`)
+* **Lint** : `npm run lint` (double `tsc --noEmit`)
+* **Tests** : `npm test` offline, déterministes (use `sinon.useFakeTimers()`), seeds fixées
+* **Zod** : messages `code`/`message`/`hint` courts, stables
+* **FS** : pas de `..`, chemins normalisés (utilise `src/paths.ts`)
+* **Logs** : JSONL compact + rotation, pas de blobs lourds en CI
 
 ---
 
-## B) Implémenter le **Scoring qualitatif** (manquant)
+## A) Graphes : expressivité, hiérarchie, réécriture, transactions
 
-**Fichiers à créer**
+### A1. Sous-graphes hiérarchiques (plans imbriqués)
 
-* [x] `src/quality/scoring.ts`
+* [x] **Créer** `src/graph/hierarchy.ts`
 
-  * [x] `scoreCode({ testsPassed, lintErrors, complexity }): { score: number, rubric: Record<string,number> }`
-  * [x] `scoreText({ factsOK, readability, structure }): { score: number, rubric }`
-  * [x] `scorePlan({ coherence, coverage, risk }): { score: number, rubric }`
-  * [x] Tous les scores ∈ [0,100], rubrics lisibles
+  * [x] Types :
 
-**Intégration**
+    * `HierNode = TaskNode | SubgraphNode`
+    * `SubgraphNode = { id, kind:"subgraph", ref:string, params?:Record<string,any> }`
+    * `HierGraph = { id, nodes:HierNode[], edges:Edge[] }`
+  * [x] API : `embedSubgraph(parent:HierGraph, nodeId, sub:HierGraph)`, `flatten(h:HierGraph): Graph` (expansion contrôlée)
+  * [x] **Validation** (no cycles inter-niveaux, ports d’entrée/sortie nommés)
+* [ ] **Modifier** `src/server.ts`
 
-* [x] `src/server.ts`
+  * [ ] Étendre `graph_generate`/`graph_mutate` pour `kind:"subgraph"`
+  * [ ] Nouvelle tool `graph_subgraph_extract` (extrait un sous-plan en fichier JSON, versionné dans run dir)
+* [x] **Tests**
 
-  * [x] Après chaque call tool “livrable” → scorer selon `kind`
-  * [x] Si `score < threshold` → relancer amélioration (optionnel) ou marquer “needs_revision”
-  * [x] Exposer option d’activation dans options runtime
+  * [x] `tests/graph.hierarchy.generate-embed.test.ts` (embed + validate)
+  * [x] `tests/graph.hierarchy.flatten.test.ts` (flatten = graphe équivalent, topologie conservée)
 
-**Tests**
+### A2. Hyper-arêtes minimales (relations n-aires ciblées)
 
-* [x] `tests/quality.scoring.test.ts`
+* [x] **Créer** `src/graph/hypergraph.ts`
 
-  * [x] Cas nominal + cas extrêmes (0/100)
-  * [x] Robustesse sur champs manquants (zod)
+  * [x] `HyperEdge = { id, sources:string[], targets:string[], label?, weight? }`
+  * [x] Projection automatique → arêtes binaires (pour algos existants) avec métadonnées
+* [x] **Modifier** `graph_export` (Mermaid/DOT) pour indiquer hyper-arêtes (annotation)
+* [x] **Tests**
 
----
+  * [x] `tests/graph.hyper.project.test.ts` (projection correcte)
+  * [x] `tests/graph.export.hyper.test.ts` (export annoté lisible)
 
-## C) Revue & durcissement des **modules ajoutés récemment**
+### A3. Moteur de réécriture & adaptativité contrôlée
 
-> Vérifie chacun des modules suivants, déjà PRÉSENTS, avec une courte passe QA (contrats, erreurs, tests négatifs).
+* [x] **Créer** `src/graph/rewrite.ts`
 
-* [x] `src/memory/store.ts`
+  * [x] `Rule = { name, match:(g)=>MatchSet, apply:(g, m)=>g’ }`
+  * [x] Banque de règles : *split-parallel*, *inline-subgraph*, *reroute-avoid(node/label)*
+  * [x] Combinator : `applyAll(g, rules, stopOnNoChange=true)`
+* [x] **Relier** à `src/graph/adaptive.ts` (renforcement/élagage déclenchent règles)
+* [x] **Tests**
 
-  * [x] Vérifie TTL/GC des entrées et tailles max
-  * [x] Tests : `tests/memory.store.test.ts` → ajouter cas de saturation mémoire
+  * [x] `tests/graph.rewrite.rules.test.ts` (idempotence, pas de cycles induits)
+  * [x] `tests/graph.adaptive.rewrite.test.ts` (réécriture pilotée par score)
 
-* [x] `src/memory/attention.ts`
+### A4. Transactions & versions
 
-  * [x] Vérifie traitement du bruit, sélection stricte du contexte
-  * [x] Tests : `tests/memory.attention.test.ts` → ajouter cas avec contexte contradictoire
+* [x] **Créer** `src/graph/tx.ts`
 
-* [x] `src/graph/adaptive.ts`
+  * [x] Snapshot/rollback : `begin(g)->txId`, `commit(txId)`, `rollback(txId)`
+  * [x] Numéro de **version** incrémental + horodatage
+* [ ] **Intégrer** à *toutes* mutations serveur (wrap `graph_mutate`, `graph_rewrite_apply`)
+  * [x] Wrap `graph_mutate`
+  * [ ] Wrap `graph_rewrite_apply`
+* [ ] **Tests**
 
-  * [x] Vérifie que le renforcement/élagage est **idempotent** et versionne le graphe
-  * [x] Tests : `tests/graph.adaptive.test.ts` → compléter cas d’élagage
-
-* [x] `src/strategies/hypotheses.ts`
-
-  * [x] Vérifie divergence (≥2 plans) + convergence (sélection/fusion)
-  * [x] Tests : `tests/strategies.hypotheses.test.ts` → ajouter un cas de fusion partielle
-
-* [x] `src/sim/sandbox.ts`
-
-  * [x] Vérifie isolement I/O et horloge mockée
-  * [x] Tests : `tests/sim.sandbox.test.ts` → ajouter cas d’exception et timeouts
-
-* [x] `src/router/modelRouter.ts`
-
-  * [x] Vérifie routage par type, fallback Codex, refus si modèle indispo
-  * [x] Tests : `tests/router.modelRouter.test.ts` → ajouter table de routage invalide
-
-* [ ] `src/audit/planBias.ts`
-
-  * [x] Vérifie déclencheurs d’alertes (ancrage, monoculture) + actions correctives
-  * [x] Tests : `tests/audit.planBias.test.ts` → ajouter un cas “fausse alerte”
-
-* [ ] `src/monitor/dashboard.ts`
-
-  * [ ] Vérifie endpoints min. (health, graph state snapshot)
-  * [ ] Tests : `tests/monitor.dashboard.test.ts` → smoke + JSON shape stable
-
-* [ ] `src/guard/loopDetector.ts`
-
-  * [x] Vérifie détection cycles & mitige (pause/kill)
-  * [x] Tests : `tests/guard.loopDetector.test.ts` → graph synthétique A↔B
-
-* [x] `src/viz/mermaid.ts` / `src/viz/dot.ts`
-
-  * [x] Vérifie échappement des labels/ids
-  * [x] Tests : compléter `tests/graph.export.test.ts` avec cas d’échappement
+  * [x] `tests/graph.tx.snapshot-rollback.test.ts`
+  * [x] `tests/graph.tx.concurrency.test.ts` (refus MAJ si version diverge)
 
 ---
 
-## D) Enfants, Planification, Graph-Forge (conformité finale)
+## B) Exécution **réactive** et **itérative**
 
-* [x] `src/childRuntime.ts` / `src/state/childrenIndex.ts` / `src/artifacts.ts` / `src/prompts.ts` / `src/paths.ts`
+### B1. Interpréteur Behavior Tree (BT)
 
-  * [x] Re-passer tests négatifs : invalid inputs, fs traversal, kill forcé
-  * [x] `tests/child.lifecycle.test.ts` / `tests/state.childrenIndex.test.ts` / `tests/paths.test.ts` OK
+* [ ] **Créer** `src/executor/bt/types.ts` (Status: `SUCCESS|FAILURE|RUNNING`)
+* [ ] **Créer** `src/executor/bt/nodes.ts`
 
-* [ ] `src/server.ts` plan_*
+  * [ ] Composites : `Sequence`, `Selector`, `Parallel(policy:all/any)`
+  * [ ] Décorateurs : `Retry(n, backoff)`, `Timeout(ms)`, `Guard(cond)`
+  * [ ] Feuilles : `TaskLeaf(toolName, inputSchema)` → appelle tools existants (child_send, graph_*…)
+* [ ] **Créer** `src/executor/bt/interpreter.ts` (tick async, persistance état nœuds)
+* [ ] **Créer** `src/executor/bt/compiler.ts` (compile `HierGraph` → BT selon patrons)
+* [ ] **Modifier** `src/server.ts`
 
-  * [ ] `plan_fanout` retry/backoff, `plan_join` (all|first_success|quorum), `plan_reduce` (concat|merge_json|vote)
-  * [ ] `tests/plan.fanout-join.test.ts` / `tests/plan.reduce.test.ts` : ajouter cas “quorum = 2/3” avec échec d’un enfant
+  * [ ] Nouvelle tool `plan_compile_bt` (retourne JSON BT)
+  * [ ] Nouvelle tool `plan_run_bt` (lance interpréteur + expose events)
+* [ ] **Tests**
 
-* [ ] `graph-forge/src/algorithms/{yen,brandes,constraints}.ts` + `graph-forge/src/index.ts`
+  * [ ] `tests/bt.nodes.sequence-selector.test.ts`
+  * [ ] `tests/bt.decorators.retry-timeout.test.ts` (fake timers)
+  * [ ] `tests/bt.compiler.from-hiergraph.test.ts`
+  * [ ] `tests/bt.run.integration.test.ts` (BT → outils réels mockés)
 
-  * [ ] Assurer no-dup des chemins (Yen), précision betweenness, respect contraintes
-  * [x] `tests/graphforge.*.test.ts` : ajouter cas pondéré très extrême (poids 10⁶) pour overflow
+### B2. Scheduler réactif & bus d’événements
 
----
+* [ ] **Créer** `src/executor/reactiveScheduler.ts`
 
-## E) Simulation/Optimisation/Causalité (cohérence)
+  * [ ] EventBus (Node `EventEmitter`) : `taskReady`, `taskDone`, `blackboardChanged`, `stigmergyChanged`
+  * [ ] Politique : priorité dynamique (âge, criticité, phéromones)
+* [ ] **Relier** BT → Scheduler (ticks pilotés par événements)
+* [ ] **Tests**
 
-* [ ] `src/server.ts` : `graph_simulate`, `graph_critical_path`, `graph_optimize`, `graph_optimize_moo`, `graph_causal_analyze`
+  * [ ] `tests/executor.scheduler.reactivity.test.ts` (réaction immédiate aux events)
+  * [ ] `tests/executor.scheduler.prio.test.ts` (priorités évolutives)
 
-  * [x] Vérifier cohérence makespan vs. chemin critique, Pareto non dominé
-* [x] Tests : `tests/graph.simulate.test.ts`, `tests/graph.critical-path.test.ts`, `tests/graph.optimize*.test.ts`, `tests/graph.causal.test.ts`
-  * [x] Ajouter un test Pareto avec 3 solutions (2 extrêmes + 1 médiane)
+### B3. Boucle de *ticks* & budgets
 
----
+* [ ] **Créer** `src/executor/loop.ts`
 
-## F) Scripts, CI, Docs
+  * [ ] Tick cadencé (`setInterval`) + `pause/resume/stop`
+  * [ ] Budgets : tâches longues → coopérative (yield)
+* [ ] **Tests**
 
-* [x] `package.json`
-
-  * [x] S’assurer que `test:unit` référence bien `mocha/bin/mocha.js` (chemin résolu)
-  * [x] `test:int` : vérifier `scripts/run-int-tests.mjs` (si présent)
-
-* [x] `.github/workflows/ci.yml`
-
-  * [x] Confirmer “install dependencies **without writing**” (no-save/no-lock quand pas de lockfile)
-
-* [x] `README.md` / `AGENTS.md`
-
-  * [x] Ajouter exemples d’usage pour **selfReflect** et **scoring** (inputs/outputs courts)
-  * [x] Mettre à jour sections mémoire/attention, adaptive graph, hypotheses, sandbox, dashboard
-
----
-
-# Acceptation (doit être vrai à la fin)
-
-* Tous les **tools** sont enregistrés, valides, et testés (happy + erreurs).
-* **Self-Reflection** & **Scoring** existent, intégrés, testés, et visibles dans les logs.
-* Les modules **memory/attention, adaptive, hypotheses, sandbox, router, planBias, dashboard, loopDetector, viz** passent leurs tests.
-* **Graph-Forge** : Yen/Brandes/Constraints conformes, sans doublons ni overflow.
-* **Simulation/Optimisation/Causalité** : tests précis et cohérents.
-* **CI** verte sur Node 18/20/22.
-* **Docs** (README/AGENTS) à jour avec exemples concrets.
+  * [ ] `tests/executor.loop.timing.test.ts` (fake timers, no drift)
+  * [ ] `tests/executor.loop.budget.test.ts`
 
 ---
 
-## Rappels build/tests (copier-coller)
+## C) Coordination & communication (blackboard, stigmergie, contrat, consensus)
 
-```
-# Installation (sans écriture si pas de lockfile)
-if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
-  npm ci
-else
-  npm install --omit=dev --no-save --no-package-lock
-fi
+### C1. **Blackboard** (tableau noir)
 
-# Build + lint + tests
-npm run build
-npm run lint
-npm test -- -R spec
-```
+* [ ] **Créer** `src/coord/blackboard.ts`
 
-Si tu veux, je peux te générer **les squelettes** pour `src/agents/selfReflect.ts`, `src/quality/scoring.ts` et leurs tests Mocha, prêts à coller dans le repo.
+  * [ ] KV typé + tags + TTL + watch (events)
+  * [ ] Snapshots (pour débogage, export)
+* [ ] **Modifier** `src/server.ts`
+
+  * [ ] Tools : `bb_set`, `bb_get`, `bb_query`, `bb_watch(startFromVersion)` (stream)
+* [ ] **Tests**
+
+  * [ ] `tests/coord.blackboard.kv.test.ts`
+  * [ ] `tests/coord.blackboard.watch.test.ts` (dédup + ordre)
+
+### C2. **Stigmergie** (phéromones)
+
+* [ ] **Créer** `src/coord/stigmergy.ts`
+
+  * [ ] API : `mark(nodeId, type, intensity)`, `evaporate(halfLifeMs)`, `fieldSnapshot()`
+* [ ] **Modifier** scheduler pour pondérer sélection de tâches par champ de phéromones
+* [ ] **Server tools** : `stig_mark`, `stig_decay`, `stig_snapshot`
+* [ ] **Tests**
+
+  * [ ] `tests/coord.stigmergy.field.test.ts` (accumulation/évaporation)
+  * [ ] `tests/coord.stigmergy.scheduler.test.ts` (impact mesurable sur choix)
+
+### C3. **Contract-Net Protocol**
+
+* [ ] **Créer** `src/coord/contractNet.ts`
+
+  * [ ] Messages : `announce(task)`, `bid(agentId,cost)`, `award(agentId)`
+  * [ ] Stratégie d’attribution (min cost, heuristique)
+* [ ] **Intégrer** à `child_create`/`child_send` (routeur de tâches via CNP si activé)
+* [ ] **Server tool** : `cnp_announce` (expérimental)
+* [ ] **Tests**
+
+  * [ ] `tests/coord.contractnet.basic.test.ts`
+  * [ ] `tests/coord.contractnet.tie-breaker.test.ts`
+
+### C4. **Consensus / Vote**
+
+* [ ] **Créer** `src/coord/consensus.ts`
+
+  * [ ] `majority`, `quorum(k)`, `weighted(weights)`
+* [ ] **Relier** à `plan_join` / `plan_reduce` (mode `vote`)
+* [ ] **Tests**
+
+  * [ ] `tests/coord.consensus.modes.test.ts`
+  * [ ] `tests/plan.join.vote.integration.test.ts`
 
 ---
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 20)
-- ✅ Implémenté `src/agents/selfReflect.ts` + fixtures/tests et intégré le module dans `child_collect` avec journalisation cognitive.
-- ✅ Ajouté `src/quality/scoring.ts`, branché le scoring dans `child_collect` avec options CLI (`--quality-threshold`, `--no-reflection`) et tests dédiés.
-- ✅ Actualisé `README.md` pour documenter reflection/scoring et rappeler les modules mémoire/attention, adaptive graph, sandbox, dashboard.
-- ✅ Exécuté `npm run build`, `npm run lint`, `npm test -- -R spec` (169 suites vertes).
+## D) Auto-organisation & robustesse (autoscaler, superviseur, sécurité)
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 21)
-- ✅ Durci `src/memory/store.ts` avec TTL configurables, limites de capacité et reconstruction des embeddings ; complété `tests/memory.store.test.ts` avec scénarios de saturation/TTL.
-- ✅ Raffiné `selectMemoryContext` pour filtrer les épisodes contradictoires et ajouté le test dédié dans `tests/memory.attention.test.ts`.
-- ✅ Repassé `npm run build`, `npm run lint`, `npm test -- -R spec` (171 suites vertes) après les modifications mémoire.
+### D1. **Autoscaler d’enfants**
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 22)
-- ✅ Ajouté la gestion dynamique de disponibilité des spécialistes dans `src/router/modelRouter.ts` avec refus clair si le fallback est hors ligne.
-- ✅ Étendu `tests/router.modelRouter.test.ts` pour couvrir les tables invalides, la désactivation temporaire et la défaillance du fallback.
-- ✅ Re-exécuté `npm run build`, `npm run lint`, `npm test -- -R spec` (174 suites vertes) pour valider les régressions.
+* [ ] **Créer** `src/agents/autoscaler.ts`
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 23)
-- ✅ Raffiné la détection d'ancrage dans `src/audit/planBias.ts` pour prendre en compte les étapes de challenge explicites et ajuster la sévérité.
-- ✅ Ajouté un scénario « fausse alerte » dans `tests/audit.planBias.test.ts` et un cycle synthétique A↔B dans `tests/guard.loopDetector.test.ts`.
-- ✅ Vérifié les heuristiques via `npm run build`, `npm run lint`, `npm test -- -R spec`.
+  * [ ] Metrics : backlog scheduler, latence, taux d’échec
+  * [ ] Politique : spawn/retire avec bornes et *cooldown*
+* [ ] **Intégrer** au loop (tick → `reconcile()`)
+* [ ] **Server tool** : `agent_autoscale_set({min,max,cooldown})`
+* [ ] **Tests**
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 24)
-- ✅ Renforcé l'échappement des identifiants et labels dans `src/viz/mermaid.ts` et `src/viz/dot.ts` avec commentaires et normalisation linéaire.
-- ✅ Ajouté un scénario d'échappement dédié dans `tests/graph.export.test.ts` pour valider les caractères spéciaux.
-- ✅ Exécuté `npm run build`, `npm run lint`, `npm test -- -R spec` (177 suites vertes) après les ajustements de visualisation.
+  * [ ] `tests/agents.autoscaler.scale-updown.test.ts` (sans fuite de process)
+  * [ ] `tests/agents.autoscaler.cooldown.test.ts`
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 25)
-- ✅ Ajouté un test de pagination invalide sur `ChildRuntime.streamMessages` et confirmé la protection contre les requêtes hors bornes.
-- ✅ Durci les artefacts en empêchant la lecture hors sandbox et couvert le scénario via `tests/artifacts.test.ts`.
-- ✅ Étendu `tests/plan.fanout-join.test.ts` avec un cas quorum 2/3 impliquant un runner têtu pour vérifier la voie timeout.
-- ✅ Relancé `npm run build`, `npm run lint`, `npm test -- -R spec` (180 suites vertes) pour valider la campagne.
+### D2. **Superviseur (Global Workspace)**
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 26)
-- ✅ Ajouté un refus explicite des identifiants enfants traversants (`tests/child.lifecycle.test.ts`, `tests/paths.test.ts`) et confirmé les garde-fous FS.
-- ✅ Introduit un garde contre les débordements dans `graph-forge` Yen et couvert les poids extrêmes via `tests/graphforge.ksp.test.ts`.
-- ✅ Aligné simulation et chemin critique et vérifié le Pareto complet via `tests/graph.simulate-optimize.test.ts` et `tests/graph.optimize-moo.test.ts`.
-- ✅ Exécuté `npm run build`, `npm run lint`, `npm test -- -R spec` (184 suites vertes) après les nouvelles régressions.
+* [ ] **Créer** `src/agents/supervisor.ts`
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 27)
-- ✅ Rendu l'élagage adaptatif idempotent avec incrément de version contrôlé et ajouté le test de régression dédié (`src/graph/adaptive.ts`, `tests/graph.adaptive.test.ts`).
-- ✅ Dédupliqué les divergences de plan, amélioré la fusion ordonnée et couvert la fusion partielle (`src/strategies/hypotheses.ts`, `tests/strategies.hypotheses.test.ts`).
-- ✅ Renforcé l'isolement sandbox (clonage profond, gel, abort observable) et ajouté les tests d'erreur/timeout (`src/sim/sandbox.ts`, `tests/sim.sandbox.test.ts`).
-- ✅ Revalidé `npm run build`, `npm run lint`, `npm test -- -R spec`.
+  * [ ] Détecte stagnation (aucun progrès N ticks), deadlocks, starvation
+  * [ ] Actions : réécriture de plan ciblée, redispatch, alertes
+* [ ] **Relier** à `loopDetector` et `rewrite`
+* [ ] **Tests**
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 28)
-- ✅ Relu les suites `graph.simulate*`, `graph.critical-path`, `graph.optimize*` et `graph.causal` pour confirmer la couverture des alignements makespan/chemin critique et la Pareto-frontière à trois points.
-- ✅ Vérifié les scripts `test:unit`/`test:int` et l’exécution CI afin de garantir l’utilisation directe de `mocha/bin/mocha.js` et l’installation sans lockfile.
-- ✅ Confirmé la conformité I/O, Zod et garde-fous FS via l’audit des helpers `paths` et des validations runtime existantes.
+  * [ ] `tests/agents.supervisor.stagnation.test.ts`
+  * [ ] `tests/agents.supervisor.unblock.test.ts`
 
-### 2025-10-01 – Agent `gpt-5-codex` (iteration 29)
-- ✅ Repassé `npm run build`, `npm run lint` et `npm test` pour valider la campagne complète (188 suites vertes).
-- ✅ Vérifié l’intégration reflection/scoring dans `child_collect` et les options CLI (`--no-reflection`, `--quality-threshold`, `--no-quality-gate`).
-- ✅ Audit rapide des modules mémoire/adaptive/hypothèses/sandbox/router/planBias/dashboard/loopDetector/viz et confirmation que les régressions ajoutées couvrent bien les cas négatifs demandés.
+### D3. **Sécurité/opération**
+
+* [ ] Limiteurs : nb max d’enfants, mémoire/CPU par enfant (config)
+* [ ] Timeouts catégorisés (BT decorators)
+* [ ] **Tests** : `tests/op.safety.limits.test.ts`
+
+---
+
+## E) Mémoire d’implémentation (réutilisation pratique des plans)
+
+### E1. **Graphe de connaissances interne (KG)**
+
+* [ ] **Créer** `src/knowledge/knowledgeGraph.ts`
+
+  * [ ] Triplets `{subject,predicate,object,source?,confidence?}` + index
+  * [ ] Query simple par motif (sans dépendance RDF)
+* [ ] **Relier** `graph_generate` pour *suggérer* patrons de plan depuis KG
+* [ ] **Server tools** : `kg_insert`, `kg_query`, `kg_export`
+* [ ] **Tests**
+
+  * [ ] `tests/knowledge.kg.insert-query.test.ts`
+  * [ ] `tests/graph.generate.from-kg.test.ts` (patrons appliqués)
+
+### E2. **Mémoire causale d’événements**
+
+* [ ] **Créer** `src/knowledge/causalMemory.ts`
+
+  * [ ] Noeuds = événements, arêtes cause→effet (exécution réelle)
+  * [ ] API : `record(event, causes[])`, `explain(outcome)`
+* [ ] **Brancher** exécution (BT & scheduler) pour enregistrer événements
+* [ ] **Server tools** : `causal_export`, `causal_explain(outcomeId)`
+* [ ] **Tests**
+
+  * [ ] `tests/knowledge.causal.record-explain.test.ts`
+  * [ ] `tests/causal.integration.bt-scheduler.test.ts`
+
+---
+
+## F) **Graphe de valeurs** & filtrage des plans
+
+* [ ] **Créer** `src/values/valueGraph.ts`
+
+  * [ ] Noeuds : valeurs (sécurité, confidentialité, coût, perfo…), arêtes : priorités/contraintes
+  * [ ] `scorePlan(plan):{score,total,violations[]}` + `filter(plan)`
+* [ ] **Intégrer** à `plan_fanout` (pré-filtrer), `plan_reduce` (pondérer)
+* [ ] **Server tools** : `values_set`, `values_score`, `values_filter`
+* [ ] **Tests**
+
+  * [ ] `tests/values.score-filter.test.ts`
+  * [ ] `tests/plan.values-integration.test.ts` (plan rejeté si violation critique)
+
+---
+
+## G) Intégration serveur (nouvelles tools, schémas, erreurs)
+
+* [ ] **Modifier** `src/server.ts` (registre tools)
+
+  * [ ] Ajouter :
+
+    * `graph_subgraph_extract`, `graph_rewrite_apply`, `graph_hyper_export`
+    * `plan_compile_bt`, `plan_run_bt`, `plan_run_reactive`
+    * `bb_set/get/query/watch`, `stig_mark/decay/snapshot`
+    * `cnp_announce`, `consensus_vote`
+    * `agent_autoscale_set`
+    * `kg_insert/query/export`, `causal_export/explain`
+    * `values_set/score/filter`
+  * [ ] **Zod schemas** pour chaque input, validation stricte
+  * [ ] Codes d’erreurs :
+
+    * `E-BT-INVALID`, `E-BT-RUN-TIMEOUT`
+    * `E-BB-NOTFOUND`, `E-STIG-TYPE`
+    * `E-CNP-NO-BIDS`, `E-CONSENSUS-NO-QUORUM`
+    * `E-KG-BAD-TRIPLE`, `E-CAUSAL-NO-PATH`
+    * `E-VALUES-VIOLATION`, `E-REWRITE-CONFLICT`
+* [ ] **Tests**
+
+  * [ ] `tests/server.tools.schemas.test.ts` (validation négative)
+  * [ ] `tests/server.tools.errors.test.ts` (codes/msgs cohérents)
+
+---
+
+## H) Visualisation & Dashboard (temps réel, interprétable)
+
+* [ ] **Modifier** `src/monitor/dashboard.ts`
+
+  * [ ] Streams : état BT (nœuds RUNNING/OK/KO), heatmap stigmergie (champ par nœud), backlog scheduler
+  * [ ] Endpoints JSON + SSE/WebSocket (local by default)
+* [ ] **Modifier** `src/viz/mermaid.ts`
+
+  * [ ] Overlays (labels couleur par intensité stigmergique, badges BT)
+* [ ] **Tests**
+
+  * [ ] `tests/monitor.dashboard.streams.test.ts` (smoke + shape)
+  * [ ] `tests/viz.mermaid.overlays.test.ts` (échappement/attributs stables)
+
+---
+
+## I) Build, tsconfig, CI
+
+* [ ] **tsconfig.json**
+
+  * [ ] Ajouter paths pour `executor/*`, `coord/*`, `knowledge/*`, `values/*`, `graph/*`
+  * [ ] `types:["node"]`, `strict:true`, `moduleResolution:"node"`, `lib:["ES2022"]`
+* [ ] **package.json**
+
+  * [ ] Scripts : `test:unit`, `test:int`, `coverage` (nyc/c8)
+  * [ ] `start:dashboard` si déport UI local facultatif
+* [ ] **.github/workflows/ci.yml**
+
+  * [ ] Matrice Node 18/20/22, steps : install → build → lint → test → coverage artifact
+* [ ] **Tests**
+
+  * [ ] `tests/ci.smoke-all-tools.test.ts` (appelle rapidement chaque tool en mode mock)
+
+---
+
+## J) Documentation & démos
+
+* [ ] **README.md**
+
+  * [ ] Section “Mode réactif (BT + scheduler)” avec exemples JSON d’un BT
+  * [ ] Usage blackboard/stigmergie/contract-net/consensus
+  * [ ] Valeurs/KG/causal : exemples courts
+* [ ] **AGENTS.md**
+
+  * [ ] Recettes :
+
+    * Fan-out via CNP → Join par `quorum` → Reduce `vote`
+    * Plan réécrit dynamiquement (rewrite rules) en fonction des échecs
+    * Autoscaler + superviseur pour déblocage automatique
+* [ ] **playground_codex_demo/**
+
+  * [ ] Scénarios couvrant : BT, stigmergie visible, consensus, values filter, KG bootstrap
+
+---
+
+## K) Feature flags & configuration
+
+* [ ] **Modifier** `src/serverOptions.ts`
+
+  * [ ] Flags (off par défaut) :
+
+    * `enableBT`, `enableReactiveScheduler`
+    * `enableBlackboard`, `enableStigmergy`, `enableCNP`, `enableConsensus`
+    * `enableAutoscaler`, `enableSupervisor`
+    * `enableKnowledge`, `enableCausalMemory`, `enableValueGuard`
+  * [ ] Timeouts/délais : `btTickMs`, `stigHalfLifeMs`, `supervisorStallTicks`
+* [ ] **Tests**
+
+  * [ ] `tests/options.flags.wiring.test.ts` (activation/désactivation propre)
+
+---
+
+## L) Suites d’intégration (end-to-end ciblées)
+
+* [ ] **E2E-1 : Plan hiérarchique réactif**
+
+  * [ ] Génère `HierGraph` → compile BT → run réactif → succès avec re-ordonnancement après `bb_set`
+* [ ] **E2E-2 : Stigmergie + autoscaling**
+
+  * [ ] Backlog lourd → champs phéromones → autoscaler scale-up → drain → scale-down
+* [ ] **E2E-3 : Contract-Net + consensus**
+
+  * [ ] `cnp_announce` 3 enfants → bids → attribution → `plan_join quorum=2/3` → reduce vote
+* [ ] **E2E-4 : Values guard**
+
+  * [ ] 2 plans, 1 viole “confidentialité” → filtré → autre plan choisi
+* [ ] **E2E-5 : Rewrite sous pression**
+
+  * [ ] Échecs répétés → superviseur déclenche `rewrite` → plan passe
+
+---
+
+## M) Qualité, perfs et robustesse
+
+* [ ] **Micro-bench** scheduler (avant/après stigmergie) dans `tests/perf/` (non-CI)
+* [ ] **Robustesse** : chaos tests légers (enfant qui crash → récupération)
+* [ ] **Flakiness** : ré-exécuter 10× tests sensibles avec timers fake
+
+---
+
+### Notes d’implémentation (pragmatiques)
+
+* **Interop avec existants** : reposer sur `graph-forge` pour algos de base, ne pas réinventer. Les hyper-arêtes restent *internes* et sont projetées avant passage aux algos.
+* **Feuilles BT** : mapper chaque leaf vers une tool existante (ou vers `child_send`), sérialiser l’input validé Zod, journaliser `start/stop/status`.
+* **Blackboard** : commencer en mémoire (Map + index par tag). Snapshot sur disque *optionnel* (JSON) dans le run dir.
+* **Stigmergie** : champ = dictionnaire `{nodeId: intensity}`, appliquer décroissance à chaque tick.
+* **Contract-Net** : implémenter d’abord attribution “min-cost”, puis heuristique.
+* **Consensus** : préférer `quorum(k)` pour intégration simple avec `plan_join`.
+* **Autoscaler** : bornes strictes, `cooldown` pour éviter oscillations.
+* **Supervisor** : s’appuyer sur `loopDetector` existant, ajouter seuils de stagnation + actions prioritaires.
+* **ValueGuard** : commencer avec règles déclaratives JSON (ex : “no network write” sans flag explicite).
+* **CausalMemory** : enregistrer *seulement* événements clés (début/fin/échec de nœuds), lier par dépendances + erreurs.
+* **Dashboard** : SSE pour simplicité (SSE > WS si pas besoin de duplex).
+* **Erreurs** : codes stables, messages courts, `hint` actionnable.
+
+---
+
+Si tu veux, je peux ensuite te générer les **squelettes TypeScript** (fichiers & exports) et les **fichiers de tests Mocha** correspondants aux modules marqués “Créer”, pour te faire gagner du temps sur l’amorçage.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 30)
+- ✅ Créé `src/graph/hierarchy.ts` avec types hiérarchiques, validations anti-cycles et expansion `flatten` documentée.
+- ✅ Rédigé les tests `tests/graph.hierarchy.generate-embed.test.ts` et `tests/graph.hierarchy.flatten.test.ts` couvrant l’embed multi-niveaux et la projection.
+- ✅ Vérifié l’intégrité des ports et le rejet des cycles via les nouvelles validations.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 31)
+- ✅ Ajouté `src/graph/hypergraph.ts` avec projection des hyper-arêtes vers des arêtes binaires annotées et validations robustes.
+- ✅ Étendu les exports Mermaid/DOT pour afficher les annotations hyper-arêtes et couvert avec `tests/graph.export.hyper.test.ts`.
+- ✅ Couvert la projection hypergraphe avec `tests/graph.hyper.project.test.ts` et aligné la checklist A2.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 32)
+- ✅ Implémenté `src/graph/rewrite.ts` (règles split-parallel / inline-subgraph / reroute-avoid + combinator `applyAll`).
+- ✅ Relié les réécritures adaptatives dans `src/graph/adaptive.ts` via `applyAdaptiveRewrites`.
+- ✅ Ajouté les tests `tests/graph.rewrite.rules.test.ts` et `tests/graph.adaptive.rewrite.test.ts` couvrant idempotence et pilotage par renforcement.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 33)
+- ✅ Créé le gestionnaire transactionnel `src/graph/tx.ts` (snapshots, rollback, version + horodatage, métadonnée `__txCommittedAt`).
+- ✅ Ajouté les tests `tests/graph.tx.snapshot-rollback.test.ts` et `tests/graph.tx.concurrency.test.ts` validant rollback et conflits de version.
+- ⏳ Intégration serveur à venir : wrap des mutations MCP avec le gestionnaire transactionnel.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 34)
+- ✅ Intégré le gestionnaire transactionnel côté serveur pour `graph_mutate` avec rollback automatique et journalisation dédiée.
+- ✅ Exposé des helpers de normalisation/sérialisation pour relier les outils de graphe aux transactions.
+- ✅ Ajouté le test `tests/graph.tx.mutate-integration.test.ts` couvrant l'interop entre mutations et transactions.

--- a/dist/graph/hierarchy.js
+++ b/dist/graph/hierarchy.js
@@ -1,0 +1,298 @@
+const DEFAULT_INPUT_PORT = "in";
+const DEFAULT_OUTPUT_PORT = "out";
+const EMBEDDED_GRAPH_KEY = "__embeddedGraph";
+const ANCESTRY_KEY = "__hierarchyAncestry";
+function isTaskNode(node) {
+    return node.kind === "task";
+}
+function isSubgraphNode(node) {
+    return node.kind === "subgraph";
+}
+function normalisePorts(ports, fallback) {
+    if (!ports || ports.length === 0) {
+        return new Set([fallback]);
+    }
+    const unique = new Set();
+    for (const port of ports) {
+        if (typeof port !== "string" || port.trim().length === 0) {
+            throw new Error(`Invalid port name "${port}"`);
+        }
+        unique.add(port);
+    }
+    return unique;
+}
+function extractSubgraphPorts(node) {
+    const raw = node.params?.ports;
+    if (!raw || typeof raw !== "object") {
+        throw new Error(`Subgraph node ${node.id} is missing ports declaration`);
+    }
+    const inputs = {};
+    const outputs = {};
+    const rawInputs = raw.inputs;
+    const rawOutputs = raw.outputs;
+    if (!rawInputs || typeof rawInputs !== "object") {
+        throw new Error(`Subgraph node ${node.id} is missing input ports`);
+    }
+    if (!rawOutputs || typeof rawOutputs !== "object") {
+        throw new Error(`Subgraph node ${node.id} is missing output ports`);
+    }
+    for (const [key, value] of Object.entries(rawInputs)) {
+        if (typeof value !== "string" || value.trim().length === 0) {
+            throw new Error(`Invalid input port mapping for subgraph ${node.id}`);
+        }
+        inputs[key] = value;
+    }
+    for (const [key, value] of Object.entries(rawOutputs)) {
+        if (typeof value !== "string" || value.trim().length === 0) {
+            throw new Error(`Invalid output port mapping for subgraph ${node.id}`);
+        }
+        outputs[key] = value;
+    }
+    return { inputs, outputs };
+}
+function extractEmbeddedGraph(node) {
+    const raw = node.params?.[EMBEDDED_GRAPH_KEY];
+    if (!raw) {
+        return undefined;
+    }
+    if (typeof raw !== "object") {
+        throw new Error(`Embedded graph payload for node ${node.id} is invalid`);
+    }
+    return raw;
+}
+function cloneHierGraph(graph) {
+    return structuredClone(graph);
+}
+function assertNoInterLevelCycle(graph, ancestors) {
+    if (ancestors.has(graph.id)) {
+        throw new Error(`Embedding graph ${graph.id} would introduce a cycle`);
+    }
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(graph.id);
+    for (const node of graph.nodes) {
+        if (isSubgraphNode(node)) {
+            if (ancestors.has(node.ref)) {
+                throw new Error(`Embedding subgraph ${node.ref} would create an inter-level cycle`);
+            }
+            const embedded = extractEmbeddedGraph(node);
+            if (embedded) {
+                assertNoInterLevelCycle(embedded, nextAncestors);
+            }
+        }
+    }
+}
+function validateHierGraph(graph) {
+    const idSet = new Set();
+    const nodeById = new Map();
+    for (const node of graph.nodes) {
+        if (idSet.has(node.id)) {
+            throw new Error(`Duplicate node identifier detected: ${node.id}`);
+        }
+        idSet.add(node.id);
+        nodeById.set(node.id, node);
+        if (isTaskNode(node)) {
+            normalisePorts(node.inputs, DEFAULT_INPUT_PORT);
+            normalisePorts(node.outputs, DEFAULT_OUTPUT_PORT);
+        }
+        else if (isSubgraphNode(node)) {
+            if (!node.ref || node.ref.trim().length === 0) {
+                throw new Error(`Subgraph node ${node.id} must reference a subgraph identifier`);
+            }
+            extractSubgraphPorts(node);
+            const embedded = extractEmbeddedGraph(node);
+            if (embedded) {
+                validateHierGraph(embedded);
+            }
+        }
+    }
+    for (const edge of graph.edges) {
+        const fromNode = nodeById.get(edge.from.nodeId);
+        const toNode = nodeById.get(edge.to.nodeId);
+        if (!fromNode) {
+            throw new Error(`Edge ${edge.id} references unknown source node ${edge.from.nodeId}`);
+        }
+        if (!toNode) {
+            throw new Error(`Edge ${edge.id} references unknown target node ${edge.to.nodeId}`);
+        }
+        const fromPort = edge.from.port ?? DEFAULT_OUTPUT_PORT;
+        if (isTaskNode(fromNode)) {
+            const ports = normalisePorts(fromNode.outputs, DEFAULT_OUTPUT_PORT);
+            if (!ports.has(fromPort)) {
+                throw new Error(`Edge ${edge.id} references missing output port ${fromPort} on ${fromNode.id}`);
+            }
+        }
+        else {
+            const ports = extractSubgraphPorts(fromNode).outputs;
+            if (!ports[fromPort]) {
+                throw new Error(`Edge ${edge.id} references missing subgraph output port ${fromPort} on ${fromNode.id}`);
+            }
+        }
+        const toPort = edge.to.port ?? DEFAULT_INPUT_PORT;
+        if (isTaskNode(toNode)) {
+            const ports = normalisePorts(toNode.inputs, DEFAULT_INPUT_PORT);
+            if (!ports.has(toPort)) {
+                throw new Error(`Edge ${edge.id} references missing input port ${toPort} on ${toNode.id}`);
+            }
+        }
+        else {
+            const ports = extractSubgraphPorts(toNode).inputs;
+            if (!ports[toPort]) {
+                throw new Error(`Edge ${edge.id} references missing subgraph input port ${toPort} on ${toNode.id}`);
+            }
+        }
+    }
+}
+export function getEmbeddedGraph(node) {
+    return extractEmbeddedGraph(node);
+}
+export function embedSubgraph(parent, nodeId, sub) {
+    validateHierGraph(parent);
+    validateHierGraph(sub);
+    const node = parent.nodes.find((candidate) => candidate.id === nodeId);
+    if (!node) {
+        throw new Error(`Unknown node ${nodeId}`);
+    }
+    if (!isSubgraphNode(node)) {
+        throw new Error(`Node ${nodeId} is not a subgraph node`);
+    }
+    if (node.ref !== sub.id) {
+        throw new Error(`Subgraph node ${nodeId} expects graph ${node.ref} but received ${sub.id}`);
+    }
+    const declaredPorts = extractSubgraphPorts(node);
+    const subNodeIds = new Set(sub.nodes.map((candidate) => candidate.id));
+    for (const target of Object.values(declaredPorts.inputs)) {
+        if (!subNodeIds.has(target)) {
+            throw new Error(`Input port on ${node.id} targets missing node ${target} in subgraph ${sub.id}`);
+        }
+    }
+    for (const target of Object.values(declaredPorts.outputs)) {
+        if (!subNodeIds.has(target)) {
+            throw new Error(`Output port on ${node.id} targets missing node ${target} in subgraph ${sub.id}`);
+        }
+    }
+    const ancestry = new Set(Array.isArray(node.params?.[ANCESTRY_KEY]) ? node.params?.[ANCESTRY_KEY] : []);
+    ancestry.add(parent.id);
+    assertNoInterLevelCycle(sub, ancestry);
+    const embedded = cloneHierGraph(sub);
+    const updatedNode = {
+        ...node,
+        params: {
+            ...node.params,
+            [EMBEDDED_GRAPH_KEY]: embedded,
+            [ANCESTRY_KEY]: Array.from(ancestry),
+        },
+    };
+    return {
+        ...parent,
+        nodes: parent.nodes.map((candidate) => candidate.id === nodeId ? updatedNode : candidate),
+    };
+}
+export function flatten(hier) {
+    validateHierGraph(hier);
+    const nodes = [];
+    const edges = [];
+    const addedNodeIds = new Set();
+    function addNode(record) {
+        if (addedNodeIds.has(record.id)) {
+            return;
+        }
+        addedNodeIds.add(record.id);
+        nodes.push(record);
+    }
+    function flattenRecursive(graph, prefix, ancestors) {
+        assertNoInterLevelCycle(graph, ancestors);
+        const idPrefix = prefix.length > 0 ? `${prefix}/` : "";
+        const mapping = new Map();
+        const portBindings = new Map();
+        const localAncestors = new Set(ancestors);
+        localAncestors.add(graph.id);
+        for (const node of graph.nodes) {
+            if (isTaskNode(node)) {
+                const finalId = `${idPrefix}${node.id}`;
+                mapping.set(node.id, finalId);
+                const attributes = { kind: "task" };
+                if (node.attributes) {
+                    for (const [key, value] of Object.entries(node.attributes)) {
+                        if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+                            attributes[key] = value;
+                        }
+                    }
+                }
+                const record = {
+                    id: finalId,
+                    label: node.label,
+                    attributes,
+                };
+                addNode(record);
+            }
+            else {
+                const embedded = extractEmbeddedGraph(node);
+                if (!embedded) {
+                    throw new Error(`Subgraph node ${node.id} does not have an embedded graph`);
+                }
+                const finalId = `${idPrefix}${node.id}`;
+                const childMapping = flattenRecursive(embedded, finalId, localAncestors);
+                const ports = extractSubgraphPorts(node);
+                const inputs = {};
+                for (const [port, target] of Object.entries(ports.inputs)) {
+                    const resolved = childMapping.get(target);
+                    if (!resolved) {
+                        throw new Error(`Input port ${port} on ${node.id} targets missing node ${target}`);
+                    }
+                    inputs[port] = resolved;
+                }
+                const outputs = {};
+                for (const [port, target] of Object.entries(ports.outputs)) {
+                    const resolved = childMapping.get(target);
+                    if (!resolved) {
+                        throw new Error(`Output port ${port} on ${node.id} targets missing node ${target}`);
+                    }
+                    outputs[port] = resolved;
+                }
+                portBindings.set(node.id, { inputs, outputs });
+            }
+        }
+        for (const edge of graph.edges) {
+            const fromNode = graph.nodes.find((candidate) => candidate.id === edge.from.nodeId);
+            const toNode = graph.nodes.find((candidate) => candidate.id === edge.to.nodeId);
+            const fromPort = edge.from.port ?? DEFAULT_OUTPUT_PORT;
+            const toPort = edge.to.port ?? DEFAULT_INPUT_PORT;
+            const fromId = isTaskNode(fromNode)
+                ? mapping.get(fromNode.id)
+                : portBindings.get(fromNode.id)?.outputs[fromPort];
+            if (!fromId) {
+                throw new Error(`Unable to resolve source node for edge ${edge.id}`);
+            }
+            const toId = isTaskNode(toNode)
+                ? mapping.get(toNode.id)
+                : portBindings.get(toNode.id)?.inputs[toPort];
+            if (!toId) {
+                throw new Error(`Unable to resolve target node for edge ${edge.id}`);
+            }
+            const attributes = {
+                ...(edge.attributes ?? {}),
+                hierarchy_edge: edge.id,
+                from_port: fromPort,
+                to_port: toPort,
+            };
+            edges.push({
+                from: fromId,
+                to: toId,
+                label: edge.label,
+                attributes,
+            });
+        }
+        return mapping;
+    }
+    flattenRecursive(hier, "", new Set());
+    nodes.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+    edges.sort((a, b) => (a.from < b.from ? -1 : a.from > b.from ? 1 : a.to < b.to ? -1 : a.to > b.to ? 1 : 0));
+    return {
+        name: hier.id,
+        graphId: hier.id,
+        graphVersion: 1,
+        nodes,
+        edges,
+        metadata: { hierarchical: true },
+    };
+}

--- a/dist/graph/hypergraph.js
+++ b/dist/graph/hypergraph.js
@@ -1,0 +1,119 @@
+/** Metadata key storing the hyper-edge identifier after projection. */
+const HYPER_EDGE_ID_KEY = "hyper_edge_id";
+/** Metadata key storing the pair index generated during projection. */
+const HYPER_EDGE_PAIR_INDEX_KEY = "hyper_edge_pair_index";
+/** Metadata key storing the index of the source endpoint in the hyper-edge. */
+const HYPER_EDGE_SOURCE_INDEX_KEY = "hyper_edge_source_index";
+/** Metadata key storing the index of the target endpoint in the hyper-edge. */
+const HYPER_EDGE_TARGET_INDEX_KEY = "hyper_edge_target_index";
+/** Metadata key capturing the number of sources in the hyper-edge. */
+const HYPER_EDGE_SOURCE_CARDINALITY_KEY = "hyper_edge_source_cardinality";
+/** Metadata key capturing the number of targets in the hyper-edge. */
+const HYPER_EDGE_TARGET_CARDINALITY_KEY = "hyper_edge_target_cardinality";
+/**
+ * Project an n-ary hyper-edge into a set of binary edges.
+ *
+ * Each generated edge retains enough metadata to rebuild the original hyper-edge
+ * or to provide context to reporting tools. The metadata intentionally relies on
+ * primitive values so that downstream serialisations remain stable.
+ */
+function projectHyperEdge(edge, nodeIds) {
+    if (!edge.id || edge.id.trim().length === 0) {
+        throw new Error("hyper-edge must expose a stable identifier");
+    }
+    if (!Array.isArray(edge.sources) || edge.sources.length === 0) {
+        throw new Error(`hyper-edge ${edge.id} must declare at least one source`);
+    }
+    if (!Array.isArray(edge.targets) || edge.targets.length === 0) {
+        throw new Error(`hyper-edge ${edge.id} must declare at least one target`);
+    }
+    const projected = [];
+    let pairIndex = 0;
+    for (let sourceIndex = 0; sourceIndex < edge.sources.length; sourceIndex += 1) {
+        const source = edge.sources[sourceIndex];
+        if (!nodeIds.has(source)) {
+            throw new Error(`hyper-edge ${edge.id} references unknown source node ${source}`);
+        }
+        for (let targetIndex = 0; targetIndex < edge.targets.length; targetIndex += 1) {
+            const target = edge.targets[targetIndex];
+            if (!nodeIds.has(target)) {
+                throw new Error(`hyper-edge ${edge.id} references unknown target node ${target}`);
+            }
+            const attributes = {
+                [HYPER_EDGE_ID_KEY]: edge.id,
+                [HYPER_EDGE_PAIR_INDEX_KEY]: pairIndex,
+                [HYPER_EDGE_SOURCE_INDEX_KEY]: sourceIndex,
+                [HYPER_EDGE_TARGET_INDEX_KEY]: targetIndex,
+                [HYPER_EDGE_SOURCE_CARDINALITY_KEY]: edge.sources.length,
+                [HYPER_EDGE_TARGET_CARDINALITY_KEY]: edge.targets.length,
+            };
+            if (edge.attributes) {
+                for (const [key, value] of Object.entries(edge.attributes)) {
+                    attributes[key] = value;
+                }
+            }
+            projected.push({
+                from: source,
+                to: target,
+                label: edge.label,
+                weight: edge.weight,
+                attributes,
+            });
+            pairIndex += 1;
+        }
+    }
+    return projected;
+}
+/**
+ * Validate and normalise the node list of the provided hyper-graph.
+ *
+ * The helper guarantees a stable foundation before projection by enforcing
+ * unique node identifiers and by ensuring each node exposes an attribute map.
+ */
+function normaliseNodes(nodes) {
+    const nodeIds = new Set();
+    const records = [];
+    for (const node of nodes) {
+        if (!node.id || node.id.trim().length === 0) {
+            throw new Error("hyper-graph nodes must provide an identifier");
+        }
+        if (nodeIds.has(node.id)) {
+            throw new Error(`duplicate node identifier detected in hyper-graph: ${node.id}`);
+        }
+        nodeIds.add(node.id);
+        records.push({
+            ...node,
+            attributes: node.attributes ?? {},
+        });
+    }
+    return { ids: nodeIds, records };
+}
+/**
+ * Project a hyper-graph into the normalised representation consumed by the rest
+ * of the graph tooling. The resulting graph preserves the original nodes while
+ * expanding every hyper-edge into a set of binary edges enriched with metadata
+ * for traceability.
+ */
+export function projectHyperGraph(graph, options = {}) {
+    if (!graph.id || graph.id.trim().length === 0) {
+        throw new Error("hyper-graph must expose an identifier");
+    }
+    const { ids: nodeIds, records } = normaliseNodes(graph.nodes);
+    const edges = [];
+    for (const edge of graph.hyperEdges) {
+        const projected = projectHyperEdge(edge, nodeIds);
+        edges.push(...projected);
+    }
+    return {
+        name: graph.id,
+        graphId: graph.id,
+        graphVersion: options.graphVersion ?? 1,
+        nodes: records,
+        edges,
+        metadata: {
+            ...(graph.metadata ?? {}),
+            hyper_edge_projection: true,
+        },
+    };
+}
+export { HYPER_EDGE_ID_KEY, HYPER_EDGE_PAIR_INDEX_KEY, HYPER_EDGE_SOURCE_CARDINALITY_KEY, HYPER_EDGE_SOURCE_INDEX_KEY, HYPER_EDGE_TARGET_CARDINALITY_KEY, HYPER_EDGE_TARGET_INDEX_KEY, projectHyperEdge };

--- a/dist/graph/rewrite.js
+++ b/dist/graph/rewrite.js
@@ -1,0 +1,525 @@
+import { flatten } from "./hierarchy.js";
+/** Unique key storing the serialized registry of sub-graphs embedded inside a normalised graph. */
+const SUBGRAPH_REGISTRY_KEY = "hierarchy:subgraphs";
+/** Attribute flag automatically added to edges produced by the split-parallel rule. */
+const SPLIT_PARALLEL_FLAG = "rewritten_split_parallel";
+/** Attribute flag automatically added to edges produced by the inline-subgraph rule. */
+const INLINE_SUBGRAPH_FLAG = "rewritten_inline_subgraph";
+/** Attribute flag automatically added to edges produced by the reroute-avoid rule. */
+const REROUTE_AVOID_FLAG = "rewritten_reroute_avoid";
+/** Internal upper bound that prevents the rewriting pipeline from looping forever. */
+const MAX_ITERATIONS = 25;
+/**
+ * Apply the provided list of rewrite rules to a graph until either no further
+ * changes are produced or the maximum iteration count is reached.
+ */
+export function applyAll(graph, rules, stopOnNoChange = true) {
+    let current = cloneGraph(graph);
+    const history = [];
+    let iteration = 0;
+    while (iteration < MAX_ITERATIONS) {
+        iteration += 1;
+        let changedThisRound = false;
+        for (const rule of rules) {
+            const { graph: nextGraph, applied, matches } = applyRule(current, rule);
+            history.push({ rule: rule.name, applied, matches });
+            if (applied > 0) {
+                current = nextGraph;
+                changedThisRound = true;
+            }
+        }
+        if (!changedThisRound) {
+            break;
+        }
+        if (stopOnNoChange) {
+            break;
+        }
+    }
+    return { graph: current, history };
+}
+/** Create the canonical split-parallel rule used to expand parallel fan-outs. */
+export function createSplitParallelRule(targetEdges) {
+    return {
+        name: "split-parallel",
+        match(graph) {
+            const matches = [];
+            for (const edge of graph.edges) {
+                const key = edgeKey(edge);
+                if (targetEdges && !targetEdges.has(key)) {
+                    continue;
+                }
+                if (edge.attributes[SPLIT_PARALLEL_FLAG]) {
+                    continue;
+                }
+                const shouldSplit = edge.attributes.parallel === true || edge.attributes.mode === "parallel";
+                if (!shouldSplit) {
+                    continue;
+                }
+                const nodeId = ensureUniqueNodeId(graph, `${edge.from}∥${edge.to}`);
+                matches.push({ type: "split-parallel", edge, proposedNodeId: nodeId });
+            }
+            return matches;
+        },
+        apply(graph, match) {
+            if (match.type !== "split-parallel") {
+                return graph;
+            }
+            const edgeIndex = graph.edges.findIndex((candidate) => sameEdge(candidate, match.edge));
+            if (edgeIndex === -1) {
+                return graph;
+            }
+            const newNode = {
+                id: match.proposedNodeId,
+                label: `Parallel ${match.edge.label ?? match.edge.to}`,
+                attributes: {
+                    kind: "parallel",
+                    parent: match.edge.from,
+                },
+            };
+            const preservedAttributes = { ...match.edge.attributes };
+            delete preservedAttributes.parallel;
+            delete preservedAttributes.mode;
+            const fanoutEdge = {
+                from: match.edge.from,
+                to: newNode.id,
+                label: match.edge.label,
+                weight: match.edge.weight,
+                attributes: {
+                    ...preservedAttributes,
+                    [SPLIT_PARALLEL_FLAG]: true,
+                    role: "fanout",
+                },
+            };
+            const branchEdge = {
+                from: newNode.id,
+                to: match.edge.to,
+                label: match.edge.label,
+                weight: match.edge.weight,
+                attributes: {
+                    ...preservedAttributes,
+                    [SPLIT_PARALLEL_FLAG]: true,
+                    role: "branch",
+                },
+            };
+            const next = {
+                ...graph,
+                graphVersion: graph.graphVersion + 1,
+                nodes: [...graph.nodes, newNode],
+                edges: replaceAt(graph.edges, edgeIndex, [fanoutEdge, branchEdge]),
+            };
+            return next;
+        },
+    };
+}
+/** Create the canonical inline-subgraph rule that expands embedded hierarchies. */
+export function createInlineSubgraphRule() {
+    return {
+        name: "inline-subgraph",
+        match(graph) {
+            const registry = parseSubgraphRegistry(graph.metadata[SUBGRAPH_REGISTRY_KEY]);
+            if (!registry) {
+                return [];
+            }
+            const matches = [];
+            for (const node of graph.nodes) {
+                if (node.attributes.kind !== "subgraph") {
+                    continue;
+                }
+                const reference = node.attributes.ref ?? node.attributes.subgraph_ref;
+                if (typeof reference !== "string") {
+                    continue;
+                }
+                const descriptor = registry.get(reference);
+                if (!descriptor) {
+                    continue;
+                }
+                matches.push({ type: "inline-subgraph", node, descriptor });
+            }
+            return matches;
+        },
+        apply(graph, match) {
+            if (match.type !== "inline-subgraph") {
+                return graph;
+            }
+            const registry = parseSubgraphRegistry(graph.metadata[SUBGRAPH_REGISTRY_KEY]);
+            if (!registry) {
+                return graph;
+            }
+            const reference = match.node.attributes.ref ?? match.node.attributes.subgraph_ref;
+            if (typeof reference !== "string") {
+                return graph;
+            }
+            const descriptor = registry.get(reference);
+            if (!descriptor) {
+                return graph;
+            }
+            const flattened = normaliseEmbeddedGraph(descriptor.graph);
+            const prefixed = prefixGraph(flattened, match.node.id);
+            const entryHints = descriptor.entryPoints ?? match.descriptor.entryPoints;
+            const exitHints = descriptor.exitPoints ?? match.descriptor.exitPoints;
+            const entryNodes = entryHints && entryHints.length > 0
+                ? entryHints
+                    .map((id) => prefixed.mapping.get(id) ?? id)
+                    .filter((id) => typeof id === "string")
+                : inferEntryNodes(prefixed.graph);
+            const exitNodes = exitHints && exitHints.length > 0
+                ? exitHints
+                    .map((id) => prefixed.mapping.get(id) ?? id)
+                    .filter((id) => typeof id === "string")
+                : inferExitNodes(prefixed.graph);
+            const incoming = graph.edges.filter((edge) => edge.to === match.node.id);
+            const outgoing = graph.edges.filter((edge) => edge.from === match.node.id);
+            const retainedNodes = graph.nodes.filter((node) => node.id !== match.node.id);
+            const retainedEdges = graph.edges.filter((edge) => edge.from !== match.node.id && edge.to !== match.node.id);
+            const rewiredEdges = [];
+            for (const edge of incoming) {
+                for (const entry of entryNodes) {
+                    if (edge.from === entry) {
+                        continue;
+                    }
+                    rewiredEdges.push({
+                        from: edge.from,
+                        to: entry,
+                        label: edge.label,
+                        weight: edge.weight,
+                        attributes: {
+                            ...edge.attributes,
+                            [INLINE_SUBGRAPH_FLAG]: true,
+                            via: match.node.id,
+                        },
+                    });
+                }
+            }
+            for (const edge of outgoing) {
+                for (const exit of exitNodes) {
+                    if (edge.to === exit) {
+                        continue;
+                    }
+                    rewiredEdges.push({
+                        from: exit,
+                        to: edge.to,
+                        label: edge.label,
+                        weight: edge.weight,
+                        attributes: {
+                            ...edge.attributes,
+                            [INLINE_SUBGRAPH_FLAG]: true,
+                            via: match.node.id,
+                        },
+                    });
+                }
+            }
+            const nextNodes = mergeNodes(retainedNodes, prefixed.graph.nodes, match.node.id);
+            const nextEdges = [...retainedEdges, ...prefixed.graph.edges, ...rewiredEdges];
+            return {
+                ...graph,
+                graphVersion: graph.graphVersion + 1,
+                nodes: sortNodes(nextNodes),
+                edges: sortEdges(nextEdges),
+            };
+        },
+    };
+}
+/** Create the canonical reroute-avoid rule that bypasses weak or unsafe nodes. */
+export function createRerouteAvoidRule(options) {
+    return {
+        name: "reroute-avoid",
+        match(graph) {
+            const matches = [];
+            for (const node of graph.nodes) {
+                const shouldAvoidById = options.avoidNodeIds?.has(node.id);
+                const shouldAvoidByLabel = node.label && options.avoidLabels?.has(node.label);
+                if (!shouldAvoidById && !shouldAvoidByLabel) {
+                    continue;
+                }
+                matches.push({ type: "reroute-avoid", node });
+            }
+            return matches;
+        },
+        apply(graph, match) {
+            if (match.type !== "reroute-avoid") {
+                return graph;
+            }
+            const nodeExists = graph.nodes.some((node) => node.id === match.node.id);
+            if (!nodeExists) {
+                return graph;
+            }
+            const incoming = graph.edges.filter((edge) => edge.to === match.node.id);
+            const outgoing = graph.edges.filter((edge) => edge.from === match.node.id);
+            if (incoming.length === 0 || outgoing.length === 0) {
+                const nextNodes = graph.nodes.filter((node) => node.id !== match.node.id);
+                const nextEdges = graph.edges.filter((edge) => edge.from !== match.node.id && edge.to !== match.node.id);
+                return {
+                    ...graph,
+                    graphVersion: graph.graphVersion + 1,
+                    nodes: nextNodes,
+                    edges: nextEdges,
+                };
+            }
+            const bypassEdges = [];
+            const seen = new Set();
+            for (const source of incoming) {
+                for (const target of outgoing) {
+                    if (source.from === target.to) {
+                        continue;
+                    }
+                    const key = `${source.from}→${target.to}`;
+                    if (seen.has(key)) {
+                        continue;
+                    }
+                    seen.add(key);
+                    bypassEdges.push({
+                        from: source.from,
+                        to: target.to,
+                        label: target.label ?? source.label,
+                        weight: source.weight ?? target.weight,
+                        attributes: {
+                            ...target.attributes,
+                            [REROUTE_AVOID_FLAG]: true,
+                            avoided: match.node.id,
+                        },
+                    });
+                }
+            }
+            const nodes = graph.nodes.filter((node) => node.id !== match.node.id);
+            const edges = graph.edges.filter((edge) => edge.from !== match.node.id && edge.to !== match.node.id);
+            return {
+                ...graph,
+                graphVersion: graph.graphVersion + 1,
+                nodes,
+                edges: sortEdges([...edges, ...bypassEdges]),
+            };
+        },
+    };
+}
+/** Apply a single rule until it can no longer mutate the graph. */
+function applyRule(graph, rule) {
+    let current = graph;
+    let applied = 0;
+    let matches = 0;
+    const visited = new Set();
+    for (let iteration = 0; iteration < MAX_ITERATIONS; iteration += 1) {
+        const set = rule.match(current);
+        matches += set.length;
+        if (set.length === 0) {
+            break;
+        }
+        const snapshot = snapshotGraph(current);
+        if (visited.has(snapshot.serialised)) {
+            break;
+        }
+        visited.add(snapshot.serialised);
+        let mutated = false;
+        for (const match of set) {
+            const next = rule.apply(current, match);
+            if (!graphsEqual(current, next)) {
+                current = next;
+                applied += 1;
+                mutated = true;
+                break;
+            }
+        }
+        if (!mutated) {
+            break;
+        }
+    }
+    return { graph: current, applied, matches };
+}
+/** Extract and validate the subgraph registry stored in the metadata map. */
+function parseSubgraphRegistry(value) {
+    if (!value || typeof value !== "string") {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(value);
+        const registry = new Map();
+        for (const [key, descriptor] of Object.entries(parsed)) {
+            if (!descriptor || typeof descriptor !== "object") {
+                continue;
+            }
+            registry.set(key, descriptor);
+        }
+        return registry;
+    }
+    catch {
+        return null;
+    }
+}
+/** Ensure that a node identifier remains unique within the provided graph. */
+function ensureUniqueNodeId(graph, baseId) {
+    let candidate = baseId;
+    let suffix = 1;
+    const existing = new Set(graph.nodes.map((node) => node.id));
+    while (existing.has(candidate)) {
+        suffix += 1;
+        candidate = `${baseId}#${suffix}`;
+    }
+    return candidate;
+}
+/** Verify whether two edges point to the same source and target. */
+function sameEdge(left, right) {
+    return left.from === right.from && left.to === right.to && left.label === right.label;
+}
+/** Replace a single edge with a new list, returning a new array. */
+function replaceAt(edges, index, replacements) {
+    return [...edges.slice(0, index), ...replacements, ...edges.slice(index + 1)];
+}
+/** Clone a graph to maintain immutability guarantees across rewrites. */
+function cloneGraph(graph) {
+    return {
+        ...graph,
+        nodes: graph.nodes.map((node) => ({
+            id: node.id,
+            label: node.label,
+            attributes: { ...node.attributes },
+        })),
+        edges: graph.edges.map((edge) => ({
+            from: edge.from,
+            to: edge.to,
+            label: edge.label,
+            weight: edge.weight,
+            attributes: { ...edge.attributes },
+        })),
+        metadata: { ...graph.metadata },
+    };
+}
+/** Generate a structural snapshot used to detect idempotence. */
+function snapshotGraph(graph) {
+    return { serialised: serialiseGraph(graph) };
+}
+/** Determine whether two graphs are structurally identical. */
+function graphsEqual(left, right) {
+    return serialiseGraph(left) === serialiseGraph(right);
+}
+/** Produce a deterministic serialisation of a graph. */
+function serialiseGraph(graph) {
+    const nodes = sortNodes(graph.nodes).map((node) => ({
+        id: node.id,
+        label: node.label,
+        attributes: sortAttributes(node.attributes),
+    }));
+    const edges = sortEdges(graph.edges).map((edge) => ({
+        from: edge.from,
+        to: edge.to,
+        label: edge.label,
+        weight: edge.weight,
+        attributes: sortAttributes(edge.attributes),
+    }));
+    const metadata = sortAttributes(graph.metadata);
+    return JSON.stringify({
+        ...graph,
+        nodes,
+        edges,
+        metadata,
+    });
+}
+/** Sort nodes deterministically by their identifier. */
+function sortNodes(nodes) {
+    return [...nodes].sort((a, b) => a.id.localeCompare(b.id));
+}
+/** Sort edges deterministically by source/target/label. */
+function sortEdges(edges) {
+    return [...edges].sort((a, b) => {
+        if (a.from !== b.from)
+            return a.from.localeCompare(b.from);
+        if (a.to !== b.to)
+            return a.to.localeCompare(b.to);
+        return (a.label ?? "").localeCompare(b.label ?? "");
+    });
+}
+/** Produce a sorted copy of an attribute map for deterministic outputs. */
+function sortAttributes(attributes) {
+    const entries = Object.entries(attributes).sort(([a], [b]) => a.localeCompare(b));
+    return Object.fromEntries(entries);
+}
+/** Prefix a graph so that embedded nodes remain globally unique. */
+function prefixGraph(graph, prefix) {
+    const mapping = new Map();
+    for (const node of graph.nodes) {
+        mapping.set(node.id, `${prefix}/${node.id}`);
+    }
+    const nodes = graph.nodes.map((node) => ({
+        id: mapping.get(node.id),
+        label: node.label,
+        attributes: {
+            ...node.attributes,
+            parent_subgraph: prefix,
+        },
+    }));
+    const edges = graph.edges.map((edge) => ({
+        from: mapping.get(edge.from),
+        to: mapping.get(edge.to),
+        label: edge.label,
+        weight: edge.weight,
+        attributes: { ...edge.attributes, parent_subgraph: prefix },
+    }));
+    return {
+        graph: {
+            ...graph,
+            nodes,
+            edges,
+        },
+        mapping,
+    };
+}
+/**
+ * Merge nodes while guarding against duplicates when inlining a sub-graph.
+ */
+function mergeNodes(base, addition, parentId) {
+    const result = [...base];
+    const existing = new Set(base.map((node) => node.id));
+    for (const node of addition) {
+        if (existing.has(node.id)) {
+            continue;
+        }
+        result.push({
+            id: node.id,
+            label: node.label,
+            attributes: {
+                ...node.attributes,
+                host: parentId,
+            },
+        });
+        existing.add(node.id);
+    }
+    return result;
+}
+/**
+ * Determine entry nodes as the ones without in-edges in the embedded graph.
+ */
+function inferEntryNodes(graph) {
+    const targets = new Set(graph.edges.map((edge) => edge.to));
+    return graph.nodes
+        .filter((node) => !targets.has(node.id))
+        .map((node) => node.id)
+        .sort();
+}
+/** Determine exit nodes as the ones without out-edges in the embedded graph. */
+function inferExitNodes(graph) {
+    const sources = new Set(graph.edges.map((edge) => edge.from));
+    return graph.nodes
+        .filter((node) => !sources.has(node.id))
+        .map((node) => node.id)
+        .sort();
+}
+/**
+ * Normalise any embedded hierarchical graph so downstream rules can reuse it as
+ * a regular normalised graph without leaking implementation details.
+ */
+function normaliseEmbeddedGraph(graph) {
+    if (isNormalisedGraph(graph)) {
+        return graph;
+    }
+    return flatten(graph);
+}
+/** Compute a stable identifier for an edge. */
+function edgeKey(edge) {
+    return `${edge.from}→${edge.to}`;
+}
+/** Narrow a parsed descriptor to a normalised graph when the shape matches. */
+function isNormalisedGraph(graph) {
+    const candidate = graph;
+    if (!candidate || !Array.isArray(candidate.nodes) || !Array.isArray(candidate.edges)) {
+        return false;
+    }
+    return candidate.edges.every((edge) => typeof edge.from === "string" && typeof edge.to === "string");
+}

--- a/dist/graph/tx.js
+++ b/dist/graph/tx.js
@@ -1,0 +1,170 @@
+import { randomUUID } from "node:crypto";
+/** Metadata key storing the timestamp of the last successful transaction commit. */
+const TX_COMMITTED_AT_METADATA_KEY = "__txCommittedAt";
+/**
+ * Generic error thrown by the transaction manager whenever an unexpected
+ * situation occurs (unknown transaction, invalid graph id, ...).
+ */
+export class GraphTransactionError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "GraphTransactionError";
+    }
+}
+/** Error thrown when attempting to commit using a stale base version. */
+export class GraphVersionConflictError extends GraphTransactionError {
+    constructor(graphId, expected, found) {
+        super(`graph '${graphId}' diverged: expected version ${expected} but received ${found}`);
+        this.name = "GraphVersionConflictError";
+    }
+}
+/** Error thrown when a caller references a transaction identifier that expired. */
+export class UnknownTransactionError extends GraphTransactionError {
+    constructor(txId) {
+        super(`transaction '${txId}' is not active`);
+        this.name = "UnknownTransactionError";
+    }
+}
+/**
+ * Manage transactional snapshots for normalised graphs. The manager enforces a
+ * strict single-writer policy: concurrent transactions must observe the latest
+ * committed version otherwise the commit will fail with a conflict.
+ */
+export class GraphTransactionManager {
+    /** Latest committed state tracked per graph identifier. */
+    states = new Map();
+    /** Active transaction records keyed by their identifier. */
+    transactions = new Map();
+    /**
+     * Open a new transaction for the provided graph. The caller receives a fresh
+     * working copy which can be mutated freely before invoking {@link commit} or
+     * {@link rollback}.
+     */
+    begin(graph) {
+        if (!graph.graphId || graph.graphId.trim().length === 0) {
+            throw new GraphTransactionError("graph id must be provided before opening a transaction");
+        }
+        const state = this.states.get(graph.graphId);
+        if (state) {
+            if (state.version !== graph.graphVersion) {
+                throw new GraphVersionConflictError(graph.graphId, state.version, graph.graphVersion);
+            }
+            state.graph = this.cloneGraph(graph);
+        }
+        else {
+            const committedAt = Date.now();
+            this.states.set(graph.graphId, {
+                version: graph.graphVersion,
+                committedAt,
+                graph: this.cloneGraph(graph),
+            });
+        }
+        const txId = randomUUID();
+        const startedAt = Date.now();
+        const snapshot = this.cloneGraph(graph);
+        const record = {
+            txId,
+            graphId: graph.graphId,
+            baseVersion: graph.graphVersion,
+            snapshot,
+            startedAt,
+        };
+        this.transactions.set(txId, record);
+        return {
+            txId,
+            graphId: graph.graphId,
+            baseVersion: graph.graphVersion,
+            startedAt,
+            workingCopy: this.cloneGraph(graph),
+        };
+    }
+    /**
+     * Commit the transaction identified by {@link txId}. The provided graph must
+     * originate from the working copy returned by {@link begin}. The manager will
+     * increment the graph version, stamp the commit timestamp, and update the
+     * latest committed snapshot.
+     */
+    commit(txId, updatedGraph) {
+        const record = this.transactions.get(txId);
+        if (!record) {
+            throw new UnknownTransactionError(txId);
+        }
+        this.transactions.delete(txId);
+        if (updatedGraph.graphId !== record.graphId) {
+            throw new GraphTransactionError(`graph id mismatch: expected '${record.graphId}' but received '${updatedGraph.graphId}'`);
+        }
+        const state = this.states.get(record.graphId);
+        if (!state) {
+            throw new GraphTransactionError(`no committed state registered for graph '${record.graphId}'`);
+        }
+        if (state.version !== record.baseVersion) {
+            throw new GraphVersionConflictError(record.graphId, state.version, record.baseVersion);
+        }
+        const expectedVersion = record.baseVersion;
+        const providedVersion = updatedGraph.graphVersion;
+        if (providedVersion < expectedVersion || providedVersion > expectedVersion + 1) {
+            throw new GraphVersionConflictError(record.graphId, expectedVersion, providedVersion);
+        }
+        const mutated = !this.graphsEqual(record.snapshot, updatedGraph);
+        const committedAt = mutated ? Date.now() : state.committedAt;
+        const nextVersion = mutated ? expectedVersion + 1 : state.version;
+        let finalGraph;
+        if (mutated) {
+            finalGraph = this.cloneGraph(updatedGraph);
+            finalGraph.graphVersion = nextVersion;
+            finalGraph.metadata = {
+                ...finalGraph.metadata,
+                [TX_COMMITTED_AT_METADATA_KEY]: committedAt,
+            };
+            state.version = nextVersion;
+            state.committedAt = committedAt;
+            state.graph = this.cloneGraph(finalGraph);
+        }
+        else {
+            finalGraph = this.cloneGraph(state.graph);
+        }
+        return {
+            txId,
+            graphId: record.graphId,
+            version: nextVersion,
+            committedAt,
+            graph: finalGraph,
+        };
+    }
+    /**
+     * Abort the transaction identified by {@link txId}, restoring the snapshot
+     * captured at {@link begin}. The caller receives the pristine state so it can
+     * be re-used or inspected safely.
+     */
+    rollback(txId) {
+        const record = this.transactions.get(txId);
+        if (!record) {
+            throw new UnknownTransactionError(txId);
+        }
+        this.transactions.delete(txId);
+        const rolledBackAt = Date.now();
+        return {
+            txId,
+            graphId: record.graphId,
+            version: record.baseVersion,
+            rolledBackAt,
+            snapshot: this.cloneGraph(record.snapshot),
+        };
+    }
+    /** Retrieve the number of active transactions, useful for diagnostics. */
+    countActiveTransactions() {
+        return this.transactions.size;
+    }
+    /** Shallow helper to deep-clone a normalised graph without sharing references. */
+    cloneGraph(graph) {
+        return structuredClone(graph);
+    }
+    /**
+     * Compare two graphs for structural equality. The normalised representation
+     * preserves node/edge ordering which makes a simple JSON serialisation safe
+     * for equality checks without introducing a heavy diff dependency.
+     */
+    graphsEqual(first, second) {
+        return JSON.stringify(first) === JSON.stringify(second);
+    }
+}

--- a/dist/tools/graphTools.js
+++ b/dist/tools/graphTools.js
@@ -226,6 +226,20 @@ export const GraphMutateInputSchema = z.object({
         .min(1, "at least one operation must be provided"),
 });
 export const GraphMutateInputShape = GraphMutateInputSchema.shape;
+/**
+ * Convert a serialised graph payload (typically exchanged with tools) into the
+ * internal normalised representation leveraged by the transaction manager.
+ */
+export function normaliseGraphPayload(payload) {
+    return normaliseDescriptor(payload);
+}
+/**
+ * Serialise a normalised graph so it can be returned to clients or chained into
+ * other tooling primitives without exposing the internal structure.
+ */
+export function serialiseNormalisedGraph(descriptor) {
+    return serialiseDescriptor(descriptor);
+}
 /** Apply idempotent graph operations, returning the mutated graph. */
 export function handleGraphMutate(input) {
     const descriptor = normaliseDescriptor(input.graph);

--- a/dist/viz/mermaid.js
+++ b/dist/viz/mermaid.js
@@ -1,4 +1,5 @@
 import { GraphDescriptorSchema } from "../tools/graphTools.js";
+/** Options influencing the Mermaid serialisation. */
 /**
  * Convert a graph descriptor into a Mermaid flowchart definition.
  *
@@ -11,38 +12,47 @@ export function renderMermaidFromGraph(descriptor, options = {}) {
     const direction = options.direction ?? "LR";
     const maxLength = Math.max(8, options.maxLabelLength ?? 48);
     const idMap = new Map();
+    // Track the generated identifiers separately to avoid repeatedly scanning the
+    // cache. This keeps the deterministic suffixing logic linear in the number
+    // of nodes instead of quadratic when collisions appear.
+    const usedIds = new Set();
     const lines = [`graph ${direction}`];
     for (const node of parsed.nodes) {
-        const normalisedId = normaliseId(node.id, idMap);
+        const normalisedId = normaliseId(node.id, idMap, usedIds);
         const label = buildNodeLabel(node, options.labelAttribute, maxLength);
         lines.push(`${normalisedId}["${label}"]`);
     }
     for (const edge of parsed.edges) {
-        const fromId = idMap.get(edge.from) ?? normaliseId(edge.from, idMap);
-        const toId = idMap.get(edge.to) ?? normaliseId(edge.to, idMap);
+        const fromId = idMap.get(edge.from) ?? normaliseId(edge.from, idMap, usedIds);
+        const toId = idMap.get(edge.to) ?? normaliseId(edge.to, idMap, usedIds);
         const label = buildEdgeLabel(edge, options.weightAttribute, maxLength);
-        const segment = label ? ` -- "${label}" --> ` : " --> ";
+        const hyperAnnotation = buildHyperEdgeAnnotation(edge);
+        const combinedLabel = hyperAnnotation ? label ? `${label} ${hyperAnnotation}` : hyperAnnotation : label;
+        const segment = combinedLabel ? ` -- "${combinedLabel}" --> ` : " --> ";
         lines.push(`${fromId}${segment}${toId}`);
     }
     return lines.join("\n");
 }
-function normaliseId(original, cache) {
+function normaliseId(original, cache, used) {
     const existing = cache.get(original);
     if (existing) {
         return existing;
     }
     const base = original
         .trim()
+        // Replace characters Mermaid cannot accept in identifiers with a safe
+        // underscore placeholder.
         .replace(/[^a-zA-Z0-9_]/g, "_")
         .replace(/_{2,}/g, "_");
     const candidate = base.length > 0 ? base : "node";
     let finalId = candidate;
     let counter = 1;
-    while ([...cache.values()].includes(finalId)) {
+    while (used.has(finalId)) {
         counter += 1;
         finalId = `${candidate}_${counter}`;
     }
     cache.set(original, finalId);
+    used.add(finalId);
     return finalId;
 }
 function buildNodeLabel(node, fallbackAttribute, maxLength) {
@@ -75,6 +85,28 @@ function buildEdgeLabel(edge, weightAttribute, maxLength) {
     const text = typeof raw === "string" ? raw : String(raw);
     return truncateLabel(text.trim(), maxLength);
 }
+function buildHyperEdgeAnnotation(edge) {
+    const identifier = edge.attributes?.hyper_edge_id;
+    if (typeof identifier !== "string") {
+        return null;
+    }
+    const trimmed = identifier.trim();
+    if (!trimmed) {
+        return null;
+    }
+    let annotation = `[H:${trimmed}`;
+    const pairIndex = edge.attributes?.hyper_edge_pair_index;
+    if (typeof pairIndex === "number" && Number.isFinite(pairIndex)) {
+        annotation += `#${pairIndex}`;
+    }
+    const sourceCardinality = edge.attributes?.hyper_edge_source_cardinality;
+    const targetCardinality = edge.attributes?.hyper_edge_target_cardinality;
+    if (typeof sourceCardinality === "number" && Number.isFinite(sourceCardinality) && typeof targetCardinality === "number" && Number.isFinite(targetCardinality)) {
+        annotation += ` ${sourceCardinality}->${targetCardinality}`;
+    }
+    annotation += "]";
+    return escapeLabel(annotation);
+}
 function truncateLabel(label, maxLength) {
     if (label.length <= maxLength) {
         return escapeLabel(label);
@@ -83,5 +115,16 @@ function truncateLabel(label, maxLength) {
     return `${escapeLabel(slice)}…`;
 }
 function escapeLabel(label) {
-    return label.replace(/"/g, '\\"');
+    // Escape backslashes first so subsequent replacements keep their semantics.
+    return label
+        .replace(/\\/g, "\\\\")
+        .replace(/\r\n|\r|\n/g, "\\n")
+        .replace(/"/g, '\\"')
+        // Brackets occasionally appear in labels; escape them so Mermaid does not
+        // mistake them for node syntax.
+        .replace(/\[/g, "\\[")
+        .replace(/\]/g, "\\]")
+        // Replace remaining control characters with spaces to keep the diagram
+        // readable if unexpected values slip through.
+        .replace(/[\u0000-\u001f]/g, " ");
 }

--- a/src/graph/hierarchy.ts
+++ b/src/graph/hierarchy.ts
@@ -1,0 +1,419 @@
+import { NormalisedGraph, type GraphAttributeValue, type GraphEdgeRecord, type GraphNodeRecord } from "./types.js";
+
+/** Default input port assigned when a task endpoint does not specify one explicitly. */
+const DEFAULT_INPUT_PORT = "in";
+/** Default output port assigned when a task endpoint does not specify one explicitly. */
+const DEFAULT_OUTPUT_PORT = "out";
+
+/** Internal key used to store the embedded hierarchical sub-graph within a subgraph node. */
+const EMBEDDED_GRAPH_KEY = "__embeddedGraph";
+/** Internal key used to track the ancestry of embeddings to detect cycles. */
+const ANCESTRY_KEY = "__hierarchyAncestry";
+
+/** Strongly typed mapping between named ports and target node identifiers. */
+export interface SubgraphPorts {
+  inputs: Record<string, string>;
+  outputs: Record<string, string>;
+}
+
+/** Description of a task node living at a specific hierarchical level. */
+export interface TaskNode {
+  id: string;
+  kind: "task";
+  label?: string;
+  /** Optional attributes propagated to the flattened normalised graph. */
+  attributes?: Record<string, GraphAttributeValue>;
+  /** Optional list of accepted input port names. */
+  inputs?: string[];
+  /** Optional list of exposed output port names. */
+  outputs?: string[];
+}
+
+/** Structural node that references a sub-graph to embed. */
+export interface SubgraphNode {
+  id: string;
+  kind: "subgraph";
+  ref: string;
+  params?: Record<string, unknown>;
+}
+
+/** Union of all possible node types within a hierarchical graph. */
+export type HierNode = TaskNode | SubgraphNode;
+
+/** Endpoint describing a reference to a node identifier and an optional port. */
+export interface EdgeEndpoint {
+  nodeId: string;
+  port?: string;
+}
+
+/** Directed edge within a hierarchical graph. */
+export interface Edge {
+  id: string;
+  from: EdgeEndpoint;
+  to: EdgeEndpoint;
+  label?: string;
+  attributes?: Record<string, GraphAttributeValue>;
+}
+
+/** High-level hierarchical graph description used before expansion. */
+export interface HierGraph {
+  id: string;
+  nodes: HierNode[];
+  edges: Edge[];
+}
+
+/** Shape returned internally when flattening an embedded sub-graph. */
+interface PortBinding {
+  inputs: Record<string, string>;
+  outputs: Record<string, string>;
+}
+
+/**
+ * Determine whether the provided node represents a task.
+ */
+function isTaskNode(node: HierNode): node is TaskNode {
+  return node.kind === "task";
+}
+
+/**
+ * Determine whether the provided node represents a sub-graph placeholder.
+ */
+function isSubgraphNode(node: HierNode): node is SubgraphNode {
+  return node.kind === "subgraph";
+}
+
+/**
+ * Normalise the provided list of port names, defaulting to a single entry when undefined.
+ */
+function normalisePorts(ports: string[] | undefined, fallback: string): Set<string> {
+  if (!ports || ports.length === 0) {
+    return new Set([fallback]);
+  }
+  const unique = new Set<string>();
+  for (const port of ports) {
+    if (typeof port !== "string" || port.trim().length === 0) {
+      throw new Error(`Invalid port name \"${port}\"`);
+    }
+    unique.add(port);
+  }
+  return unique;
+}
+
+/**
+ * Extract and validate the SubgraphPorts contract stored inside a subgraph node.
+ */
+function extractSubgraphPorts(node: SubgraphNode): SubgraphPorts {
+  const raw = node.params?.ports as unknown;
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`Subgraph node ${node.id} is missing ports declaration`);
+  }
+  const inputs: Record<string, string> = {};
+  const outputs: Record<string, string> = {};
+  const rawInputs = (raw as { inputs?: unknown }).inputs;
+  const rawOutputs = (raw as { outputs?: unknown }).outputs;
+  if (!rawInputs || typeof rawInputs !== "object") {
+    throw new Error(`Subgraph node ${node.id} is missing input ports`);
+  }
+  if (!rawOutputs || typeof rawOutputs !== "object") {
+    throw new Error(`Subgraph node ${node.id} is missing output ports`);
+  }
+  for (const [key, value] of Object.entries(rawInputs as Record<string, unknown>)) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Invalid input port mapping for subgraph ${node.id}`);
+    }
+    inputs[key] = value;
+  }
+  for (const [key, value] of Object.entries(rawOutputs as Record<string, unknown>)) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Invalid output port mapping for subgraph ${node.id}`);
+    }
+    outputs[key] = value;
+  }
+  return { inputs, outputs };
+}
+
+/**
+ * Retrieve the embedded graph stored inside a subgraph node, if any.
+ */
+function extractEmbeddedGraph(node: SubgraphNode): HierGraph | undefined {
+  const raw = node.params?.[EMBEDDED_GRAPH_KEY] as unknown;
+  if (!raw) {
+    return undefined;
+  }
+  if (typeof raw !== "object") {
+    throw new Error(`Embedded graph payload for node ${node.id} is invalid`);
+  }
+  return raw as HierGraph;
+}
+
+/**
+ * Deep clone a hierarchical graph to avoid accidental mutations when embedding.
+ */
+function cloneHierGraph(graph: HierGraph): HierGraph {
+  return structuredClone(graph);
+}
+
+/**
+ * Recursively ensure that embedding the provided sub-graph would not introduce a cycle across hierarchy levels.
+ */
+function assertNoInterLevelCycle(graph: HierGraph, ancestors: Set<string>): void {
+  if (ancestors.has(graph.id)) {
+    throw new Error(`Embedding graph ${graph.id} would introduce a cycle`);
+  }
+  const nextAncestors = new Set(ancestors);
+  nextAncestors.add(graph.id);
+  for (const node of graph.nodes) {
+    if (isSubgraphNode(node)) {
+      if (ancestors.has(node.ref)) {
+        throw new Error(`Embedding subgraph ${node.ref} would create an inter-level cycle`);
+      }
+      const embedded = extractEmbeddedGraph(node);
+      if (embedded) {
+        assertNoInterLevelCycle(embedded, nextAncestors);
+      }
+    }
+  }
+}
+
+/**
+ * Ensure node identifiers are unique and all edges reference valid nodes and ports.
+ */
+function validateHierGraph(graph: HierGraph): void {
+  const idSet = new Set<string>();
+  const nodeById = new Map<string, HierNode>();
+  for (const node of graph.nodes) {
+    if (idSet.has(node.id)) {
+      throw new Error(`Duplicate node identifier detected: ${node.id}`);
+    }
+    idSet.add(node.id);
+    nodeById.set(node.id, node);
+    if (isTaskNode(node)) {
+      normalisePorts(node.inputs, DEFAULT_INPUT_PORT);
+      normalisePorts(node.outputs, DEFAULT_OUTPUT_PORT);
+    } else if (isSubgraphNode(node)) {
+      if (!node.ref || node.ref.trim().length === 0) {
+        throw new Error(`Subgraph node ${node.id} must reference a subgraph identifier`);
+      }
+      // Validate ports and embedded graphs up-front.
+      extractSubgraphPorts(node);
+      const embedded = extractEmbeddedGraph(node);
+      if (embedded) {
+        validateHierGraph(embedded);
+      }
+    }
+  }
+  for (const edge of graph.edges) {
+    const fromNode = nodeById.get(edge.from.nodeId);
+    const toNode = nodeById.get(edge.to.nodeId);
+    if (!fromNode) {
+      throw new Error(`Edge ${edge.id} references unknown source node ${edge.from.nodeId}`);
+    }
+    if (!toNode) {
+      throw new Error(`Edge ${edge.id} references unknown target node ${edge.to.nodeId}`);
+    }
+    const fromPort = edge.from.port ?? DEFAULT_OUTPUT_PORT;
+    if (isTaskNode(fromNode)) {
+      const ports = normalisePorts(fromNode.outputs, DEFAULT_OUTPUT_PORT);
+      if (!ports.has(fromPort)) {
+        throw new Error(`Edge ${edge.id} references missing output port ${fromPort} on ${fromNode.id}`);
+      }
+    } else {
+      const ports = extractSubgraphPorts(fromNode).outputs;
+      if (!ports[fromPort]) {
+        throw new Error(`Edge ${edge.id} references missing subgraph output port ${fromPort} on ${fromNode.id}`);
+      }
+    }
+    const toPort = edge.to.port ?? DEFAULT_INPUT_PORT;
+    if (isTaskNode(toNode)) {
+      const ports = normalisePorts(toNode.inputs, DEFAULT_INPUT_PORT);
+      if (!ports.has(toPort)) {
+        throw new Error(`Edge ${edge.id} references missing input port ${toPort} on ${toNode.id}`);
+      }
+    } else {
+      const ports = extractSubgraphPorts(toNode).inputs;
+      if (!ports[toPort]) {
+        throw new Error(`Edge ${edge.id} references missing subgraph input port ${toPort} on ${toNode.id}`);
+      }
+    }
+  }
+}
+
+/**
+ * Helper exposing the embedded graph stored inside a subgraph node (used in tests and diagnostics).
+ */
+export function getEmbeddedGraph(node: SubgraphNode): HierGraph | undefined {
+  return extractEmbeddedGraph(node);
+}
+
+/**
+ * Embed the provided sub-graph inside the selected subgraph node, returning a new hierarchical graph instance.
+ */
+export function embedSubgraph(parent: HierGraph, nodeId: string, sub: HierGraph): HierGraph {
+  validateHierGraph(parent);
+  validateHierGraph(sub);
+  const node = parent.nodes.find((candidate) => candidate.id === nodeId);
+  if (!node) {
+    throw new Error(`Unknown node ${nodeId}`);
+  }
+  if (!isSubgraphNode(node)) {
+    throw new Error(`Node ${nodeId} is not a subgraph node`);
+  }
+  if (node.ref !== sub.id) {
+    throw new Error(`Subgraph node ${nodeId} expects graph ${node.ref} but received ${sub.id}`);
+  }
+  const declaredPorts = extractSubgraphPorts(node);
+  const subNodeIds = new Set(sub.nodes.map((candidate) => candidate.id));
+  for (const target of Object.values(declaredPorts.inputs)) {
+    if (!subNodeIds.has(target)) {
+      throw new Error(`Input port on ${node.id} targets missing node ${target} in subgraph ${sub.id}`);
+    }
+  }
+  for (const target of Object.values(declaredPorts.outputs)) {
+    if (!subNodeIds.has(target)) {
+      throw new Error(`Output port on ${node.id} targets missing node ${target} in subgraph ${sub.id}`);
+    }
+  }
+  const ancestry = new Set<string>(
+    Array.isArray(node.params?.[ANCESTRY_KEY]) ? (node.params?.[ANCESTRY_KEY] as string[]) : [],
+  );
+  ancestry.add(parent.id);
+  assertNoInterLevelCycle(sub, ancestry);
+  const embedded = cloneHierGraph(sub);
+  const updatedNode: SubgraphNode = {
+    ...node,
+    params: {
+      ...node.params,
+      [EMBEDDED_GRAPH_KEY]: embedded,
+      [ANCESTRY_KEY]: Array.from(ancestry),
+    },
+  };
+  return {
+    ...parent,
+    nodes: parent.nodes.map((candidate) => (candidate.id === nodeId ? updatedNode : candidate)),
+  };
+}
+
+/**
+ * Convert a hierarchical graph into the flattened normalised representation consumed by the rest of the orchestrator.
+ */
+export function flatten(hier: HierGraph): NormalisedGraph {
+  validateHierGraph(hier);
+  const nodes: GraphNodeRecord[] = [];
+  const edges: GraphEdgeRecord[] = [];
+  const addedNodeIds = new Set<string>();
+
+  function addNode(record: GraphNodeRecord): void {
+    if (addedNodeIds.has(record.id)) {
+      return;
+    }
+    addedNodeIds.add(record.id);
+    nodes.push(record);
+  }
+
+  function flattenRecursive(graph: HierGraph, prefix: string, ancestors: Set<string>): Map<string, string> {
+    assertNoInterLevelCycle(graph, ancestors);
+    const idPrefix = prefix.length > 0 ? `${prefix}/` : "";
+    const mapping = new Map<string, string>();
+    const portBindings = new Map<string, PortBinding>();
+    const localAncestors = new Set(ancestors);
+    localAncestors.add(graph.id);
+
+    for (const node of graph.nodes) {
+      if (isTaskNode(node)) {
+        const finalId = `${idPrefix}${node.id}`;
+        mapping.set(node.id, finalId);
+        const attributes: Record<string, GraphAttributeValue> = { kind: "task" };
+        if (node.attributes) {
+          for (const [key, value] of Object.entries(node.attributes)) {
+            if (
+              typeof value === "string" ||
+              typeof value === "number" ||
+              typeof value === "boolean"
+            ) {
+              attributes[key] = value;
+            }
+          }
+        }
+        const record: GraphNodeRecord = {
+          id: finalId,
+          label: node.label,
+          attributes,
+        };
+        addNode(record);
+      } else {
+        const embedded = extractEmbeddedGraph(node);
+        if (!embedded) {
+          throw new Error(`Subgraph node ${node.id} does not have an embedded graph`);
+        }
+        const finalId = `${idPrefix}${node.id}`;
+        const childMapping = flattenRecursive(embedded, finalId, localAncestors);
+        const ports = extractSubgraphPorts(node);
+        const inputs: Record<string, string> = {};
+        for (const [port, target] of Object.entries(ports.inputs)) {
+          const resolved = childMapping.get(target);
+          if (!resolved) {
+            throw new Error(`Input port ${port} on ${node.id} targets missing node ${target}`);
+          }
+          inputs[port] = resolved;
+        }
+        const outputs: Record<string, string> = {};
+        for (const [port, target] of Object.entries(ports.outputs)) {
+          const resolved = childMapping.get(target);
+          if (!resolved) {
+            throw new Error(`Output port ${port} on ${node.id} targets missing node ${target}`);
+          }
+          outputs[port] = resolved;
+        }
+        portBindings.set(node.id, { inputs, outputs });
+      }
+    }
+
+    for (const edge of graph.edges) {
+      const fromNode = graph.nodes.find((candidate) => candidate.id === edge.from.nodeId)!;
+      const toNode = graph.nodes.find((candidate) => candidate.id === edge.to.nodeId)!;
+      const fromPort = edge.from.port ?? DEFAULT_OUTPUT_PORT;
+      const toPort = edge.to.port ?? DEFAULT_INPUT_PORT;
+      const fromId = isTaskNode(fromNode)
+        ? mapping.get(fromNode.id)
+        : portBindings.get(fromNode.id)?.outputs[fromPort];
+      if (!fromId) {
+        throw new Error(`Unable to resolve source node for edge ${edge.id}`);
+      }
+      const toId = isTaskNode(toNode)
+        ? mapping.get(toNode.id)
+        : portBindings.get(toNode.id)?.inputs[toPort];
+      if (!toId) {
+        throw new Error(`Unable to resolve target node for edge ${edge.id}`);
+      }
+      const attributes: Record<string, GraphAttributeValue> = {
+        ...(edge.attributes ?? {}),
+        hierarchy_edge: edge.id,
+        from_port: fromPort,
+        to_port: toPort,
+      };
+      const record: GraphEdgeRecord = {
+        from: fromId,
+        to: toId,
+        label: edge.label,
+        attributes,
+      };
+      edges.push(record);
+    }
+
+    return mapping;
+  }
+
+  flattenRecursive(hier, "", new Set<string>());
+
+  nodes.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  edges.sort((a, b) => (a.from < b.from ? -1 : a.from > b.from ? 1 : a.to < b.to ? -1 : a.to > b.to ? 1 : 0));
+
+  return {
+    name: hier.id,
+    graphId: hier.id,
+    graphVersion: 1,
+    nodes,
+    edges,
+    metadata: { hierarchical: true },
+  };
+}

--- a/src/graph/hypergraph.ts
+++ b/src/graph/hypergraph.ts
@@ -1,0 +1,178 @@
+import {
+  GraphAttributeValue,
+  GraphEdgeRecord,
+  GraphNodeRecord,
+  NormalisedGraph,
+} from "./types.js";
+
+/** Metadata key storing the hyper-edge identifier after projection. */
+const HYPER_EDGE_ID_KEY = "hyper_edge_id";
+/** Metadata key storing the pair index generated during projection. */
+const HYPER_EDGE_PAIR_INDEX_KEY = "hyper_edge_pair_index";
+/** Metadata key storing the index of the source endpoint in the hyper-edge. */
+const HYPER_EDGE_SOURCE_INDEX_KEY = "hyper_edge_source_index";
+/** Metadata key storing the index of the target endpoint in the hyper-edge. */
+const HYPER_EDGE_TARGET_INDEX_KEY = "hyper_edge_target_index";
+/** Metadata key capturing the number of sources in the hyper-edge. */
+const HYPER_EDGE_SOURCE_CARDINALITY_KEY = "hyper_edge_source_cardinality";
+/** Metadata key capturing the number of targets in the hyper-edge. */
+const HYPER_EDGE_TARGET_CARDINALITY_KEY = "hyper_edge_target_cardinality";
+
+/** Allowed hyper-edge structure prior to projection. */
+export interface HyperEdge {
+  id: string;
+  sources: string[];
+  targets: string[];
+  label?: string;
+  weight?: number;
+  /** Optional per-edge attributes propagated to every projected edge. */
+  attributes?: Record<string, GraphAttributeValue>;
+}
+
+/** Minimal representation of a hyper-graph before projection. */
+export interface HyperGraph {
+  id: string;
+  nodes: GraphNodeRecord[];
+  hyperEdges: HyperEdge[];
+  metadata?: Record<string, GraphAttributeValue>;
+}
+
+/** Options influencing the projection of a {@link HyperGraph}. */
+export interface HyperProjectionOptions {
+  /** Version number propagated to the resulting normalised graph (defaults to 1). */
+  graphVersion?: number;
+}
+
+/**
+ * Project an n-ary hyper-edge into a set of binary edges.
+ *
+ * Each generated edge retains enough metadata to rebuild the original hyper-edge
+ * or to provide context to reporting tools. The metadata intentionally relies on
+ * primitive values so that downstream serialisations remain stable.
+ */
+function projectHyperEdge(
+  edge: HyperEdge,
+  nodeIds: Set<string>,
+): GraphEdgeRecord[] {
+  if (!edge.id || edge.id.trim().length === 0) {
+    throw new Error("hyper-edge must expose a stable identifier");
+  }
+  if (!Array.isArray(edge.sources) || edge.sources.length === 0) {
+    throw new Error(`hyper-edge ${edge.id} must declare at least one source`);
+  }
+  if (!Array.isArray(edge.targets) || edge.targets.length === 0) {
+    throw new Error(`hyper-edge ${edge.id} must declare at least one target`);
+  }
+
+  const projected: GraphEdgeRecord[] = [];
+  let pairIndex = 0;
+
+  for (let sourceIndex = 0; sourceIndex < edge.sources.length; sourceIndex += 1) {
+    const source = edge.sources[sourceIndex];
+    if (!nodeIds.has(source)) {
+      throw new Error(`hyper-edge ${edge.id} references unknown source node ${source}`);
+    }
+
+    for (let targetIndex = 0; targetIndex < edge.targets.length; targetIndex += 1) {
+      const target = edge.targets[targetIndex];
+      if (!nodeIds.has(target)) {
+        throw new Error(`hyper-edge ${edge.id} references unknown target node ${target}`);
+      }
+
+      const attributes: Record<string, GraphAttributeValue> = {
+        [HYPER_EDGE_ID_KEY]: edge.id,
+        [HYPER_EDGE_PAIR_INDEX_KEY]: pairIndex,
+        [HYPER_EDGE_SOURCE_INDEX_KEY]: sourceIndex,
+        [HYPER_EDGE_TARGET_INDEX_KEY]: targetIndex,
+        [HYPER_EDGE_SOURCE_CARDINALITY_KEY]: edge.sources.length,
+        [HYPER_EDGE_TARGET_CARDINALITY_KEY]: edge.targets.length,
+      };
+      if (edge.attributes) {
+        for (const [key, value] of Object.entries(edge.attributes)) {
+          attributes[key] = value;
+        }
+      }
+
+      projected.push({
+        from: source,
+        to: target,
+        label: edge.label,
+        weight: edge.weight,
+        attributes,
+      });
+      pairIndex += 1;
+    }
+  }
+
+  return projected;
+}
+
+/**
+ * Validate and normalise the node list of the provided hyper-graph.
+ *
+ * The helper guarantees a stable foundation before projection by enforcing
+ * unique node identifiers and by ensuring each node exposes an attribute map.
+ */
+function normaliseNodes(nodes: GraphNodeRecord[]): { ids: Set<string>; records: GraphNodeRecord[] } {
+  const nodeIds = new Set<string>();
+  const records: GraphNodeRecord[] = [];
+  for (const node of nodes) {
+    if (!node.id || node.id.trim().length === 0) {
+      throw new Error("hyper-graph nodes must provide an identifier");
+    }
+    if (nodeIds.has(node.id)) {
+      throw new Error(`duplicate node identifier detected in hyper-graph: ${node.id}`);
+    }
+    nodeIds.add(node.id);
+    records.push({
+      ...node,
+      attributes: node.attributes ?? {},
+    });
+  }
+  return { ids: nodeIds, records };
+}
+
+/**
+ * Project a {@link HyperGraph} into the normalised representation consumed by
+ * the rest of the graph tooling. The resulting graph preserves the original
+ * nodes while expanding every hyper-edge into a set of binary edges enriched
+ * with metadata for traceability.
+ */
+export function projectHyperGraph(
+  graph: HyperGraph,
+  options: HyperProjectionOptions = {},
+): NormalisedGraph {
+  if (!graph.id || graph.id.trim().length === 0) {
+    throw new Error("hyper-graph must expose an identifier");
+  }
+
+  const { ids: nodeIds, records } = normaliseNodes(graph.nodes);
+  const edges: GraphEdgeRecord[] = [];
+
+  for (const edge of graph.hyperEdges) {
+    const projected = projectHyperEdge(edge, nodeIds);
+    edges.push(...projected);
+  }
+
+  return {
+    name: graph.id,
+    graphId: graph.id,
+    graphVersion: options.graphVersion ?? 1,
+    nodes: records,
+    edges,
+    metadata: {
+      ...(graph.metadata ?? {}),
+      hyper_edge_projection: true,
+    },
+  };
+}
+
+export {
+  HYPER_EDGE_ID_KEY,
+  HYPER_EDGE_PAIR_INDEX_KEY,
+  HYPER_EDGE_SOURCE_CARDINALITY_KEY,
+  HYPER_EDGE_SOURCE_INDEX_KEY,
+  HYPER_EDGE_TARGET_CARDINALITY_KEY,
+  HYPER_EDGE_TARGET_INDEX_KEY,
+  projectHyperEdge,
+};

--- a/src/graph/rewrite.ts
+++ b/src/graph/rewrite.ts
@@ -1,0 +1,620 @@
+import { flatten, type HierGraph } from "./hierarchy.js";
+import type { NormalisedGraph, GraphEdgeRecord, GraphNodeRecord, GraphAttributeValue } from "./types.js";
+
+/** Unique key storing the serialized registry of sub-graphs embedded inside a normalised graph. */
+const SUBGRAPH_REGISTRY_KEY = "hierarchy:subgraphs";
+/** Attribute flag automatically added to edges produced by the split-parallel rule. */
+const SPLIT_PARALLEL_FLAG = "rewritten_split_parallel";
+/** Attribute flag automatically added to edges produced by the inline-subgraph rule. */
+const INLINE_SUBGRAPH_FLAG = "rewritten_inline_subgraph";
+/** Attribute flag automatically added to edges produced by the reroute-avoid rule. */
+const REROUTE_AVOID_FLAG = "rewritten_reroute_avoid";
+/** Internal upper bound that prevents the rewriting pipeline from looping forever. */
+const MAX_ITERATIONS = 25;
+
+/** Snapshot of a graph used to detect idempotent rewrite applications. */
+interface GraphSnapshot {
+  serialised: string;
+}
+
+/** Metadata describing how an embedded sub-graph should be inlined within the host graph. */
+interface InlineDescriptor {
+  graph: HierGraph | NormalisedGraph;
+  entryPoints?: string[];
+  exitPoints?: string[];
+}
+
+/** Description of a match surfaced by a rewrite rule. */
+export type RewriteMatch =
+  | { type: "split-parallel"; edge: GraphEdgeRecord; proposedNodeId: string }
+  | { type: "inline-subgraph"; node: GraphNodeRecord; descriptor: InlineDescriptor }
+  | { type: "reroute-avoid"; node: GraphNodeRecord };
+
+/** Result of evaluating a rule to locate potential rewrite candidates. */
+export type MatchSet = RewriteMatch[];
+
+/** Structured description of a graph rewrite rule. */
+export interface RewriteRule {
+  name: string;
+  match(graph: NormalisedGraph): MatchSet;
+  apply(graph: NormalisedGraph, match: RewriteMatch): NormalisedGraph;
+}
+
+/** Execution trace returned after applying a sequence of rewrite rules. */
+export interface RewriteHistoryEntry {
+  rule: string;
+  applied: number;
+  matches: number;
+}
+
+/** Output of the {@link applyAll} combinator. */
+export interface RewriteApplicationResult {
+  graph: NormalisedGraph;
+  history: RewriteHistoryEntry[];
+}
+
+/**
+ * Apply the provided list of rewrite rules to a graph until either no further
+ * changes are produced or the maximum iteration count is reached.
+ */
+export function applyAll(
+  graph: NormalisedGraph,
+  rules: RewriteRule[],
+  stopOnNoChange = true,
+): RewriteApplicationResult {
+  let current = cloneGraph(graph);
+  const history: RewriteHistoryEntry[] = [];
+  let iteration = 0;
+
+  while (iteration < MAX_ITERATIONS) {
+    iteration += 1;
+    let changedThisRound = false;
+
+    for (const rule of rules) {
+      const { graph: nextGraph, applied, matches } = applyRule(current, rule);
+      history.push({ rule: rule.name, applied, matches });
+      if (applied > 0) {
+        current = nextGraph;
+        changedThisRound = true;
+      }
+    }
+
+    if (!changedThisRound) {
+      break;
+    }
+    if (stopOnNoChange) {
+      break;
+    }
+  }
+
+  return { graph: current, history };
+}
+
+/** Create the canonical split-parallel rule used to expand parallel fan-outs. */
+export function createSplitParallelRule(targetEdges?: Set<string>): RewriteRule {
+  return {
+    name: "split-parallel",
+    match(graph) {
+      const matches: RewriteMatch[] = [];
+      for (const edge of graph.edges) {
+        const key = edgeKey(edge);
+        if (targetEdges && !targetEdges.has(key)) {
+          continue;
+        }
+        if (edge.attributes[SPLIT_PARALLEL_FLAG]) {
+          continue;
+        }
+        const shouldSplit = edge.attributes.parallel === true || edge.attributes.mode === "parallel";
+        if (!shouldSplit) {
+          continue;
+        }
+        const nodeId = ensureUniqueNodeId(graph, `${edge.from}∥${edge.to}`);
+        matches.push({ type: "split-parallel", edge, proposedNodeId: nodeId });
+      }
+      return matches;
+    },
+    apply(graph, match) {
+      if (match.type !== "split-parallel") {
+        return graph;
+      }
+      const edgeIndex = graph.edges.findIndex((candidate) => sameEdge(candidate, match.edge));
+      if (edgeIndex === -1) {
+        return graph;
+      }
+      const newNode: GraphNodeRecord = {
+        id: match.proposedNodeId,
+        label: `Parallel ${match.edge.label ?? match.edge.to}`,
+        attributes: {
+          kind: "parallel",
+          parent: match.edge.from,
+        },
+      };
+      const preservedAttributes = { ...match.edge.attributes };
+      delete preservedAttributes.parallel;
+      delete preservedAttributes.mode;
+      const fanoutEdge: GraphEdgeRecord = {
+        from: match.edge.from,
+        to: newNode.id,
+        label: match.edge.label,
+        weight: match.edge.weight,
+        attributes: {
+          ...preservedAttributes,
+          [SPLIT_PARALLEL_FLAG]: true,
+          role: "fanout",
+        },
+      };
+      const branchEdge: GraphEdgeRecord = {
+        from: newNode.id,
+        to: match.edge.to,
+        label: match.edge.label,
+        weight: match.edge.weight,
+        attributes: {
+          ...preservedAttributes,
+          [SPLIT_PARALLEL_FLAG]: true,
+          role: "branch",
+        },
+      };
+      const next: NormalisedGraph = {
+        ...graph,
+        graphVersion: graph.graphVersion + 1,
+        nodes: [...graph.nodes, newNode],
+        edges: replaceAt(graph.edges, edgeIndex, [fanoutEdge, branchEdge]),
+      };
+      return next;
+    },
+  };
+}
+
+/** Create the canonical inline-subgraph rule that expands embedded hierarchies. */
+export function createInlineSubgraphRule(): RewriteRule {
+  return {
+    name: "inline-subgraph",
+    match(graph) {
+      const registry = parseSubgraphRegistry(graph.metadata[SUBGRAPH_REGISTRY_KEY]);
+      if (!registry) {
+        return [];
+      }
+      const matches: RewriteMatch[] = [];
+      for (const node of graph.nodes) {
+        if (node.attributes.kind !== "subgraph") {
+          continue;
+        }
+        const reference = node.attributes.ref ?? node.attributes.subgraph_ref;
+        if (typeof reference !== "string") {
+          continue;
+        }
+        const descriptor = registry.get(reference);
+        if (!descriptor) {
+          continue;
+        }
+        matches.push({ type: "inline-subgraph", node, descriptor });
+      }
+      return matches;
+    },
+    apply(graph, match) {
+      if (match.type !== "inline-subgraph") {
+        return graph;
+      }
+      const registry = parseSubgraphRegistry(graph.metadata[SUBGRAPH_REGISTRY_KEY]);
+      if (!registry) {
+        return graph;
+      }
+      const reference = match.node.attributes.ref ?? match.node.attributes.subgraph_ref;
+      if (typeof reference !== "string") {
+        return graph;
+      }
+      const descriptor = registry.get(reference);
+      if (!descriptor) {
+        return graph;
+      }
+      const flattened = normaliseEmbeddedGraph(descriptor.graph);
+      const prefixed = prefixGraph(flattened, match.node.id);
+      const entryHints = descriptor.entryPoints ?? match.descriptor.entryPoints;
+      const exitHints = descriptor.exitPoints ?? match.descriptor.exitPoints;
+      const entryNodes =
+        entryHints && entryHints.length > 0
+          ? entryHints
+              .map((id) => prefixed.mapping.get(id) ?? id)
+              .filter((id): id is string => typeof id === "string")
+          : inferEntryNodes(prefixed.graph);
+      const exitNodes =
+        exitHints && exitHints.length > 0
+          ? exitHints
+              .map((id) => prefixed.mapping.get(id) ?? id)
+              .filter((id): id is string => typeof id === "string")
+          : inferExitNodes(prefixed.graph);
+
+      const incoming = graph.edges.filter((edge) => edge.to === match.node.id);
+      const outgoing = graph.edges.filter((edge) => edge.from === match.node.id);
+      const retainedNodes = graph.nodes.filter((node) => node.id !== match.node.id);
+      const retainedEdges = graph.edges.filter(
+        (edge) => edge.from !== match.node.id && edge.to !== match.node.id,
+      );
+
+      const rewiredEdges: GraphEdgeRecord[] = [];
+      for (const edge of incoming) {
+        for (const entry of entryNodes) {
+          if (edge.from === entry) {
+            continue;
+          }
+          rewiredEdges.push({
+            from: edge.from,
+            to: entry,
+            label: edge.label,
+            weight: edge.weight,
+            attributes: {
+              ...edge.attributes,
+              [INLINE_SUBGRAPH_FLAG]: true,
+              via: match.node.id,
+            },
+          });
+        }
+      }
+      for (const edge of outgoing) {
+        for (const exit of exitNodes) {
+          if (edge.to === exit) {
+            continue;
+          }
+          rewiredEdges.push({
+            from: exit,
+            to: edge.to,
+            label: edge.label,
+            weight: edge.weight,
+            attributes: {
+              ...edge.attributes,
+              [INLINE_SUBGRAPH_FLAG]: true,
+              via: match.node.id,
+            },
+          });
+        }
+      }
+
+      const nextNodes = mergeNodes(retainedNodes, prefixed.graph.nodes, match.node.id);
+      const nextEdges = [...retainedEdges, ...prefixed.graph.edges, ...rewiredEdges];
+
+      return {
+        ...graph,
+        graphVersion: graph.graphVersion + 1,
+        nodes: sortNodes(nextNodes),
+        edges: sortEdges(nextEdges),
+      };
+    },
+  };
+}
+
+/** Create the canonical reroute-avoid rule that bypasses weak or unsafe nodes. */
+export function createRerouteAvoidRule(options: {
+  avoidNodeIds?: Set<string>;
+  avoidLabels?: Set<string>;
+}): RewriteRule {
+  return {
+    name: "reroute-avoid",
+    match(graph) {
+      const matches: RewriteMatch[] = [];
+      for (const node of graph.nodes) {
+        const shouldAvoidById = options.avoidNodeIds?.has(node.id);
+        const shouldAvoidByLabel = node.label && options.avoidLabels?.has(node.label);
+        if (!shouldAvoidById && !shouldAvoidByLabel) {
+          continue;
+        }
+        matches.push({ type: "reroute-avoid", node });
+      }
+      return matches;
+    },
+    apply(graph, match) {
+      if (match.type !== "reroute-avoid") {
+        return graph;
+      }
+      const nodeExists = graph.nodes.some((node) => node.id === match.node.id);
+      if (!nodeExists) {
+        return graph;
+      }
+      const incoming = graph.edges.filter((edge) => edge.to === match.node.id);
+      const outgoing = graph.edges.filter((edge) => edge.from === match.node.id);
+      if (incoming.length === 0 || outgoing.length === 0) {
+        const nextNodes = graph.nodes.filter((node) => node.id !== match.node.id);
+        const nextEdges = graph.edges.filter(
+          (edge) => edge.from !== match.node.id && edge.to !== match.node.id,
+        );
+        return {
+          ...graph,
+          graphVersion: graph.graphVersion + 1,
+          nodes: nextNodes,
+          edges: nextEdges,
+        };
+      }
+      const bypassEdges: GraphEdgeRecord[] = [];
+      const seen = new Set<string>();
+      for (const source of incoming) {
+        for (const target of outgoing) {
+          if (source.from === target.to) {
+            continue;
+          }
+          const key = `${source.from}→${target.to}`;
+          if (seen.has(key)) {
+            continue;
+          }
+          seen.add(key);
+          bypassEdges.push({
+            from: source.from,
+            to: target.to,
+            label: target.label ?? source.label,
+            weight: source.weight ?? target.weight,
+            attributes: {
+              ...target.attributes,
+              [REROUTE_AVOID_FLAG]: true,
+              avoided: match.node.id,
+            },
+          });
+        }
+      }
+      const nodes = graph.nodes.filter((node) => node.id !== match.node.id);
+      const edges = graph.edges.filter((edge) => edge.from !== match.node.id && edge.to !== match.node.id);
+      return {
+        ...graph,
+        graphVersion: graph.graphVersion + 1,
+        nodes,
+        edges: sortEdges([...edges, ...bypassEdges]),
+      };
+    },
+  };
+}
+
+/** Apply a single rule until it can no longer mutate the graph. */
+function applyRule(graph: NormalisedGraph, rule: RewriteRule): {
+  graph: NormalisedGraph;
+  applied: number;
+  matches: number;
+} {
+  let current = graph;
+  let applied = 0;
+  let matches = 0;
+  const visited = new Set<string>();
+  for (let iteration = 0; iteration < MAX_ITERATIONS; iteration += 1) {
+    const set = rule.match(current);
+    matches += set.length;
+    if (set.length === 0) {
+      break;
+    }
+    const snapshot = snapshotGraph(current);
+    if (visited.has(snapshot.serialised)) {
+      break;
+    }
+    visited.add(snapshot.serialised);
+    let mutated = false;
+    for (const match of set) {
+      const next = rule.apply(current, match);
+      if (!graphsEqual(current, next)) {
+        current = next;
+        applied += 1;
+        mutated = true;
+        break;
+      }
+    }
+    if (!mutated) {
+      break;
+    }
+  }
+  return { graph: current, applied, matches };
+}
+
+/** Extract and validate the subgraph registry stored in the metadata map. */
+function parseSubgraphRegistry(value: GraphAttributeValue | undefined): Map<string, InlineDescriptor> | null {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as Record<string, InlineDescriptor>;
+    const registry = new Map<string, InlineDescriptor>();
+    for (const [key, descriptor] of Object.entries(parsed)) {
+      if (!descriptor || typeof descriptor !== "object") {
+        continue;
+      }
+      registry.set(key, descriptor);
+    }
+    return registry;
+  } catch {
+    return null;
+  }
+}
+
+/** Ensure that a node identifier remains unique within the provided graph. */
+function ensureUniqueNodeId(graph: NormalisedGraph, baseId: string): string {
+  let candidate = baseId;
+  let suffix = 1;
+  const existing = new Set(graph.nodes.map((node) => node.id));
+  while (existing.has(candidate)) {
+    suffix += 1;
+    candidate = `${baseId}#${suffix}`;
+  }
+  return candidate;
+}
+
+/** Verify whether two edges point to the same source and target. */
+function sameEdge(left: GraphEdgeRecord, right: GraphEdgeRecord): boolean {
+  return left.from === right.from && left.to === right.to && left.label === right.label;
+}
+
+/** Replace a single edge with a new list, returning a new array. */
+function replaceAt(edges: GraphEdgeRecord[], index: number, replacements: GraphEdgeRecord[]): GraphEdgeRecord[] {
+  return [...edges.slice(0, index), ...replacements, ...edges.slice(index + 1)];
+}
+
+/** Clone a graph to maintain immutability guarantees across rewrites. */
+function cloneGraph(graph: NormalisedGraph): NormalisedGraph {
+  return {
+    ...graph,
+    nodes: graph.nodes.map((node) => ({
+      id: node.id,
+      label: node.label,
+      attributes: { ...node.attributes },
+    })),
+    edges: graph.edges.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      label: edge.label,
+      weight: edge.weight,
+      attributes: { ...edge.attributes },
+    })),
+    metadata: { ...graph.metadata },
+  };
+}
+
+/** Generate a structural snapshot used to detect idempotence. */
+function snapshotGraph(graph: NormalisedGraph): GraphSnapshot {
+  return { serialised: serialiseGraph(graph) };
+}
+
+/** Determine whether two graphs are structurally identical. */
+function graphsEqual(left: NormalisedGraph, right: NormalisedGraph): boolean {
+  return serialiseGraph(left) === serialiseGraph(right);
+}
+
+/** Produce a deterministic serialisation of a graph. */
+function serialiseGraph(graph: NormalisedGraph): string {
+  const nodes = sortNodes(graph.nodes).map((node) => ({
+    id: node.id,
+    label: node.label,
+    attributes: sortAttributes(node.attributes),
+  }));
+  const edges = sortEdges(graph.edges).map((edge) => ({
+    from: edge.from,
+    to: edge.to,
+    label: edge.label,
+    weight: edge.weight,
+    attributes: sortAttributes(edge.attributes),
+  }));
+  const metadata = sortAttributes(graph.metadata as Record<string, GraphAttributeValue>);
+  return JSON.stringify({
+    ...graph,
+    nodes,
+    edges,
+    metadata,
+  });
+}
+
+/** Sort nodes deterministically by their identifier. */
+function sortNodes(nodes: GraphNodeRecord[]): GraphNodeRecord[] {
+  return [...nodes].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Sort edges deterministically by source/target/label. */
+function sortEdges(edges: GraphEdgeRecord[]): GraphEdgeRecord[] {
+  return [...edges].sort((a, b) => {
+    if (a.from !== b.from) return a.from.localeCompare(b.from);
+    if (a.to !== b.to) return a.to.localeCompare(b.to);
+    return (a.label ?? "").localeCompare(b.label ?? "");
+  });
+}
+
+/** Produce a sorted copy of an attribute map for deterministic outputs. */
+function sortAttributes(attributes: Record<string, GraphAttributeValue>): Record<string, GraphAttributeValue> {
+  const entries = Object.entries(attributes).sort(([a], [b]) => a.localeCompare(b));
+  return Object.fromEntries(entries);
+}
+
+/** Prefix a graph so that embedded nodes remain globally unique. */
+function prefixGraph(graph: NormalisedGraph, prefix: string): {
+  graph: NormalisedGraph;
+  mapping: Map<string, string>;
+} {
+  const mapping = new Map<string, string>();
+  for (const node of graph.nodes) {
+    mapping.set(node.id, `${prefix}/${node.id}`);
+  }
+  const nodes = graph.nodes.map<GraphNodeRecord>((node) => ({
+    id: mapping.get(node.id)!,
+    label: node.label,
+    attributes: {
+      ...node.attributes,
+      parent_subgraph: prefix,
+    },
+  }));
+  const edges = graph.edges.map<GraphEdgeRecord>((edge) => ({
+    from: mapping.get(edge.from)!,
+    to: mapping.get(edge.to)!,
+    label: edge.label,
+    weight: edge.weight,
+    attributes: { ...edge.attributes, parent_subgraph: prefix },
+  }));
+  return {
+    graph: {
+      ...graph,
+      nodes,
+      edges,
+    },
+    mapping,
+  };
+}
+
+/**
+ * Merge nodes while guarding against duplicates when inlining a sub-graph.
+ */
+function mergeNodes(
+  base: GraphNodeRecord[],
+  addition: GraphNodeRecord[],
+  parentId: string,
+): GraphNodeRecord[] {
+  const result = [...base];
+  const existing = new Set(base.map((node) => node.id));
+  for (const node of addition) {
+    if (existing.has(node.id)) {
+      continue;
+    }
+    result.push({
+      id: node.id,
+      label: node.label,
+      attributes: {
+        ...node.attributes,
+        host: parentId,
+      },
+    });
+    existing.add(node.id);
+  }
+  return result;
+}
+
+/**
+ * Determine entry nodes as the ones without in-edges in the embedded graph.
+ */
+function inferEntryNodes(graph: NormalisedGraph): string[] {
+  const targets = new Set(graph.edges.map((edge) => edge.to));
+  return graph.nodes
+    .filter((node) => !targets.has(node.id))
+    .map((node) => node.id)
+    .sort();
+}
+
+/** Determine exit nodes as the ones without out-edges in the embedded graph. */
+function inferExitNodes(graph: NormalisedGraph): string[] {
+  const sources = new Set(graph.edges.map((edge) => edge.from));
+  return graph.nodes
+    .filter((node) => !sources.has(node.id))
+    .map((node) => node.id)
+    .sort();
+}
+
+/**
+ * Normalise any embedded hierarchical graph so downstream rules can reuse it as
+ * a regular normalised graph without leaking implementation details.
+ */
+function normaliseEmbeddedGraph(graph: HierGraph | NormalisedGraph): NormalisedGraph {
+  if (isNormalisedGraph(graph)) {
+    return graph as NormalisedGraph;
+  }
+  return flatten(graph as HierGraph);
+}
+
+/** Compute a stable identifier for an edge. */
+function edgeKey(edge: GraphEdgeRecord): string {
+  return `${edge.from}→${edge.to}`;
+}
+
+/** Narrow a parsed descriptor to a normalised graph when the shape matches. */
+function isNormalisedGraph(graph: HierGraph | NormalisedGraph): graph is NormalisedGraph {
+  const candidate = graph as NormalisedGraph;
+  if (!candidate || !Array.isArray(candidate.nodes) || !Array.isArray(candidate.edges)) {
+    return false;
+  }
+  return candidate.edges.every((edge) => typeof edge.from === "string" && typeof edge.to === "string");
+}

--- a/src/graph/tx.ts
+++ b/src/graph/tx.ts
@@ -1,0 +1,246 @@
+import { randomUUID } from "node:crypto";
+
+import type { NormalisedGraph } from "./types.js";
+
+/** Metadata key storing the timestamp of the last successful transaction commit. */
+const TX_COMMITTED_AT_METADATA_KEY = "__txCommittedAt";
+
+/**
+ * Generic error thrown by the transaction manager whenever an unexpected
+ * situation occurs (unknown transaction, invalid graph id, ...).
+ */
+export class GraphTransactionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GraphTransactionError";
+  }
+}
+
+/** Error thrown when attempting to commit using a stale base version. */
+export class GraphVersionConflictError extends GraphTransactionError {
+  constructor(graphId: string, expected: number, found: number) {
+    super(
+      `graph '${graphId}' diverged: expected version ${expected} but received ${found}`,
+    );
+    this.name = "GraphVersionConflictError";
+  }
+}
+
+/** Error thrown when a caller references a transaction identifier that expired. */
+export class UnknownTransactionError extends GraphTransactionError {
+  constructor(txId: string) {
+    super(`transaction '${txId}' is not active`);
+    this.name = "UnknownTransactionError";
+  }
+}
+
+/** Snapshot of the latest committed state for a graph identifier. */
+interface GraphVersionState {
+  version: number;
+  committedAt: number;
+  graph: NormalisedGraph;
+}
+
+/** Internal representation of a live transaction. */
+interface TransactionRecord {
+  txId: string;
+  graphId: string;
+  baseVersion: number;
+  snapshot: NormalisedGraph;
+  startedAt: number;
+}
+
+/** Result returned when opening a new transaction. */
+export interface BeginTransactionResult {
+  txId: string;
+  graphId: string;
+  baseVersion: number;
+  startedAt: number;
+  /** Working copy that callers can mutate before attempting a commit. */
+  workingCopy: NormalisedGraph;
+}
+
+/** Result returned after successfully committing a transaction. */
+export interface CommitTransactionResult {
+  txId: string;
+  graphId: string;
+  version: number;
+  committedAt: number;
+  graph: NormalisedGraph;
+}
+
+/** Result returned when a transaction gets rolled back. */
+export interface RollbackTransactionResult {
+  txId: string;
+  graphId: string;
+  version: number;
+  rolledBackAt: number;
+  snapshot: NormalisedGraph;
+}
+
+/**
+ * Manage transactional snapshots for normalised graphs. The manager enforces a
+ * strict single-writer policy: concurrent transactions must observe the latest
+ * committed version otherwise the commit will fail with a conflict.
+ */
+export class GraphTransactionManager {
+  /** Latest committed state tracked per graph identifier. */
+  private readonly states = new Map<string, GraphVersionState>();
+
+  /** Active transaction records keyed by their identifier. */
+  private readonly transactions = new Map<string, TransactionRecord>();
+
+  /**
+   * Open a new transaction for the provided graph. The caller receives a fresh
+   * working copy which can be mutated freely before invoking {@link commit} or
+   * {@link rollback}.
+   */
+  begin(graph: NormalisedGraph): BeginTransactionResult {
+    if (!graph.graphId || graph.graphId.trim().length === 0) {
+      throw new GraphTransactionError("graph id must be provided before opening a transaction");
+    }
+
+    const state = this.states.get(graph.graphId);
+    if (state) {
+      if (state.version !== graph.graphVersion) {
+        throw new GraphVersionConflictError(graph.graphId, state.version, graph.graphVersion);
+      }
+      state.graph = this.cloneGraph(graph);
+    } else {
+      const committedAt = Date.now();
+      this.states.set(graph.graphId, {
+        version: graph.graphVersion,
+        committedAt,
+        graph: this.cloneGraph(graph),
+      });
+    }
+
+    const txId = randomUUID();
+    const startedAt = Date.now();
+    const snapshot = this.cloneGraph(graph);
+    const record: TransactionRecord = {
+      txId,
+      graphId: graph.graphId,
+      baseVersion: graph.graphVersion,
+      snapshot,
+      startedAt,
+    };
+    this.transactions.set(txId, record);
+
+    return {
+      txId,
+      graphId: graph.graphId,
+      baseVersion: graph.graphVersion,
+      startedAt,
+      workingCopy: this.cloneGraph(graph),
+    };
+  }
+
+  /**
+   * Commit the transaction identified by {@link txId}. The provided graph must
+   * originate from the working copy returned by {@link begin}. The manager will
+   * increment the graph version, stamp the commit timestamp, and update the
+   * latest committed snapshot.
+   */
+  commit(txId: string, updatedGraph: NormalisedGraph): CommitTransactionResult {
+    const record = this.transactions.get(txId);
+    if (!record) {
+      throw new UnknownTransactionError(txId);
+    }
+
+    this.transactions.delete(txId);
+
+    if (updatedGraph.graphId !== record.graphId) {
+      throw new GraphTransactionError(
+        `graph id mismatch: expected '${record.graphId}' but received '${updatedGraph.graphId}'`,
+      );
+    }
+
+    const state = this.states.get(record.graphId);
+    if (!state) {
+      throw new GraphTransactionError(
+        `no committed state registered for graph '${record.graphId}'`,
+      );
+    }
+
+    if (state.version !== record.baseVersion) {
+      throw new GraphVersionConflictError(record.graphId, state.version, record.baseVersion);
+    }
+
+    const expectedVersion = record.baseVersion;
+    const providedVersion = updatedGraph.graphVersion;
+    if (providedVersion < expectedVersion || providedVersion > expectedVersion + 1) {
+      throw new GraphVersionConflictError(record.graphId, expectedVersion, providedVersion);
+    }
+
+    const mutated = !this.graphsEqual(record.snapshot, updatedGraph);
+    const committedAt = mutated ? Date.now() : state.committedAt;
+    const nextVersion = mutated ? expectedVersion + 1 : state.version;
+
+    let finalGraph: NormalisedGraph;
+    if (mutated) {
+      finalGraph = this.cloneGraph(updatedGraph);
+      finalGraph.graphVersion = nextVersion;
+      finalGraph.metadata = {
+        ...finalGraph.metadata,
+        [TX_COMMITTED_AT_METADATA_KEY]: committedAt,
+      };
+
+      state.version = nextVersion;
+      state.committedAt = committedAt;
+      state.graph = this.cloneGraph(finalGraph);
+    } else {
+      finalGraph = this.cloneGraph(state.graph);
+    }
+
+    return {
+      txId,
+      graphId: record.graphId,
+      version: nextVersion,
+      committedAt,
+      graph: finalGraph,
+    };
+  }
+
+  /**
+   * Abort the transaction identified by {@link txId}, restoring the snapshot
+   * captured at {@link begin}. The caller receives the pristine state so it can
+   * be re-used or inspected safely.
+   */
+  rollback(txId: string): RollbackTransactionResult {
+    const record = this.transactions.get(txId);
+    if (!record) {
+      throw new UnknownTransactionError(txId);
+    }
+
+    this.transactions.delete(txId);
+
+    const rolledBackAt = Date.now();
+    return {
+      txId,
+      graphId: record.graphId,
+      version: record.baseVersion,
+      rolledBackAt,
+      snapshot: this.cloneGraph(record.snapshot),
+    };
+  }
+
+  /** Retrieve the number of active transactions, useful for diagnostics. */
+  countActiveTransactions(): number {
+    return this.transactions.size;
+  }
+
+  /** Shallow helper to deep-clone a normalised graph without sharing references. */
+  private cloneGraph(graph: NormalisedGraph): NormalisedGraph {
+    return structuredClone(graph) as NormalisedGraph;
+  }
+
+  /**
+   * Compare two graphs for structural equality. The normalised representation
+   * preserves node/edge ordering which makes a simple JSON serialisation safe
+   * for equality checks without introducing a heavy diff dependency.
+   */
+  private graphsEqual(first: NormalisedGraph, second: NormalisedGraph): boolean {
+    return JSON.stringify(first) === JSON.stringify(second);
+  }
+}

--- a/src/tools/graphTools.ts
+++ b/src/tools/graphTools.ts
@@ -402,6 +402,25 @@ export interface GraphMutateResult extends Record<string, unknown> {
   applied: GraphMutationRecord[];
 }
 
+/**
+ * Convert a serialised graph payload (typically exchanged with tools) into the
+ * internal normalised representation leveraged by the transaction manager.
+ *
+ * The helper intentionally reuses the same normalisation routine as the graph
+ * tools to preserve ordering guarantees and ensure cache keys remain stable.
+ */
+export function normaliseGraphPayload(payload: GraphDescriptorPayload): NormalisedGraph {
+  return normaliseDescriptor(payload as z.infer<typeof GraphDescriptorSchema>);
+}
+
+/**
+ * Serialise a normalised graph so it can be returned to clients or chained into
+ * other tooling primitives without exposing the internal structure.
+ */
+export function serialiseNormalisedGraph(descriptor: NormalisedGraph): GraphDescriptorPayload {
+  return serialiseDescriptor(descriptor);
+}
+
 /** Apply idempotent graph operations, returning the mutated graph. */
 export function handleGraphMutate(input: GraphMutateInput): GraphMutateResult {
   const descriptor = normaliseDescriptor(input.graph);

--- a/tests/graph.adaptive.rewrite.test.ts
+++ b/tests/graph.adaptive.rewrite.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { applyAdaptiveRewrites, type AdaptiveEvaluationResult } from "../src/graph/adaptive.js";
+import type { HierGraph } from "../src/graph/hierarchy.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+
+/**
+ * Integration tests ensuring the adaptive evaluation can drive the rewrite
+ * pipeline and that the generated structures remain coherent.
+ */
+describe("graph adaptive - rewrite integration", () => {
+  it("derives rewrite decisions from reinforcement insights", () => {
+    const embedded: HierGraph = {
+      id: "embedded", 
+      nodes: [
+        { id: "entry", kind: "task", label: "Sub Entry" },
+        { id: "exit", kind: "task", label: "Sub Exit" },
+      ],
+      edges: [
+        { id: "inner", from: { nodeId: "entry" }, to: { nodeId: "exit" } },
+      ],
+    };
+
+    const graph: NormalisedGraph = {
+      name: "adaptive", 
+      graphId: "adaptive", 
+      graphVersion: 1,
+      nodes: [
+        { id: "start", label: "Start", attributes: { kind: "task" } },
+        { id: "sub", label: "Sub", attributes: { kind: "subgraph", ref: "embedded" } },
+        { id: "beta", label: "Beta", attributes: { kind: "task" } },
+        { id: "blocker", label: "Blocker", attributes: { kind: "task" } },
+        { id: "sink", label: "Sink", attributes: { kind: "task" } },
+      ],
+      edges: [
+        { from: "start", to: "sub", label: "fanout", attributes: { parallel: true } },
+        { from: "sub", to: "beta", label: "advance", attributes: {} },
+        { from: "beta", to: "blocker", label: "risky", attributes: {} },
+        { from: "blocker", to: "sink", label: "final", attributes: {} },
+      ],
+      metadata: {
+        "hierarchy:subgraphs": JSON.stringify({
+          embedded: { graph: embedded, entryPoints: ["entry"], exitPoints: ["exit"] },
+        }),
+      },
+    };
+
+    const evaluation: AdaptiveEvaluationResult = {
+      insights: [],
+      edgesToBoost: ["start→sub"],
+      edgesToPrune: ["beta→blocker"],
+    };
+
+    const { graph: rewritten, history } = applyAdaptiveRewrites(graph, evaluation);
+
+    const newNodeIds = new Set(rewritten.nodes.map((node) => node.id));
+    expect(newNodeIds.has("start∥sub")).to.equal(true);
+    expect(newNodeIds.has("sub/entry")).to.equal(true);
+    expect(newNodeIds.has("blocker")).to.equal(false);
+    const newEdges = new Set(rewritten.edges.map((edge) => `${edge.from}->${edge.to}`));
+    expect(newEdges.has("start->start∥sub")).to.equal(true);
+    expect(newEdges.has("start∥sub->sub/entry")).to.equal(true);
+    expect(newEdges.has("beta->sink")).to.equal(true);
+
+    const splitHistory = history.find((entry) => entry.rule === "split-parallel");
+    const inlineHistory = history.find((entry) => entry.rule === "inline-subgraph");
+    const rerouteHistory = history.find((entry) => entry.rule === "reroute-avoid");
+    expect(splitHistory?.applied).to.be.greaterThan(0);
+    expect(inlineHistory?.applied).to.be.greaterThan(0);
+    expect(rerouteHistory?.applied).to.be.greaterThan(0);
+  });
+});

--- a/tests/graph.export.hyper.test.ts
+++ b/tests/graph.export.hyper.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { projectHyperGraph, type HyperGraph } from "../src/graph/hypergraph.js";
+import { renderMermaidFromGraph } from "../src/viz/mermaid.js";
+import { renderDotFromGraph } from "../src/viz/dot.js";
+
+// The export suite focuses on the textual annotations ensuring that visual
+// renderers keep the link with the original hyper-edge definition.
+describe("graph export - hyper-edge annotations", () => {
+  it("embeds hyper-edge information in Mermaid exports", () => {
+    const hyperGraph: HyperGraph = {
+      id: "fanout",
+      nodes: [
+        { id: "source", label: "Source", attributes: {} },
+        { id: "left", label: "Left", attributes: {} },
+        { id: "right", label: "Right", attributes: {} },
+      ],
+      hyperEdges: [
+        {
+          id: "split",
+          sources: ["source"],
+          targets: ["left", "right"],
+          label: "dispatch",
+        },
+      ],
+    };
+
+    const projected = projectHyperGraph(hyperGraph);
+    const descriptor = {
+      name: projected.name,
+      nodes: projected.nodes.map((node) => ({
+        id: node.id,
+        label: node.label,
+        attributes: node.attributes,
+      })),
+      edges: projected.edges.map((edge) => ({
+        from: edge.from,
+        to: edge.to,
+        label: edge.label ?? undefined,
+        weight: edge.weight,
+        attributes: edge.attributes,
+      })),
+      metadata: projected.metadata,
+      graph_id: projected.graphId,
+      graph_version: projected.graphVersion,
+    };
+
+    const mermaid = renderMermaidFromGraph(descriptor);
+    expect(mermaid).to.include('source -- "dispatch \\[H:split#0 1->2\\]" --> left');
+    expect(mermaid).to.include('source -- "dispatch \\[H:split#1 1->2\\]" --> right');
+  });
+
+  it("embeds hyper-edge information in DOT exports", () => {
+    const hyperGraph: HyperGraph = {
+      id: "fanout",
+      nodes: [
+        { id: "source", label: "Source", attributes: {} },
+        { id: "left", label: "Left", attributes: {} },
+        { id: "right", label: "Right", attributes: {} },
+      ],
+      hyperEdges: [
+        {
+          id: "split",
+          sources: ["source"],
+          targets: ["left", "right"],
+          label: "dispatch",
+        },
+      ],
+    };
+
+    const projected = projectHyperGraph(hyperGraph);
+    const descriptor = {
+      name: projected.name,
+      nodes: projected.nodes.map((node) => ({
+        id: node.id,
+        label: node.label,
+        attributes: node.attributes,
+      })),
+      edges: projected.edges.map((edge) => ({
+        from: edge.from,
+        to: edge.to,
+        label: edge.label ?? undefined,
+        weight: edge.weight,
+        attributes: edge.attributes,
+      })),
+      metadata: projected.metadata,
+      graph_id: projected.graphId,
+      graph_version: projected.graphVersion,
+    };
+
+    const dot = renderDotFromGraph(descriptor);
+    expect(dot).to.include('"source" -> "left" [label="dispatch [H:split#0 1->2]"]');
+    expect(dot).to.include('"source" -> "right" [label="dispatch [H:split#1 1->2]"]');
+  });
+});

--- a/tests/graph.hierarchy.flatten.test.ts
+++ b/tests/graph.hierarchy.flatten.test.ts
@@ -1,0 +1,88 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { embedSubgraph, flatten, type HierGraph } from "../src/graph/hierarchy.js";
+
+describe("graph hierarchy - flatten", () => {
+  it("expands nested subgraphs into a normalised graph", () => {
+    const quality: HierGraph = {
+      id: "quality",
+      nodes: [
+        { id: "lint", kind: "task", label: "Lint", outputs: ["out"] },
+        { id: "test", kind: "task", label: "Test", inputs: ["in"], outputs: ["out"] },
+      ],
+      edges: [{ id: "q1", from: { nodeId: "lint", port: "out" }, to: { nodeId: "test", port: "in" } }],
+    };
+
+    const analysis: HierGraph = {
+      id: "analysis",
+      nodes: [
+        { id: "parse", kind: "task", label: "Parse", outputs: ["out"] },
+        {
+          id: "qualityStage",
+          kind: "subgraph",
+          ref: "quality",
+          params: { ports: { inputs: { begin: "lint" }, outputs: { end: "test" } } },
+        },
+        { id: "score", kind: "task", label: "Score", inputs: ["in"] },
+      ],
+      edges: [
+        { id: "a1", from: { nodeId: "parse", port: "out" }, to: { nodeId: "qualityStage", port: "begin" } },
+        { id: "a2", from: { nodeId: "qualityStage", port: "end" }, to: { nodeId: "score", port: "in" } },
+      ],
+    };
+
+    const root: HierGraph = {
+      id: "root",
+      nodes: [
+        { id: "ingest", kind: "task", label: "Ingest", outputs: ["out"] },
+        {
+          id: "analysis",
+          kind: "subgraph",
+          ref: "analysis",
+          params: { ports: { inputs: { entry: "parse" }, outputs: { exit: "score" } } },
+        },
+        { id: "ship", kind: "task", label: "Ship", inputs: ["in"] },
+      ],
+      edges: [
+        { id: "r1", from: { nodeId: "ingest", port: "out" }, to: { nodeId: "analysis", port: "entry" } },
+        { id: "r2", from: { nodeId: "analysis", port: "exit" }, to: { nodeId: "ship", port: "in" } },
+      ],
+    };
+
+    const analysisEmbedded = embedSubgraph(analysis, "qualityStage", quality);
+    const fullyEmbedded = embedSubgraph(root, "analysis", analysisEmbedded);
+
+    const flat = flatten(fullyEmbedded);
+    expect(flat.metadata.hierarchical).to.equal(true);
+    expect(flat.name).to.equal("root");
+
+    const nodeIds = flat.nodes.map((node) => node.id);
+    expect(nodeIds).to.include.members([
+      "ingest",
+      "analysis/parse",
+      "analysis/qualityStage/lint",
+      "analysis/qualityStage/test",
+      "analysis/score",
+      "ship",
+    ]);
+
+    const transitions = flat.edges.map((edge) => ({ from: edge.from, to: edge.to }));
+    expect(transitions).to.deep.include({ from: "ingest", to: "analysis/parse" });
+    expect(transitions).to.deep.include({ from: "analysis/parse", to: "analysis/qualityStage/lint" });
+    expect(transitions).to.deep.include({ from: "analysis/qualityStage/lint", to: "analysis/qualityStage/test" });
+    expect(transitions).to.deep.include({ from: "analysis/qualityStage/test", to: "analysis/score" });
+    expect(transitions).to.deep.include({ from: "analysis/score", to: "ship" });
+
+    const qualityEdge = flat.edges.find(
+      (edge) => edge.from === "analysis/qualityStage/lint" && edge.to === "analysis/qualityStage/test",
+    );
+    expect(qualityEdge?.attributes.from_port).to.equal("out");
+    expect(qualityEdge?.attributes.to_port).to.equal("in");
+
+    const repeat = flatten(fullyEmbedded);
+    expect(repeat.edges.map((edge) => `${edge.from}->${edge.to}`)).to.deep.equal(
+      flat.edges.map((edge) => `${edge.from}->${edge.to}`),
+    );
+  });
+});

--- a/tests/graph.hierarchy.generate-embed.test.ts
+++ b/tests/graph.hierarchy.generate-embed.test.ts
@@ -1,0 +1,112 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  embedSubgraph,
+  flatten,
+  getEmbeddedGraph,
+  type HierGraph,
+  type SubgraphNode,
+} from "../src/graph/hierarchy.js";
+
+describe("graph hierarchy - embed", () => {
+  it("embeds a subgraph and exposes the flattened structure", () => {
+    const parent: HierGraph = {
+      id: "root",
+      nodes: [
+        { id: "alpha", kind: "task", label: "Alpha", outputs: ["out"] },
+        {
+          id: "beta",
+          kind: "subgraph",
+          ref: "child",
+          params: { ports: { inputs: { entry: "start" }, outputs: { exit: "finish" } } },
+        },
+        { id: "omega", kind: "task", label: "Omega", inputs: ["in"] },
+      ],
+      edges: [
+        { id: "e1", from: { nodeId: "alpha", port: "out" }, to: { nodeId: "beta", port: "entry" } },
+        { id: "e2", from: { nodeId: "beta", port: "exit" }, to: { nodeId: "omega", port: "in" } },
+      ],
+    };
+
+    const child: HierGraph = {
+      id: "child",
+      nodes: [
+        { id: "start", kind: "task", label: "Start", outputs: ["out"] },
+        { id: "finish", kind: "task", label: "Finish", inputs: ["in"] },
+      ],
+      edges: [{ id: "inner", from: { nodeId: "start", port: "out" }, to: { nodeId: "finish", port: "in" } }],
+    };
+
+    const originalSubNode = parent.nodes.find((node) => node.id === "beta") as SubgraphNode;
+    expect(getEmbeddedGraph(originalSubNode)).to.equal(undefined);
+
+    const embedded = embedSubgraph(parent, "beta", child);
+    const subNode = embedded.nodes.find((node) => node.id === "beta") as SubgraphNode;
+    const embeddedGraph = getEmbeddedGraph(subNode);
+    expect(embeddedGraph).to.not.equal(undefined);
+    expect(embeddedGraph?.id).to.equal("child");
+
+    const flattened = flatten(embedded);
+    const nodeIds = flattened.nodes.map((node) => node.id);
+    expect(nodeIds).to.include.members(["alpha", "beta/start", "beta/finish", "omega"]);
+    const edgePairs = flattened.edges.map((edge) => `${edge.from}->${edge.to}`);
+    expect(edgePairs).to.include("alpha->beta/start");
+    expect(edgePairs).to.include("beta/start->beta/finish");
+    expect(edgePairs).to.include("beta/finish->omega");
+  });
+
+  it("rejects inter-level cycles referencing ancestor graphs", () => {
+    const parent: HierGraph = {
+      id: "root",
+      nodes: [
+        {
+          id: "beta",
+          kind: "subgraph",
+          ref: "child",
+          params: { ports: { inputs: { entry: "start" }, outputs: { exit: "start" } } },
+        },
+      ],
+      edges: [],
+    };
+
+    const cyc: HierGraph = {
+      id: "child",
+      nodes: [
+        { id: "start", kind: "task" },
+        {
+          id: "loopy",
+          kind: "subgraph",
+          ref: "root",
+          params: { ports: { inputs: { entry: "start" }, outputs: { exit: "start" } } },
+        },
+      ],
+      edges: [],
+    };
+
+    expect(() => embedSubgraph(parent, "beta", cyc)).to.throw(/cycle/i);
+  });
+
+  it("rejects port mappings targeting missing nodes", () => {
+    const parent: HierGraph = {
+      id: "root",
+      nodes: [
+        {
+          id: "beta",
+          kind: "subgraph",
+          ref: "child",
+          params: { ports: { inputs: { entry: "start" }, outputs: { exit: "missing" } } },
+        },
+      ],
+      edges: [],
+    };
+
+    const child: HierGraph = {
+      id: "child",
+      nodes: [{ id: "start", kind: "task" }],
+      edges: [],
+    };
+
+    expect(() => embedSubgraph(parent, "beta", child)).to.throw(/missing node/);
+  });
+});

--- a/tests/graph.hyper.project.test.ts
+++ b/tests/graph.hyper.project.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  projectHyperGraph,
+  type HyperGraph,
+  HYPER_EDGE_ID_KEY,
+  HYPER_EDGE_PAIR_INDEX_KEY,
+  HYPER_EDGE_SOURCE_CARDINALITY_KEY,
+  HYPER_EDGE_TARGET_CARDINALITY_KEY,
+} from "../src/graph/hypergraph.js";
+
+// The suite validates that hyper-edges expand deterministically and keep enough
+// context to rebuild the original n-ary relation during downstream analyses.
+describe("graph hypergraph - projection", () => {
+  it("projects hyper-edges into binary edges with metadata", () => {
+    const hyperGraph: HyperGraph = {
+      id: "build-pipeline",
+      nodes: [
+        { id: "lint", label: "Lint", attributes: { type: "task" } },
+        { id: "test", label: "Test", attributes: { type: "task" } },
+        { id: "package", label: "Package", attributes: { type: "task" } },
+        { id: "notify", label: "Notify", attributes: { type: "task" } },
+      ],
+      hyperEdges: [
+        {
+          id: "quality",
+          sources: ["lint", "test"],
+          targets: ["package"],
+          label: "quality gate",
+          weight: 2,
+          attributes: { phase: "checks" },
+        },
+        {
+          id: "broadcast",
+          sources: ["package"],
+          targets: ["notify"],
+          attributes: { phase: "delivery" },
+        },
+      ],
+      metadata: { owner: "ci" },
+    };
+
+    const normalised = projectHyperGraph(hyperGraph, { graphVersion: 7 });
+
+    expect(normalised.graphId).to.equal("build-pipeline");
+    expect(normalised.graphVersion).to.equal(7);
+    expect(normalised.metadata.hyper_edge_projection).to.equal(true);
+    expect(normalised.metadata.owner).to.equal("ci");
+
+    const edges = normalised.edges.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      attributes: edge.attributes,
+      label: edge.label,
+      weight: edge.weight,
+    }));
+
+    expect(edges).to.have.lengthOf(3);
+
+    const qualityEdges = edges.filter((edge) => edge.attributes[HYPER_EDGE_ID_KEY] === "quality");
+    expect(qualityEdges).to.have.lengthOf(2);
+    for (const edge of qualityEdges) {
+      expect(edge.label).to.equal("quality gate");
+      expect(edge.weight).to.equal(2);
+      expect(edge.attributes.phase).to.equal("checks");
+      expect(edge.attributes[HYPER_EDGE_SOURCE_CARDINALITY_KEY]).to.equal(2);
+      expect(edge.attributes[HYPER_EDGE_TARGET_CARDINALITY_KEY]).to.equal(1);
+    }
+
+    const pairIndexes = qualityEdges.map((edge) => edge.attributes[HYPER_EDGE_PAIR_INDEX_KEY]);
+    expect(pairIndexes).to.deep.equal([0, 1]);
+
+    const broadcastEdges = edges.filter((edge) => edge.attributes[HYPER_EDGE_ID_KEY] === "broadcast");
+    expect(broadcastEdges).to.have.lengthOf(1);
+    expect(broadcastEdges[0].from).to.equal("package");
+    expect(broadcastEdges[0].to).to.equal("notify");
+    expect(broadcastEdges[0].attributes.phase).to.equal("delivery");
+  });
+
+  it("throws when a hyper-edge references an unknown node", () => {
+    const hyperGraph: HyperGraph = {
+      id: "broken",
+      nodes: [{ id: "known", attributes: {} }],
+      hyperEdges: [{ id: "oops", sources: ["known"], targets: ["missing"] }],
+    };
+
+    expect(() => projectHyperGraph(hyperGraph)).to.throw(
+      "hyper-edge oops references unknown target node missing",
+    );
+  });
+});

--- a/tests/graph.rewrite.rules.test.ts
+++ b/tests/graph.rewrite.rules.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { createInlineSubgraphRule, createRerouteAvoidRule, createSplitParallelRule, applyAll } from "../src/graph/rewrite.js";
+import type { HierGraph } from "../src/graph/hierarchy.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+
+/**
+ * Unit tests covering the behaviour of the standalone rewrite rules. Each test
+ * documents the target transformation so future maintainers can evolve the
+ * heuristics without regressing foundational guarantees (idempotence,
+ * cycle-avoidance, metadata preservation).
+ */
+describe("graph rewrite - rule bank", () => {
+  it("splits parallel edges into dedicated fan-out branches", () => {
+    const graph: NormalisedGraph = {
+      name: "parallel-test",
+      graphId: "parallel-test",
+      graphVersion: 1,
+      nodes: [
+        { id: "start", label: "Start", attributes: { kind: "task" } },
+        { id: "alpha", label: "Alpha", attributes: { kind: "task" } },
+        { id: "omega", label: "Omega", attributes: { kind: "task" } },
+      ],
+      edges: [
+        { from: "start", to: "alpha", label: "spawn", attributes: { parallel: true } },
+        { from: "alpha", to: "omega", label: "finish", attributes: {} },
+      ],
+      metadata: {},
+    };
+
+    const { graph: rewritten, history } = applyAll(graph, [createSplitParallelRule()]);
+    const fanoutNode = rewritten.nodes.find((node) => node.id.startsWith("start∥alpha"));
+    expect(fanoutNode, "a synthetic fan-out node should be inserted").to.not.equal(undefined);
+    const rewrittenEdges = rewritten.edges.map((edge) => `${edge.from}->${edge.to}`);
+    expect(rewrittenEdges).to.include("start->start∥alpha");
+    expect(rewrittenEdges).to.include("start∥alpha->alpha");
+    expect(history.filter((entry) => entry.rule === "split-parallel")[0]?.applied).to.equal(1);
+
+    const secondPass = applyAll(rewritten, [createSplitParallelRule()]);
+    expect(secondPass.graph).to.deep.equal(rewritten);
+    expect(secondPass.history.filter((entry) => entry.rule === "split-parallel")[0]?.applied).to.equal(0);
+  });
+
+  it("inlines embedded subgraphs and rewires edges", () => {
+    const subgraph: HierGraph = {
+      id: "child",
+      nodes: [
+        { id: "entry", kind: "task", label: "Entry" },
+        { id: "exit", kind: "task", label: "Exit" },
+      ],
+      edges: [
+        { id: "inner", from: { nodeId: "entry" }, to: { nodeId: "exit" } },
+      ],
+    };
+
+    const graph: NormalisedGraph = {
+      name: "inline-test",
+      graphId: "inline-test",
+      graphVersion: 1,
+      nodes: [
+        { id: "root", label: "Root", attributes: { kind: "task" } },
+        { id: "sub", label: "Sub", attributes: { kind: "subgraph", ref: "child" } },
+        { id: "sink", label: "Sink", attributes: { kind: "task" } },
+      ],
+      edges: [
+        { from: "root", to: "sub", label: "enter", attributes: {} },
+        { from: "sub", to: "sink", label: "leave", attributes: {} },
+      ],
+      metadata: {
+        "hierarchy:subgraphs": JSON.stringify({
+          child: { graph: subgraph, entryPoints: ["entry"], exitPoints: ["exit"] },
+        }),
+      },
+    };
+
+    const { graph: rewritten } = applyAll(graph, [createInlineSubgraphRule()]);
+    const nodeIds = rewritten.nodes.map((node) => node.id);
+    expect(nodeIds).to.not.include("sub");
+    expect(nodeIds).to.include("sub/entry");
+    expect(nodeIds).to.include("sub/exit");
+    const edgePairs = rewritten.edges.map((edge) => `${edge.from}->${edge.to}`);
+    expect(edgePairs).to.include("root->sub/entry");
+    expect(edgePairs).to.include("sub/exit->sink");
+  });
+
+  it("reroutes around avoided nodes without creating cycles", () => {
+    const graph: NormalisedGraph = {
+      name: "avoid-test",
+      graphId: "avoid-test",
+      graphVersion: 1,
+      nodes: [
+        { id: "start", label: "Start", attributes: { kind: "task" } },
+        { id: "avoid-me", label: "Hotspot", attributes: { kind: "task" } },
+        { id: "mid", label: "Mid", attributes: { kind: "task" } },
+        { id: "end", label: "End", attributes: { kind: "task" } },
+      ],
+      edges: [
+        { from: "start", to: "avoid-me", label: "forward", attributes: {} },
+        { from: "avoid-me", to: "mid", label: "branch-a", attributes: {} },
+        { from: "avoid-me", to: "end", label: "branch-b", attributes: {} },
+        { from: "mid", to: "end", label: "close", attributes: {} },
+      ],
+      metadata: {},
+    };
+
+    const rule = createRerouteAvoidRule({ avoidNodeIds: new Set(["avoid-me"]) });
+    const { graph: rewritten } = applyAll(graph, [rule]);
+    const nodeIds = rewritten.nodes.map((node) => node.id);
+    expect(nodeIds).to.not.include("avoid-me");
+    const edgePairs = new Set(rewritten.edges.map((edge) => `${edge.from}->${edge.to}`));
+    expect(edgePairs.has("start->mid")).to.equal(true);
+    expect(edgePairs.has("start->end")).to.equal(true);
+    expect([...edgePairs].some((pair) => pair.startsWith("avoid-me"))).to.equal(false);
+  });
+});

--- a/tests/graph.tx.concurrency.test.ts
+++ b/tests/graph.tx.concurrency.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  GraphTransactionManager,
+  GraphVersionConflictError,
+} from "../src/graph/tx.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+
+/** Build a graph fixture with the provided identifier and version. */
+function makeGraph(version: number): NormalisedGraph {
+  return {
+    name: "workflow",
+    graphId: "graph-beta",
+    graphVersion: version,
+    nodes: [
+      { id: "alpha", attributes: {}, label: "Alpha" },
+      { id: "omega", attributes: {}, label: "Omega" },
+    ],
+    edges: [
+      { from: "alpha", to: "omega", attributes: {}, label: "flow" },
+    ],
+    metadata: {},
+  };
+}
+
+describe("graph transactions - concurrency control", () => {
+  it("rejects commits issued from stale transactions", () => {
+    const manager = new GraphTransactionManager();
+    const original = makeGraph(1);
+
+    const times = [10_000, 11_000, 12_000, 13_000, 14_000, 15_000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => times[Math.min(cursor++, times.length - 1)];
+
+    try {
+      const first = manager.begin(original);
+      first.workingCopy.metadata.stage = "first";
+      const firstCommit = manager.commit(first.txId, first.workingCopy);
+      expect(firstCommit.version).to.equal(2);
+
+      const second = manager.begin(firstCommit.graph);
+      const third = manager.begin(firstCommit.graph);
+
+      second.workingCopy.metadata.stage = "second";
+      const secondCommit = manager.commit(second.txId, second.workingCopy);
+      expect(secondCommit.version).to.equal(3);
+
+      third.workingCopy.metadata.stage = "third";
+      expect(() => manager.commit(third.txId, third.workingCopy)).to.throw(GraphVersionConflictError);
+      expect(manager.countActiveTransactions()).to.equal(0);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+});

--- a/tests/graph.tx.mutate-integration.test.ts
+++ b/tests/graph.tx.mutate-integration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import {
+  GraphMutateInputSchema,
+  handleGraphGenerate,
+  handleGraphMutate,
+  normaliseGraphPayload,
+  serialiseNormalisedGraph,
+} from "../src/tools/graphTools.js";
+
+/** Utility resetting the global clock after a test altered Date.now. */
+function restoreNow(original: () => number): void {
+  Date.now = original;
+}
+
+describe("graph transactions - mutate integration", () => {
+  it("commits graphs mutated via handleGraphMutate without double increment", () => {
+    const manager = new GraphTransactionManager();
+    const base = handleGraphGenerate({ name: "pipeline", preset: "lint_test_build_package" });
+    const baseline = normaliseGraphPayload(base.graph);
+
+    const times = [10_000, 11_000, 12_000, 13_000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => times[Math.min(cursor++, times.length - 1)];
+
+    try {
+      const begin = manager.begin(baseline);
+      const mutateInput = GraphMutateInputSchema.parse({
+        graph: serialiseNormalisedGraph(begin.workingCopy),
+        operations: [
+          { op: "add_node", node: { id: "qa", label: "QA" } },
+          { op: "add_edge", edge: { from: "build", to: "qa", weight: 1 } },
+        ],
+      });
+
+      const mutated = handleGraphMutate(mutateInput);
+      const committed = manager.commit(begin.txId, normaliseGraphPayload(mutated.graph));
+
+      expect(committed.version).to.equal(begin.baseVersion + 1);
+      expect(committed.graph.graphVersion).to.equal(committed.version);
+      expect(committed.graph.metadata.__txCommittedAt).to.equal(12_000);
+      expect(committed.graph.nodes.some((node) => node.id === "qa")).to.equal(true);
+    } finally {
+      restoreNow(originalNow);
+    }
+  });
+
+  it("keeps the version stable when mutations resolve to a no-op", () => {
+    const manager = new GraphTransactionManager();
+    const base = handleGraphGenerate({ name: "baseline", preset: "lint_test_build_package" });
+    const baseline = normaliseGraphPayload(base.graph);
+
+    const times = [20_000, 21_000, 22_000, 23_000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => times[Math.min(cursor++, times.length - 1)];
+
+    try {
+      const begin = manager.begin(baseline);
+      const mutateInput = GraphMutateInputSchema.parse({
+        graph: serialiseNormalisedGraph(begin.workingCopy),
+        operations: [
+          { op: "add_edge", edge: { from: "lint", to: "package", weight: 1 } },
+          { op: "remove_edge", from: "lint", to: "package" },
+        ],
+      });
+
+      const mutated = handleGraphMutate(mutateInput);
+      const committed = manager.commit(begin.txId, normaliseGraphPayload(mutated.graph));
+
+      expect(committed.version).to.equal(begin.baseVersion);
+      expect(committed.graph.graphVersion).to.equal(begin.baseVersion);
+      expect(committed.graph.edges).to.deep.equal(baseline.edges);
+      expect(committed.graph.metadata.__txCommittedAt ?? null).to.equal(null);
+    } finally {
+      restoreNow(originalNow);
+    }
+  });
+});

--- a/tests/graph.tx.snapshot-rollback.test.ts
+++ b/tests/graph.tx.snapshot-rollback.test.ts
@@ -1,0 +1,80 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+
+/**
+ * Helper producing a lightweight normalised graph used as fixture across the
+ * transaction tests.
+ */
+function makeGraph(version = 1): NormalisedGraph {
+  return {
+    name: "workflow",
+    graphId: "graph-alpha",
+    graphVersion: version,
+    nodes: [
+      { id: "start", attributes: {}, label: "Start" },
+      { id: "finish", attributes: {}, label: "Finish" },
+    ],
+    edges: [
+      { from: "start", to: "finish", attributes: {}, label: "done" },
+    ],
+    metadata: { domain: "test" },
+  };
+}
+
+describe("graph transactions - snapshot & rollback", () => {
+  it("provides an isolated working copy and restores the snapshot on rollback", () => {
+    const manager = new GraphTransactionManager();
+    const baseGraph = makeGraph();
+
+    const nowValues = [1000, 1000, 2000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => nowValues[Math.min(cursor++, nowValues.length - 1)];
+
+    try {
+      const begin = manager.begin(baseGraph);
+      expect(begin.txId).to.have.length.greaterThan(10);
+      expect(begin.workingCopy).to.not.equal(baseGraph);
+      expect(begin.workingCopy).to.deep.equal(baseGraph);
+
+      // Mutate the working copy to confirm it does not affect the stored snapshot.
+      begin.workingCopy.nodes.push({ id: "extra", attributes: {}, label: "Extra" });
+
+      const rolled = manager.rollback(begin.txId);
+      expect(rolled.graphId).to.equal(baseGraph.graphId);
+      expect(rolled.version).to.equal(baseGraph.graphVersion);
+      expect(rolled.snapshot).to.deep.equal(baseGraph);
+      expect(rolled.rolledBackAt).to.equal(2000);
+      expect(manager.countActiveTransactions()).to.equal(0);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it("increments the version and stamps the commit timestamp", () => {
+    const manager = new GraphTransactionManager();
+    const baseGraph = makeGraph();
+
+    const nowValues = [5000, 6000, 7000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => nowValues[Math.min(cursor++, nowValues.length - 1)];
+
+    try {
+      const begin = manager.begin(baseGraph);
+      begin.workingCopy.metadata.note = "mutated";
+
+      const committed = manager.commit(begin.txId, begin.workingCopy);
+      expect(committed.version).to.equal(baseGraph.graphVersion + 1);
+      expect(committed.committedAt).to.equal(7000);
+      expect(committed.graph.metadata.__txCommittedAt).to.equal(7000);
+      expect(committed.graph.graphVersion).to.equal(committed.version);
+      expect(manager.countActiveTransactions()).to.equal(0);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the graph_mutate tool in the graph transaction manager with optimistic concurrency checks and rollback logging
- expose normaliseGraphPayload/serialiseNormalisedGraph helpers so server code can convert descriptors for transactions and update compiled outputs
- extend the transaction manager to accept mutate results, add integration tests, and refresh the agent checklist

## Testing
- npm run build
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dd17e866bc832f984ee8e25207c6df