### PR TITLE
Normalize consensus vote summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,10 +64,10 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
     * `HierGraph = { id, nodes:HierNode[], edges:Edge[] }`
   * [x] API : `embedSubgraph(parent:HierGraph, nodeId, sub:HierGraph)`, `flatten(h:HierGraph): Graph` (expansion contrôlée)
   * [x] **Validation** (no cycles inter-niveaux, ports d’entrée/sortie nommés)
-* [ ] **Modifier** `src/server.ts`
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] Étendre `graph_generate`/`graph_mutate` pour `kind:"subgraph"`
-  * [ ] Nouvelle tool `graph_subgraph_extract` (extrait un sous-plan en fichier JSON, versionné dans run dir)
+  * [x] Étendre `graph_generate`/`graph_mutate` pour `kind:"subgraph"`
+  * [x] Nouvelle tool `graph_subgraph_extract` (extrait un sous-plan en fichier JSON, versionné dans run dir)
 * [x] **Tests**
 
   * [x] `tests/graph.hierarchy.generate-embed.test.ts` (embed + validate)
@@ -106,7 +106,7 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
   * [x] Numéro de **version** incrémental + horodatage
 * [ ] **Intégrer** à *toutes* mutations serveur (wrap `graph_mutate`, `graph_rewrite_apply`)
   * [x] Wrap `graph_mutate`
-  * [ ] Wrap `graph_rewrite_apply`
+  * [x] Wrap `graph_rewrite_apply`
 * [ ] **Tests**
 
   * [x] `tests/graph.tx.snapshot-rollback.test.ts`
@@ -118,47 +118,47 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
 
 ### B1. Interpréteur Behavior Tree (BT)
 
-* [ ] **Créer** `src/executor/bt/types.ts` (Status: `SUCCESS|FAILURE|RUNNING`)
-* [ ] **Créer** `src/executor/bt/nodes.ts`
+* [x] **Créer** `src/executor/bt/types.ts` (Status: `SUCCESS|FAILURE|RUNNING`)
+* [x] **Créer** `src/executor/bt/nodes.ts`
 
-  * [ ] Composites : `Sequence`, `Selector`, `Parallel(policy:all/any)`
-  * [ ] Décorateurs : `Retry(n, backoff)`, `Timeout(ms)`, `Guard(cond)`
-  * [ ] Feuilles : `TaskLeaf(toolName, inputSchema)` → appelle tools existants (child_send, graph_*…)
-* [ ] **Créer** `src/executor/bt/interpreter.ts` (tick async, persistance état nœuds)
-* [ ] **Créer** `src/executor/bt/compiler.ts` (compile `HierGraph` → BT selon patrons)
-* [ ] **Modifier** `src/server.ts`
+  * [x] Composites : `Sequence`, `Selector`, `Parallel(policy:all/any)`
+  * [x] Décorateurs : `Retry(n, backoff)`, `Timeout(ms)`, `Guard(cond)`
+  * [x] Feuilles : `TaskLeaf(toolName, inputSchema)` → appelle tools existants (child_send, graph_*…)
+* [x] **Créer** `src/executor/bt/interpreter.ts` (tick async, persistance état nœuds)
+* [x] **Créer** `src/executor/bt/compiler.ts` (compile `HierGraph` → BT selon patrons)
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] Nouvelle tool `plan_compile_bt` (retourne JSON BT)
-  * [ ] Nouvelle tool `plan_run_bt` (lance interpréteur + expose events)
-* [ ] **Tests**
+  * [x] Nouvelle tool `plan_compile_bt` (retourne JSON BT)
+  * [x] Nouvelle tool `plan_run_bt` (lance interpréteur + expose events)
+* [x] **Tests**
 
-  * [ ] `tests/bt.nodes.sequence-selector.test.ts`
-  * [ ] `tests/bt.decorators.retry-timeout.test.ts` (fake timers)
-  * [ ] `tests/bt.compiler.from-hiergraph.test.ts`
-  * [ ] `tests/bt.run.integration.test.ts` (BT → outils réels mockés)
+  * [x] `tests/bt.nodes.sequence-selector.test.ts`
+  * [x] `tests/bt.decorators.retry-timeout.test.ts` (fake timers)
+  * [x] `tests/bt.compiler.from-hiergraph.test.ts`
+  * [x] `tests/bt.run.integration.test.ts` (BT → outils réels mockés)
 
 ### B2. Scheduler réactif & bus d’événements
 
-* [ ] **Créer** `src/executor/reactiveScheduler.ts`
+* [x] **Créer** `src/executor/reactiveScheduler.ts`
 
-  * [ ] EventBus (Node `EventEmitter`) : `taskReady`, `taskDone`, `blackboardChanged`, `stigmergyChanged`
-  * [ ] Politique : priorité dynamique (âge, criticité, phéromones)
-* [ ] **Relier** BT → Scheduler (ticks pilotés par événements)
-* [ ] **Tests**
+  * [x] EventBus (Node `EventEmitter`) : `taskReady`, `taskDone`, `blackboardChanged`, `stigmergyChanged`
+  * [x] Politique : priorité dynamique (âge, criticité, phéromones)
+* [x] **Relier** BT → Scheduler (ticks pilotés par événements)
+* [x] **Tests**
 
-  * [ ] `tests/executor.scheduler.reactivity.test.ts` (réaction immédiate aux events)
-  * [ ] `tests/executor.scheduler.prio.test.ts` (priorités évolutives)
+  * [x] `tests/executor.scheduler.reactivity.test.ts` (réaction immédiate aux events)
+  * [x] `tests/executor.scheduler.prio.test.ts` (priorités évolutives)
 
 ### B3. Boucle de *ticks* & budgets
 
-* [ ] **Créer** `src/executor/loop.ts`
+* [x] **Créer** `src/executor/loop.ts`
 
-  * [ ] Tick cadencé (`setInterval`) + `pause/resume/stop`
-  * [ ] Budgets : tâches longues → coopérative (yield)
-* [ ] **Tests**
+  * [x] Tick cadencé (`setInterval`) + `pause/resume/stop`
+  * [x] Budgets : tâches longues → coopérative (yield)
+* [x] **Tests**
 
-  * [ ] `tests/executor.loop.timing.test.ts` (fake timers, no drift)
-  * [ ] `tests/executor.loop.budget.test.ts`
+  * [x] `tests/executor.loop.timing.test.ts` (fake timers, no drift)
+  * [x] `tests/executor.loop.budget.test.ts`
 
 ---
 
@@ -166,53 +166,53 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
 
 ### C1. **Blackboard** (tableau noir)
 
-* [ ] **Créer** `src/coord/blackboard.ts`
+* [x] **Créer** `src/coord/blackboard.ts`
 
-  * [ ] KV typé + tags + TTL + watch (events)
-  * [ ] Snapshots (pour débogage, export)
-* [ ] **Modifier** `src/server.ts`
+  * [x] KV typé + tags + TTL + watch (events)
+  * [x] Snapshots (pour débogage, export)
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] Tools : `bb_set`, `bb_get`, `bb_query`, `bb_watch(startFromVersion)` (stream)
-* [ ] **Tests**
+  * [x] Tools : `bb_set`, `bb_get`, `bb_query`, `bb_watch(startFromVersion)` (stream)
+* [x] **Tests**
 
-  * [ ] `tests/coord.blackboard.kv.test.ts`
-  * [ ] `tests/coord.blackboard.watch.test.ts` (dédup + ordre)
+  * [x] `tests/coord.blackboard.kv.test.ts`
+  * [x] `tests/coord.blackboard.watch.test.ts` (dédup + ordre)
 
 ### C2. **Stigmergie** (phéromones)
 
-* [ ] **Créer** `src/coord/stigmergy.ts`
+* [x] **Créer** `src/coord/stigmergy.ts`
 
-  * [ ] API : `mark(nodeId, type, intensity)`, `evaporate(halfLifeMs)`, `fieldSnapshot()`
-* [ ] **Modifier** scheduler pour pondérer sélection de tâches par champ de phéromones
-* [ ] **Server tools** : `stig_mark`, `stig_decay`, `stig_snapshot`
-* [ ] **Tests**
+  * [x] API : `mark(nodeId, type, intensity)`, `evaporate(halfLifeMs)`, `fieldSnapshot()`
+* [x] **Modifier** scheduler pour pondérer sélection de tâches par champ de phéromones
+* [x] **Server tools** : `stig_mark`, `stig_decay`, `stig_snapshot`
+* [x] **Tests**
 
-  * [ ] `tests/coord.stigmergy.field.test.ts` (accumulation/évaporation)
-  * [ ] `tests/coord.stigmergy.scheduler.test.ts` (impact mesurable sur choix)
+  * [x] `tests/coord.stigmergy.field.test.ts` (accumulation/évaporation)
+  * [x] `tests/coord.stigmergy.scheduler.test.ts` (impact mesurable sur choix)
 
 ### C3. **Contract-Net Protocol**
 
-* [ ] **Créer** `src/coord/contractNet.ts`
+* [x] **Créer** `src/coord/contractNet.ts`
 
-  * [ ] Messages : `announce(task)`, `bid(agentId,cost)`, `award(agentId)`
-  * [ ] Stratégie d’attribution (min cost, heuristique)
-* [ ] **Intégrer** à `child_create`/`child_send` (routeur de tâches via CNP si activé)
-* [ ] **Server tool** : `cnp_announce` (expérimental)
-* [ ] **Tests**
+  * [x] Messages : `announce(task)`, `bid(agentId,cost)`, `award(agentId)`
+  * [x] Stratégie d’attribution (min cost, heuristique)
+* [x] **Intégrer** à `child_create`/`child_send` (routeur de tâches via CNP si activé)
+* [x] **Server tool** : `cnp_announce` (expérimental)
+* [x] **Tests**
 
-  * [ ] `tests/coord.contractnet.basic.test.ts`
-  * [ ] `tests/coord.contractnet.tie-breaker.test.ts`
+  * [x] `tests/coord.contractnet.basic.test.ts`
+  * [x] `tests/coord.contractnet.tie-breaker.test.ts`
 
 ### C4. **Consensus / Vote**
 
-* [ ] **Créer** `src/coord/consensus.ts`
+* [x] **Créer** `src/coord/consensus.ts`
 
-  * [ ] `majority`, `quorum(k)`, `weighted(weights)`
-* [ ] **Relier** à `plan_join` / `plan_reduce` (mode `vote`)
-* [ ] **Tests**
+  * [x] `majority`, `quorum(k)`, `weighted(weights)`
+* [x] **Relier** à `plan_join` / `plan_reduce` (mode `vote`)
+* [x] **Tests**
 
-  * [ ] `tests/coord.consensus.modes.test.ts`
-  * [ ] `tests/plan.join.vote.integration.test.ts`
+  * [x] `tests/coord.consensus.modes.test.ts`
+  * [x] `tests/plan.join.vote.integration.test.ts`
 
 ---
 
@@ -220,28 +220,28 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
 
 ### D1. **Autoscaler d’enfants**
 
-* [ ] **Créer** `src/agents/autoscaler.ts`
+* [x] **Créer** `src/agents/autoscaler.ts`
 
-  * [ ] Metrics : backlog scheduler, latence, taux d’échec
-  * [ ] Politique : spawn/retire avec bornes et *cooldown*
-* [ ] **Intégrer** au loop (tick → `reconcile()`)
-* [ ] **Server tool** : `agent_autoscale_set({min,max,cooldown})`
-* [ ] **Tests**
+  * [x] Metrics : backlog scheduler, latence, taux d’échec
+  * [x] Politique : spawn/retire avec bornes et *cooldown*
+* [x] **Intégrer** au loop (tick → `reconcile()`)
+* [x] **Server tool** : `agent_autoscale_set({min,max,cooldown})`
+* [x] **Tests**
 
-  * [ ] `tests/agents.autoscaler.scale-updown.test.ts` (sans fuite de process)
-  * [ ] `tests/agents.autoscaler.cooldown.test.ts`
+  * [x] `tests/agents.autoscaler.scale-updown.test.ts` (sans fuite de process)
+  * [x] `tests/agents.autoscaler.cooldown.test.ts`
 
 ### D2. **Superviseur (Global Workspace)**
 
-* [ ] **Créer** `src/agents/supervisor.ts`
+* [x] **Créer** `src/agents/supervisor.ts`
 
-  * [ ] Détecte stagnation (aucun progrès N ticks), deadlocks, starvation
-  * [ ] Actions : réécriture de plan ciblée, redispatch, alertes
-* [ ] **Relier** à `loopDetector` et `rewrite`
-* [ ] **Tests**
+  * [x] Détecte stagnation (aucun progrès N ticks), deadlocks, starvation
+  * [x] Actions : réécriture de plan ciblée, redispatch, alertes
+* [x] **Relier** à `loopDetector` et `rewrite`
+* [x] **Tests**
 
-  * [ ] `tests/agents.supervisor.stagnation.test.ts`
-  * [ ] `tests/agents.supervisor.unblock.test.ts`
+  * [x] `tests/agents.supervisor.stagnation.test.ts`
+  * [x] `tests/agents.supervisor.unblock.test.ts`
 
 ### D3. **Sécurité/opération**
 
@@ -255,44 +255,44 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
 
 ### E1. **Graphe de connaissances interne (KG)**
 
-* [ ] **Créer** `src/knowledge/knowledgeGraph.ts`
+* [x] **Créer** `src/knowledge/knowledgeGraph.ts`
 
-  * [ ] Triplets `{subject,predicate,object,source?,confidence?}` + index
-  * [ ] Query simple par motif (sans dépendance RDF)
-* [ ] **Relier** `graph_generate` pour *suggérer* patrons de plan depuis KG
-* [ ] **Server tools** : `kg_insert`, `kg_query`, `kg_export`
-* [ ] **Tests**
+  * [x] Triplets `{subject,predicate,object,source?,confidence?}` + index
+  * [x] Query simple par motif (sans dépendance RDF)
+* [x] **Relier** `graph_generate` pour *suggérer* patrons de plan depuis KG
+* [x] **Server tools** : `kg_insert`, `kg_query`, `kg_export`
+* [x] **Tests**
 
-  * [ ] `tests/knowledge.kg.insert-query.test.ts`
-  * [ ] `tests/graph.generate.from-kg.test.ts` (patrons appliqués)
+  * [x] `tests/knowledge.kg.insert-query.test.ts`
+  * [x] `tests/graph.generate.from-kg.test.ts` (patrons appliqués)
 
 ### E2. **Mémoire causale d’événements**
 
-* [ ] **Créer** `src/knowledge/causalMemory.ts`
+* [x] **Créer** `src/knowledge/causalMemory.ts`
 
-  * [ ] Noeuds = événements, arêtes cause→effet (exécution réelle)
-  * [ ] API : `record(event, causes[])`, `explain(outcome)`
-* [ ] **Brancher** exécution (BT & scheduler) pour enregistrer événements
-* [ ] **Server tools** : `causal_export`, `causal_explain(outcomeId)`
-* [ ] **Tests**
+  * [x] Noeuds = événements, arêtes cause→effet (exécution réelle)
+  * [x] API : `record(event, causes[])`, `explain(outcome)`
+* [x] **Brancher** exécution (BT & scheduler) pour enregistrer événements
+* [x] **Server tools** : `causal_export`, `causal_explain(outcomeId)`
+* [x] **Tests**
 
-  * [ ] `tests/knowledge.causal.record-explain.test.ts`
-  * [ ] `tests/causal.integration.bt-scheduler.test.ts`
+  * [x] `tests/knowledge.causal.record-explain.test.ts`
+  * [x] `tests/causal.integration.bt-scheduler.test.ts`
 
 ---
 
 ## F) **Graphe de valeurs** & filtrage des plans
 
-* [ ] **Créer** `src/values/valueGraph.ts`
+* [x] **Créer** `src/values/valueGraph.ts`
 
-  * [ ] Noeuds : valeurs (sécurité, confidentialité, coût, perfo…), arêtes : priorités/contraintes
-  * [ ] `scorePlan(plan):{score,total,violations[]}` + `filter(plan)`
-* [ ] **Intégrer** à `plan_fanout` (pré-filtrer), `plan_reduce` (pondérer)
-* [ ] **Server tools** : `values_set`, `values_score`, `values_filter`
-* [ ] **Tests**
+  * [x] Noeuds : valeurs (sécurité, confidentialité, coût, perfo…), arêtes : priorités/contraintes
+  * [x] `scorePlan(plan):{score,total,violations[]}` + `filter(plan)`
+* [x] **Intégrer** à `plan_fanout` (pré-filtrer), `plan_reduce` (pondérer)
+* [x] **Server tools** : `values_set`, `values_score`, `values_filter`
+* [x] **Tests**
 
-  * [ ] `tests/values.score-filter.test.ts`
-  * [ ] `tests/plan.values-integration.test.ts` (plan rejeté si violation critique)
+  * [x] `tests/values.score-filter.test.ts`
+  * [x] `tests/plan.values-integration.test.ts` (plan rejeté si violation critique)
 
 ---
 
@@ -307,20 +307,21 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
     * `bb_set/get/query/watch`, `stig_mark/decay/snapshot`
     * `cnp_announce`, `consensus_vote`
     * `agent_autoscale_set`
-    * `kg_insert/query/export`, `causal_export/explain`
-    * `values_set/score/filter`
+    * `kg_insert/query/export`, `causal_export/explain` ✅
+    * `values_set/score/filter` ✅
   * [ ] **Zod schemas** pour chaque input, validation stricte
-  * [ ] Codes d’erreurs :
+  * [x] Codes d’erreurs :
 
-    * `E-BT-INVALID`, `E-BT-RUN-TIMEOUT`
-    * `E-BB-NOTFOUND`, `E-STIG-TYPE`
-    * `E-CNP-NO-BIDS`, `E-CONSENSUS-NO-QUORUM`
-    * `E-KG-BAD-TRIPLE`, `E-CAUSAL-NO-PATH`
-    * `E-VALUES-VIOLATION`, `E-REWRITE-CONFLICT`
-* [ ] **Tests**
+    * [x] `E-BT-INVALID`, `E-BT-RUN-TIMEOUT`
+    * [x] `E-BB-NOTFOUND`, `E-STIG-TYPE`
+    * [x] `E-CNP-NO-BIDS`, `E-CONSENSUS-NO-QUORUM`
+    * [x] `E-KG-BAD-TRIPLE`, `E-CAUSAL-NO-PATH`
+    * [x] `E-VALUES-VIOLATION`, `E-REWRITE-CONFLICT`
+* [x] **Tests**
 
-  * [ ] `tests/server.tools.schemas.test.ts` (validation négative)
-  * [ ] `tests/server.tools.errors.test.ts` (codes/msgs cohérents)
+  * [x] `tests/server.tools.schemas.test.ts` (validation négative)
+  * [x] `tests/server.tools.errors.test.ts` (codes/msgs cohérents)
+* [x] Stabiliser `plan_reduce` (vote) pour normaliser les résumés JSON/textuels et éviter les erreurs de quorum.
 
 ---
 
@@ -381,18 +382,18 @@ Contexte inchangé : TypeScript/Node ESM, exécution locale, une instance Codex 
 
 ## K) Feature flags & configuration
 
-* [ ] **Modifier** `src/serverOptions.ts`
+* [x] **Modifier** `src/serverOptions.ts`
 
-  * [ ] Flags (off par défaut) :
+  * [x] Flags (off par défaut) :
 
     * `enableBT`, `enableReactiveScheduler`
     * `enableBlackboard`, `enableStigmergy`, `enableCNP`, `enableConsensus`
     * `enableAutoscaler`, `enableSupervisor`
     * `enableKnowledge`, `enableCausalMemory`, `enableValueGuard`
-  * [ ] Timeouts/délais : `btTickMs`, `stigHalfLifeMs`, `supervisorStallTicks`
-* [ ] **Tests**
+  * [x] Timeouts/délais : `btTickMs`, `stigHalfLifeMs`, `supervisorStallTicks`
+* [x] **Tests**
 
-  * [ ] `tests/options.flags.wiring.test.ts` (activation/désactivation propre)
+  * [x] `tests/options.flags.wiring.test.ts` (activation/désactivation propre)
 
 ---
 
@@ -467,3 +468,99 @@ Si tu veux, je peux ensuite te générer les **squelettes TypeScript** (fichiers
 - ✅ Intégré le gestionnaire transactionnel côté serveur pour `graph_mutate` avec rollback automatique et journalisation dédiée.
 - ✅ Exposé des helpers de normalisation/sérialisation pour relier les outils de graphe aux transactions.
 - ✅ Ajouté le test `tests/graph.tx.mutate-integration.test.ts` couvrant l'interop entre mutations et transactions.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 35)
+- ✅ Étendu les outils `graph_generate` et `graph_mutate` pour détecter/consigner les sous-graphes et signaler les descripteurs manquants.
+- ✅ Implémenté la tool `graph_subgraph_extract` avec export versionné vers le run dir et journalisation MCP.
+- ✅ Créé la bibliothèque `subgraphRegistry` + `subgraphExtract` et le test `graph.subgraph.extract.test.ts` (horodatage déterministe, nettoyage run dir).
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 36)
+- ✅ Implémenté `graph_rewrite_apply` côté outils avec schéma Zod, sélection manuelle/adaptative des règles et invalidation du cache.
+- ✅ Enregistré la tool `graph_rewrite_apply` sur le serveur avec transactions, journalisation détaillée et suivi des sous-graphes.
+- ✅ Ajouté `tests/graph.rewrite.apply.test.ts` et `tests/graph.tx.rewrite-integration.test.ts` couvrant règles manuelles/adaptatives et commits optimistes.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 37)
+- ✅ Créé la suite Behaviour Tree (`types.ts`, `nodes.ts`, `interpreter.ts`, `compiler.ts`) avec commentaires détaillés et nœuds Sequence/Selector/Parallel/Retry/Timeout/Guard/TaskLeaf.
+- ✅ Ajouté les outils MCP `plan_compile_bt` et `plan_run_bt` (Zod, invocations tracées, mode dry-run `noop`) et intégré au serveur.
+- ✅ Couvert l’interpréteur avec `tests/bt.nodes.sequence-selector.test.ts`, `tests/bt.decorators.retry-timeout.test.ts`, `tests/bt.compiler.from-hiergraph.test.ts`, `tests/bt.run.integration.test.ts` (fake timers, flux stub).
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 38)
+- ✅ Implémenté `src/executor/reactiveScheduler.ts` avec bus d’événements typé, calculs de priorité (criticité + phéromones + vieillissement) et traçabilité des ticks.
+- ✅ Relié `plan_run_bt` au scheduler réactif pour piloter l’interpréteur via les signaux et exposer le nombre de ticks exécutés.
+- ✅ Ajouté `tests/executor.scheduler.reactivity.test.ts` et `tests/executor.scheduler.prio.test.ts` (horloge manuelle déterministe) et maintenu `npm test` vert.
+- 🔜 Suivi : brancher les futurs modules (blackboard/stigmergie réels) sur le bus pour enrichir les signaux et ajouter des handlers d’outils BT non-« noop ».
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 39)
+- ✅ Créé `src/executor/loop.ts` avec boucle cadencée, budget coopératif et API `whenIdle`/`stop` documentées pour orchestrer les ticks.
+- ✅ Écrit `tests/executor.loop.timing.test.ts` et `tests/executor.loop.budget.test.ts` avec horloges manuelles pour valider cadence, pause/reprise et yields coopératifs.
+- ✅ Exécuté `npm test` pour garantir que l’ensemble de la suite reste déterministe et verte après l’ajout de la boucle.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 40)
+- ✅ Implémenté `src/coord/blackboard.ts` avec KV typé, TTL déterministe, journal d’événements borné et API de watch synchronisée.
+- ✅ Ajouté les tools `bb_set/get/query/watch` côté serveur (schémas Zod, logs dédiés, intégration au nettoyage TTL) et enregistrés via MCP.
+- ✅ Créé les tests `coord.blackboard.kv.test.ts` & `coord.blackboard.watch.test.ts` (horloge manuelle) pour couvrir stockage, expiration et streaming; suite `npm test` vérifiée.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 41)
+- ✅ Implémenté `src/coord/stigmergy.ts` avec accumulation déterministe, évaporation exponentielle et notifications de changements.
+- ✅ Branché le scheduler réactif sur le champ de phéromones (priorités pondérées, rebalancement live) et exposé les tools `stig_mark/decay/snapshot` via le serveur MCP.
+- ✅ Ajouté les tests `coord.stigmergy.field.test.ts` et `coord.stigmergy.scheduler.test.ts` garantissant évaporation, snapshots et impact sur la sélection des tâches.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 42)
+- ✅ Ajouté le coordinateur Contract-Net (annonce/bid/award avec biais heuristiques et pénalité de charge) et documentation inline.
+- ✅ Relié `child_create`/`child_send` au CNP (sélection automatique, résumé de dispatch, completion auto) et exposé la tool MCP `cnp_announce`.
+- ✅ Créé les tests `coord.contractnet.*` et un scénario `child_send` validant le routage Contract-Net.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 43)
+- ✅ Implémenté `src/coord/consensus.ts` avec calculs `majority`/`quorum`/`weighted`, normalisation des options et schéma Zod réutilisable.
+- ✅ Relié le consensus aux outils `plan_join` et `plan_reduce` (mode vote) avec exposition des résultats dans les traces et les événements.
+- ✅ Ajouté les tests `coord.consensus.modes.test.ts`, `plan.join.vote.integration.test.ts`, mis à jour `plan.fanout-join.test.ts` et `plan.reduce.test.ts`, puis exécuté `npm test`.
+
+### 2025-10-01 – Agent `gpt-5-codex` (iteration 44)
+- ✅ Créé `src/agents/autoscaler.ts` (métriques backlog/latence/taux d’échec, politique bornée avec cooldown) et connecté au loop via l’interface `LoopReconciler`.
+- ✅ Ajouté le tool `agent_autoscale_set` (schéma Zod + logging) et instancié l’autoscaler côté serveur.
+- ✅ Écrit les tests `agents.autoscaler.scale-updown.test.ts`, `agents.autoscaler.cooldown.test.ts`, `executor.loop.reconciler.test.ts` (horloge manuelle) et vérifié `npm test`.
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 45)
+- ✅ Stabilisé `tests/agents.autoscaler.scale-updown.test.ts` en abaissant la moyenne de latence sous le seuil de relaxation et en retirant les traces de debug.
+- ✅ Exécuté la suite complète `npm test` (245 tests) pour confirmer que l’autoscaler et le loop restent verts.
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 46)
+- ✅ Introduit `src/agents/supervisor.ts` (détection stagnation/starvation, gestion des alertes de loop, interface `LoopReconciler`).
+- ✅ Relié le superviseur au serveur (`childTools`, `planTools`, `loopDetector`) avec événements MCP (`supervisor_*`) et callbacks de réécriture/redispatch.
+- ✅ Ajouté `tests/agents.supervisor.stagnation.test.ts` & `tests/agents.supervisor.unblock.test.ts`, ajusté le scheduler pour exposer le backlog post-tick et maintenu `npm test` vert (248 tests).
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 47)
+- ✅ Étendu `serverOptions` avec les toggles de modules et délais (`btTickMs`, `stigHalfLifeMs`, `supervisorStallTicks`) et exposé l’API de configuration runtime.
+- ✅ Mis à jour `tests/serverOptions.parse.test.ts` pour couvrir l’activation/désactivation et les délais personnalisés.
+- ✅ Ajouté `tests/options.flags.wiring.test.ts` pour vérifier l’application dynamique des toggles et timings via le serveur.
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 48)
+- ✅ Créé `src/knowledge/knowledgeGraph.ts` (index triple, motifs wildcard, patterns de plan) et horloge injectée pour tests déterministes.
+- ✅ Relié `handleGraphGenerate` aux patterns KG et ajouté les tools MCP `kg_insert/query/export` avec garde feature flag.
+- ✅ Ajouté `tests/knowledge.kg.insert-query.test.ts` et `tests/graph.generate.from-kg.test.ts` couvrant stockage, requêtes et génération pilotée; suite `npm test` (254) verte.
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 49)
+- ✅ Implémenté `src/knowledge/causalMemory.ts` (enregistrement d'événements, explication ascendante, export complet) et résumé JSON compact.
+- ✅ Branché la mémoire causale sur le scheduler réactif et `plan_run_bt` (événements `bt.tool.*`, `scheduler.tick.*`) avec garde feature flag.
+- ✅ Ajouté les tools MCP `causal_export` / `causal_explain`, journalisation dédiée et tests ciblés (`knowledge.causal.record-explain`, `causal.integration.bt-scheduler`).
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 50)
+- ✅ Créé `src/values/valueGraph.ts` avec scoring, propagation des contraintes et filtrage par seuil configurable.
+- ✅ Intégré le garde-fou dans `plan_fanout` (pré-filtrage + journalisation) et `plan_reduce` (pondération des votes) avec enregistrement des décisions par enfant.
+- ✅ Ajouté les tools `values_set/score/filter`, les tests unitaires `values.score-filter` et l'intégration `plan.values-integration`, plus la signalisation d'erreur `E-VALUES-VIOLATION` côté serveur.
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 51)
+- ✅ Harmonisé les codes d’erreurs MCP (`E-BT-INVALID`, `E-BT-RUN-TIMEOUT`, `E-BB-NOTFOUND`, `E-STIG-TYPE`, `E-CNP-NO-BIDS`, `E-CONSENSUS-NO-QUORUM`, `E-KG-BAD-TRIPLE`, `E-CAUSAL-NO-PATH`, `E-VALUES-VIOLATION`, `E-REWRITE-CONFLICT`) via des classes dédiées et la normalisation serveur.
+- ✅ Étendu `plan_run_bt` avec `timeout_ms`, ajouté le timeout runtime `BehaviorTreeRunTimeoutError` et câblé `plan_reduce` pour lever `ConsensusNoQuorumError` lors des votes infructueux.
+- ✅ Ajouté les suites ciblées `tests/server.tools.schemas.test.ts` et `tests/server.tools.errors.test.ts` vérifiant les validations négatives et la remontée des codes; exécuté les nouvelles suites Mocha.
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 52)
+- ✅ Ajouté la tool `graph_hyper_export` (projection hyper-graphe → graphe standard) avec exports Mermaid/DOT et test dédié.
+- ✅ Enregistré `plan_run_reactive` (ExecutionLoop + scheduler réactif) et couvert le flux avec `tests/plan.run-reactive.test.ts`.
+- ✅ Exposé `consensus_vote` côté coordination, schéma Zod et test majoritaire pour valider le calcul.
+- 🔄 Étendu `tests/server.tools.schemas.test.ts` pour inclure les nouveaux schémas (`graph_hyper_export`, `plan_run_reactive`, `consensus_vote`).
+
+### 2025-10-02 – Agent `gpt-5-codex` (iteration 53)
+- ✅ Normalisé les résumés de vote dans `plan_reduce` pour extraire les champs `vote`/`value` lorsque disponibles et conserver des sources de diagnostic.
+- ✅ Ajouté une assertion sur la valeur gagnante dans `tests/plan.fanout-join.test.ts` et relancé la suite ciblée (verts).
+- 🔜 Audit global des schémas Zod (Section G) toujours ouvert.

--- a/src/agents/autoscaler.ts
+++ b/src/agents/autoscaler.ts
@@ -1,0 +1,344 @@
+import { StructuredLogger } from "../logger.js";
+import type { CreateChildOptions } from "../childSupervisor.js";
+import type { ChildRecordSnapshot } from "../state/childrenIndex.js";
+import type { LoopReconciler, LoopTickContext } from "../executor/loop.js";
+
+/**
+ * Subset of the {@link ChildSupervisor} API consumed by the autoscaler. Tests
+ * provide lightweight doubles while the production server passes the real
+ * supervisor instance which is structurally compatible with this interface.
+ */
+export interface AutoscalerSupervisor {
+  /** Provides lifecycle snapshots for every tracked child. */
+  readonly childrenIndex: {
+    list(): ChildRecordSnapshot[];
+  };
+  /** Spawns a new child runtime with optional creation hints. */
+  createChild(options?: CreateChildOptions): Promise<unknown>;
+  /** Requests a graceful shutdown of the provided child. */
+  cancel(childId: string, options?: { timeoutMs?: number }): Promise<unknown>;
+  /** Optional forceful shutdown fallback if graceful termination fails. */
+  kill?(childId: string, options?: { timeoutMs?: number }): Promise<unknown>;
+}
+
+/** Windowed metrics maintained by the autoscaler to drive its policy. */
+interface AutoscalerMetrics {
+  backlog: number;
+  averageLatencyMs: number | null;
+  failureRate: number;
+}
+
+/** Runtime configuration toggled via the `agent_autoscale_set` tool. */
+export interface AutoscalerConfig {
+  minChildren: number;
+  maxChildren: number;
+  cooldownMs: number;
+}
+
+/** Thresholds steering scale-up and scale-down decisions. */
+export interface AutoscalerThresholds {
+  backlogHigh: number;
+  backlogLow: number;
+  latencyHighMs: number;
+  latencyLowMs: number;
+  failureRateHigh: number;
+  failureRateLow: number;
+}
+
+/** Options accepted when constructing an {@link Autoscaler}. */
+export interface AutoscalerOptions {
+  supervisor: AutoscalerSupervisor;
+  logger?: StructuredLogger;
+  now?: () => number;
+  metricsWindow?: number;
+  config?: Partial<AutoscalerConfig>;
+  thresholds?: Partial<AutoscalerThresholds>;
+  spawnTemplate?: CreateChildOptions;
+  retireGracefulTimeoutMs?: number;
+}
+
+interface TaskSample {
+  durationMs: number;
+  success: boolean;
+}
+
+const DEFAULT_CONFIG: AutoscalerConfig = {
+  minChildren: 0,
+  maxChildren: 4,
+  cooldownMs: 5_000,
+};
+
+const DEFAULT_THRESHOLDS: AutoscalerThresholds = {
+  backlogHigh: 4,
+  backlogLow: 1,
+  latencyHighMs: 1_500,
+  latencyLowMs: 500,
+  failureRateHigh: 0.35,
+  failureRateLow: 0.1,
+};
+
+/**
+ * Autoscaler supervising the population of child runtimes. The component keeps
+ * track of scheduler pressure (backlog), observed task latency and failure
+ * rate. Decisions obey hard bounds (`minChildren`/`maxChildren`) and a cooldown
+ * period to avoid oscillations.
+ */
+export class Autoscaler implements LoopReconciler {
+  private readonly supervisor: AutoscalerSupervisor;
+  private readonly logger?: StructuredLogger;
+  private readonly now: () => number;
+  private readonly metricsWindow: number;
+  private readonly thresholds: AutoscalerThresholds;
+  private readonly spawnTemplate?: CreateChildOptions;
+  private readonly retireGracefulTimeoutMs: number;
+
+  private config: AutoscalerConfig;
+  private backlog = 0;
+  private samples: TaskSample[] = [];
+  private lastScaleAt = Number.NEGATIVE_INFINITY;
+  private scalingInFlight = false;
+
+  constructor(options: AutoscalerOptions) {
+    this.supervisor = options.supervisor;
+    this.logger = options.logger;
+    this.now = options.now ?? Date.now;
+    this.metricsWindow = Math.max(1, options.metricsWindow ?? 20);
+    this.thresholds = { ...DEFAULT_THRESHOLDS, ...(options.thresholds ?? {}) };
+    this.spawnTemplate = options.spawnTemplate;
+    this.retireGracefulTimeoutMs = Math.max(100, options.retireGracefulTimeoutMs ?? 500);
+
+    this.config = { ...DEFAULT_CONFIG, ...(options.config ?? {}) };
+    this.config = this.normaliseConfig(this.config);
+  }
+
+  /** Returns the currently applied configuration. */
+  getConfiguration(): AutoscalerConfig {
+    return { ...this.config };
+  }
+
+  /** Updates the autoscaler configuration while enforcing invariants. */
+  configure(next: Partial<AutoscalerConfig>): AutoscalerConfig {
+    const merged: AutoscalerConfig = {
+      ...this.config,
+      ...next,
+    };
+    this.config = this.normaliseConfig(merged);
+    this.logger?.info("autoscaler_config_updated", {
+      min: this.config.minChildren,
+      max: this.config.maxChildren,
+      cooldown_ms: this.config.cooldownMs,
+    });
+    return this.getConfiguration();
+  }
+
+  /**
+   * Records the number of scheduler ticks currently waiting for execution.
+   * The backlog is evaluated at reconciliation time to detect pressure.
+   */
+  updateBacklog(backlog: number): void {
+    if (!Number.isFinite(backlog)) {
+      return;
+    }
+    this.backlog = Math.max(0, Math.floor(backlog));
+  }
+
+  /**
+   * Adds an execution sample so latency and failure rate can be smoothed
+   * across multiple tasks. Samples follow a sliding window policy.
+   */
+  recordTaskResult(sample: TaskSample): void {
+    if (!Number.isFinite(sample.durationMs) || sample.durationMs < 0) {
+      return;
+    }
+    this.samples.push({ durationMs: sample.durationMs, success: sample.success });
+    if (this.samples.length > this.metricsWindow) {
+      this.samples.shift();
+    }
+  }
+
+  /** Aggregated metrics derived from the current backlog and task samples. */
+  private computeMetrics(): AutoscalerMetrics {
+    if (this.samples.length === 0) {
+      return {
+        backlog: this.backlog,
+        averageLatencyMs: null,
+        failureRate: 0,
+      };
+    }
+
+    const totalDuration = this.samples.reduce((acc, sample) => acc + sample.durationMs, 0);
+    const failures = this.samples.filter((sample) => !sample.success).length;
+    const failureRate = failures / this.samples.length;
+    const averageLatencyMs = totalDuration / this.samples.length;
+
+    return {
+      backlog: this.backlog,
+      averageLatencyMs,
+      failureRate,
+    };
+  }
+
+  /** Implements the {@link LoopReconciler} contract. */
+  async reconcile(context: LoopTickContext): Promise<void> {
+    void context; // The autoscaler currently only needs wall-clock time.
+
+    if (this.scalingInFlight) {
+      return;
+    }
+
+    const now = this.now();
+    const activeChildren = this.countActiveChildren();
+
+    if (activeChildren < this.config.minChildren) {
+      await this.scaleUp("min-bound");
+      return;
+    }
+
+    if (!this.canAct(now)) {
+      return;
+    }
+
+    const metrics = this.computeMetrics();
+
+    if (this.shouldScaleUp(metrics, activeChildren)) {
+      await this.scaleUp("pressure");
+      return;
+    }
+
+    if (this.shouldScaleDown(metrics, activeChildren)) {
+      await this.scaleDown();
+    }
+  }
+
+  /** Reports the number of children considered active for autoscaling. */
+  private countActiveChildren(): number {
+    return this.supervisor.childrenIndex
+      .list()
+      .filter((child) => this.isActive(child))
+      .length;
+  }
+
+  /** Determines whether a child counts toward the active capacity. */
+  private isActive(child: ChildRecordSnapshot): boolean {
+    switch (child.state) {
+      case "starting":
+      case "ready":
+      case "running":
+      case "idle":
+      case "stopping":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private canAct(now: number): boolean {
+    if (this.config.cooldownMs <= 0) {
+      return true;
+    }
+    return now - this.lastScaleAt >= this.config.cooldownMs;
+  }
+
+  private shouldScaleUp(metrics: AutoscalerMetrics, activeChildren: number): boolean {
+    if (activeChildren >= this.config.maxChildren) {
+      return false;
+    }
+
+    const backlogPressure = metrics.backlog >= this.thresholds.backlogHigh;
+    const latencyPressure =
+      metrics.averageLatencyMs !== null && metrics.averageLatencyMs >= this.thresholds.latencyHighMs;
+    const failurePressure = metrics.failureRate >= this.thresholds.failureRateHigh;
+
+    return backlogPressure || latencyPressure || failurePressure;
+  }
+
+  private shouldScaleDown(metrics: AutoscalerMetrics, activeChildren: number): boolean {
+    if (activeChildren <= this.config.minChildren) {
+      return false;
+    }
+
+    const backlogRelaxed = metrics.backlog <= this.thresholds.backlogLow;
+    const latencyRelaxed =
+      metrics.averageLatencyMs === null || metrics.averageLatencyMs <= this.thresholds.latencyLowMs;
+    const failureAcceptable = metrics.failureRate <= this.thresholds.failureRateLow;
+
+    if (!(backlogRelaxed && latencyRelaxed && failureAcceptable)) {
+      return false;
+    }
+
+    return this.pickRetirableChild() !== null;
+  }
+
+  private async scaleUp(reason: string): Promise<void> {
+    this.scalingInFlight = true;
+    try {
+      await this.supervisor.createChild(this.spawnTemplate);
+      this.lastScaleAt = this.now();
+      this.logger?.info("autoscaler_scale_up", {
+        reason,
+        backlog: this.backlog,
+        samples: this.samples.length,
+      });
+    } catch (error) {
+      this.logger?.error("autoscaler_scale_up_failed", {
+        reason,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.scalingInFlight = false;
+    }
+  }
+
+  private async scaleDown(): Promise<void> {
+    const candidate = this.pickRetirableChild();
+    if (!candidate) {
+      return;
+    }
+
+    this.scalingInFlight = true;
+    try {
+      await this.supervisor.cancel(candidate.childId, { timeoutMs: this.retireGracefulTimeoutMs });
+      this.lastScaleAt = this.now();
+      this.logger?.info("autoscaler_scale_down", { child_id: candidate.childId });
+    } catch (error) {
+      this.logger?.warn?.("autoscaler_scale_down_cancel_failed", {
+        child_id: candidate.childId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      if (this.supervisor.kill) {
+        try {
+          await this.supervisor.kill(candidate.childId, { timeoutMs: 200 });
+          this.lastScaleAt = this.now();
+          this.logger?.info("autoscaler_scale_down_forced", { child_id: candidate.childId });
+        } catch (killError) {
+          this.logger?.error("autoscaler_scale_down_failed", {
+            child_id: candidate.childId,
+            message: killError instanceof Error ? killError.message : String(killError),
+          });
+        }
+      }
+    } finally {
+      this.scalingInFlight = false;
+    }
+  }
+
+  private pickRetirableChild(): ChildRecordSnapshot | null {
+    const candidates = this.supervisor.childrenIndex
+      .list()
+      .filter((child) => child.state === "idle" || child.state === "ready");
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    candidates.sort((a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0));
+    return candidates[0] ?? null;
+  }
+
+  private normaliseConfig(config: AutoscalerConfig): AutoscalerConfig {
+    const minChildren = Math.max(0, Math.floor(config.minChildren));
+    const maxChildren = Math.max(minChildren, Math.floor(config.maxChildren));
+    const cooldownMs = Math.max(0, Math.floor(config.cooldownMs));
+    return { minChildren, maxChildren, cooldownMs };
+  }
+}

--- a/src/agents/supervisor.ts
+++ b/src/agents/supervisor.ts
@@ -1,0 +1,296 @@
+import { StructuredLogger } from "../logger.js";
+import type { ChildRecordSnapshot } from "../state/childrenIndex.js";
+import type { LoopReconciler, LoopTickContext } from "../executor/loop.js";
+import type { LoopAlert } from "../guard/loopDetector.js";
+
+/**
+ * Minimal subset of the {@link ChildSupervisor} consumed by the supervisor.
+ * The abstraction keeps the class easy to test by allowing lightweight doubles
+ * to stand in for the real supervisor used by the server.
+ */
+export interface SupervisorChildManager {
+  /** Lifecycle index exposing the current set of children. */
+  readonly childrenIndex: {
+    list(): ChildRecordSnapshot[];
+  };
+  /** Requests a graceful stop for a misbehaving child. */
+  cancel(childId: string, options?: { timeoutMs?: number }): Promise<unknown>;
+  /** Optional forceful stop fallback when graceful shutdown fails. */
+  kill?(childId: string, options?: { timeoutMs?: number }): Promise<unknown>;
+}
+
+/** Incident types surfaced by the supervisor. */
+export type SupervisorIncidentType = "loop" | "stagnation" | "starvation";
+
+/** Severity levels attached to incidents. */
+export type SupervisorIncidentSeverity = "info" | "warning" | "critical";
+
+/** Structured description of an incident emitted by the supervisor. */
+export interface SupervisorIncident {
+  readonly type: SupervisorIncidentType;
+  readonly severity: SupervisorIncidentSeverity;
+  readonly reason: string;
+  readonly context: Record<string, unknown>;
+}
+
+/** Runtime metrics produced by the scheduler after each tick. */
+export interface SupervisorSchedulerSnapshot {
+  /** Tick index reported by the scheduler. */
+  readonly schedulerTick: number;
+  /** Number of pending tasks waiting for execution. */
+  readonly backlog: number;
+  /** Number of tasks that completed successfully during the tick. */
+  readonly completed: number;
+  /** Number of tasks that failed during the tick. */
+  readonly failed: number;
+}
+
+/** Optional callbacks triggered when the supervisor escalates an incident. */
+export interface SupervisorActions {
+  requestRewrite?(incident: SupervisorIncident): Promise<void> | void;
+  requestRedispatch?(incident: SupervisorIncident): Promise<void> | void;
+  emitAlert?(incident: SupervisorIncident): Promise<void> | void;
+}
+
+/** Options accepted when constructing an {@link OrchestratorSupervisor}. */
+export interface OrchestratorSupervisorOptions {
+  childManager: SupervisorChildManager;
+  logger?: StructuredLogger;
+  actions?: SupervisorActions;
+  now?: () => number;
+  stagnationTickThreshold?: number;
+  stagnationBacklogThreshold?: number;
+  starvationIdleMs?: number;
+  starvationRepeatMs?: number;
+}
+
+/**
+ * Supervisor observing scheduler progress, loop alerts and child inactivity to
+ * initiate mitigating actions. The component implements {@link LoopReconciler}
+ * so it can be registered alongside the autoscaler inside the execution loop.
+ */
+export class OrchestratorSupervisor implements LoopReconciler {
+  private readonly childManager: SupervisorChildManager;
+  private readonly logger?: StructuredLogger;
+  private readonly actions: Required<SupervisorActions>;
+  private readonly now: () => number;
+  private readonly stagnationTickThreshold: number;
+  private readonly stagnationBacklogThreshold: number;
+  private readonly starvationIdleMs: number;
+  private readonly starvationRepeatMs: number;
+
+  private lastSchedulerSnapshot: SupervisorSchedulerSnapshot | null = null;
+  private lastBacklog = 0;
+  private lastProgressTick = 0;
+  private lastProgressAt = 0;
+  private lastStagnationAlertTick: number | null = null;
+  private lastStarvationAlertAt: number | null = null;
+  private handledLoopSignatures = new Set<string>();
+
+  constructor(options: OrchestratorSupervisorOptions) {
+    this.childManager = options.childManager;
+    this.logger = options.logger;
+    this.now = options.now ?? Date.now;
+    this.stagnationTickThreshold = Math.max(1, options.stagnationTickThreshold ?? 6);
+    this.stagnationBacklogThreshold = Math.max(1, options.stagnationBacklogThreshold ?? 3);
+    this.starvationIdleMs = Math.max(1_000, options.starvationIdleMs ?? 45_000);
+    this.starvationRepeatMs = Math.max(5_000, options.starvationRepeatMs ?? 60_000);
+
+    const defaultActions: Required<SupervisorActions> = {
+      requestRewrite: async (incident) => {
+        this.logger?.warn("supervisor_request_rewrite", incident.context);
+      },
+      requestRedispatch: async (incident) => {
+        this.logger?.warn("supervisor_request_redispatch", incident.context);
+      },
+      emitAlert: async (incident) => {
+        const level = incident.severity === "critical" ? "error" : "warn";
+        this.logger?.[level === "error" ? "error" : "warn"]("supervisor_incident", incident);
+      },
+    };
+
+    this.actions = {
+      ...defaultActions,
+      ...(options.actions ?? {}),
+    } as Required<SupervisorActions>;
+  }
+
+  /**
+   * Records the latest scheduler snapshot so the supervisor can detect lack of
+   * progress across multiple loop ticks.
+   */
+  recordSchedulerSnapshot(snapshot: SupervisorSchedulerSnapshot): void {
+    const backlog = Math.max(0, Math.floor(snapshot.backlog));
+    const completed = Math.max(0, Math.floor(snapshot.completed));
+    const failed = Math.max(0, Math.floor(snapshot.failed));
+
+    const progress = completed > 0 || failed > 0 || backlog < this.lastBacklog;
+    if (progress) {
+      this.lastProgressTick = snapshot.schedulerTick;
+      this.lastProgressAt = this.now();
+      this.lastStagnationAlertTick = null;
+    }
+
+    this.lastBacklog = backlog;
+    this.lastSchedulerSnapshot = {
+      schedulerTick: snapshot.schedulerTick,
+      backlog,
+      completed,
+      failed,
+    };
+  }
+
+  /**
+   * Processes a loop alert reported by the {@link LoopDetector}. The supervisor
+   * escalates critical loops by cancelling affected children and emits rewrite
+   * requests for persistent warnings.
+   */
+  async recordLoopAlert(alert: LoopAlert | null): Promise<void> {
+    if (!alert) {
+      return;
+    }
+
+    const signatureKey = `${alert.signature}|${alert.childIds.sort().join(",")}`;
+    if (this.handledLoopSignatures.has(signatureKey)) {
+      return;
+    }
+    this.handledLoopSignatures.add(signatureKey);
+
+    const incident: SupervisorIncident = {
+      type: "loop",
+      severity: alert.recommendation === "kill" ? "critical" : "warning",
+      reason: alert.reason,
+      context: {
+        signature: alert.signature,
+        recommendation: alert.recommendation,
+        child_ids: alert.childIds,
+        participants: alert.participants,
+        occurrences: alert.occurrences,
+        first_timestamp: alert.firstTimestamp,
+        last_timestamp: alert.lastTimestamp,
+      },
+    };
+
+    await this.actions.emitAlert(incident);
+
+    if (alert.recommendation === "kill" && alert.childIds.length > 0) {
+      for (const childId of alert.childIds) {
+        await this.terminateChild(childId);
+      }
+    } else {
+      await this.actions.requestRewrite(incident);
+    }
+  }
+
+  /** Implements the {@link LoopReconciler} interface. */
+  async reconcile(context: LoopTickContext): Promise<void> {
+    const snapshot = this.lastSchedulerSnapshot;
+    if (!snapshot) {
+      return;
+    }
+
+    const ticksWithoutProgress = context.tickIndex - this.lastProgressTick;
+    const stagnationActive =
+      snapshot.backlog >= this.stagnationBacklogThreshold &&
+      ticksWithoutProgress >= this.stagnationTickThreshold;
+
+    if (stagnationActive) {
+      if (this.lastStagnationAlertTick === null || context.tickIndex - this.lastStagnationAlertTick >= this.stagnationTickThreshold) {
+        const incident: SupervisorIncident = {
+          type: "stagnation",
+          severity: "warning",
+          reason: "scheduler_backlog_stalled",
+          context: {
+            backlog: snapshot.backlog,
+            ticks_without_progress: ticksWithoutProgress,
+            last_progress_tick: this.lastProgressTick,
+            last_progress_at: this.lastProgressAt,
+          },
+        };
+        this.lastStagnationAlertTick = context.tickIndex;
+        await this.actions.emitAlert(incident);
+        await this.actions.requestRewrite(incident);
+        await this.actions.requestRedispatch(incident);
+      }
+    }
+
+    await this.detectStarvation(context.now());
+  }
+
+  /** Resets previously seen loop signatures (mainly for tests). */
+  resetLoopCache(): void {
+    this.handledLoopSignatures.clear();
+  }
+
+  private async detectStarvation(now: number): Promise<void> {
+    const snapshot = this.lastSchedulerSnapshot;
+    if (!snapshot || snapshot.backlog <= 0) {
+      this.lastStarvationAlertAt = null;
+      return;
+    }
+
+    const idleCandidates = this.childManager
+      .childrenIndex
+      .list()
+      .filter((child) => this.isIdleCandidate(child, now));
+
+    if (idleCandidates.length === 0) {
+      this.lastStarvationAlertAt = null;
+      return;
+    }
+
+    if (this.lastStarvationAlertAt && now - this.lastStarvationAlertAt < this.starvationRepeatMs) {
+      return;
+    }
+
+    const worst = idleCandidates.reduce((current, next) => (next.lastHeartbeatAt ?? next.startedAt) < (current.lastHeartbeatAt ?? current.startedAt) ? next : current);
+
+    const incident: SupervisorIncident = {
+      type: "starvation",
+      severity: "warning",
+      reason: "idle_children_with_backlog",
+      context: {
+        backlog: snapshot.backlog,
+        idle_children: idleCandidates.map((child) => child.childId),
+        idle_duration_ms: now - (worst.lastHeartbeatAt ?? worst.startedAt),
+        threshold_ms: this.starvationIdleMs,
+      },
+    };
+
+    this.lastStarvationAlertAt = now;
+    await this.actions.emitAlert(incident);
+    await this.actions.requestRedispatch(incident);
+  }
+
+  private isIdleCandidate(child: ChildRecordSnapshot, now: number): boolean {
+    const state = child.state;
+    if (!["ready", "idle", "running"].includes(state)) {
+      return false;
+    }
+    const lastActivity = child.lastHeartbeatAt ?? child.startedAt;
+    return now - lastActivity >= this.starvationIdleMs;
+  }
+
+  private async terminateChild(childId: string): Promise<void> {
+    try {
+      await this.childManager.cancel(childId, { timeoutMs: 250 });
+      this.logger?.warn("supervisor_cancelled_child", { child_id: childId });
+    } catch (error) {
+      this.logger?.warn("supervisor_cancel_failed", {
+        child_id: childId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      if (this.childManager.kill) {
+        try {
+          await this.childManager.kill(childId, { timeoutMs: 200 });
+          this.logger?.error("supervisor_killed_child", { child_id: childId });
+        } catch (killError) {
+          this.logger?.error("supervisor_kill_failed", {
+            child_id: childId,
+            message: killError instanceof Error ? killError.message : String(killError),
+          });
+        }
+      }
+    }
+  }
+}

--- a/src/coord/blackboard.ts
+++ b/src/coord/blackboard.ts
@@ -1,0 +1,302 @@
+import { EventEmitter } from "node:events";
+
+/** Options accepted by {@link BlackboardStore}. */
+export interface BlackboardStoreOptions {
+  /** Clock used for TTL computations. Defaults to {@link Date.now}. */
+  now?: () => number;
+  /** Maximum number of events retained in history for watchers. */
+  historyLimit?: number;
+}
+
+/** Additional parameters supported when storing an entry. */
+export interface BlackboardSetOptions {
+  /** Optional set of tags used to group entries semantically. */
+  tags?: string[];
+  /** Time-to-live in milliseconds. When omitted the entry never expires. */
+  ttlMs?: number;
+}
+
+/** Filtering options consumed by {@link BlackboardStore.query}. */
+export interface BlackboardQueryOptions {
+  /** Restrict the result set to the provided keys. */
+  keys?: string[];
+  /** Require all provided tags to be present on the entry. */
+  tags?: string[];
+}
+
+/** Kinds of events emitted by the blackboard when its content changes. */
+export type BlackboardEventKind = "set" | "delete" | "expire";
+
+/** Snapshot exposed to callers describing a stored key/value entry. */
+export interface BlackboardEntrySnapshot {
+  key: string;
+  value: unknown;
+  tags: string[];
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number | null;
+  version: number;
+}
+
+/** Event pushed to the history log and delivered to live watchers. */
+export interface BlackboardEvent {
+  version: number;
+  kind: BlackboardEventKind;
+  key: string;
+  timestamp: number;
+  entry?: BlackboardEntrySnapshot;
+  previous?: BlackboardEntrySnapshot;
+  reason?: "ttl";
+}
+
+/** Options required to start a live watch on the blackboard. */
+export interface BlackboardWatchOptions {
+  /** Version after which events must be delivered (exclusive). */
+  fromVersion?: number;
+  /** Callback invoked for every event greater than {@link fromVersion}. */
+  listener: (event: BlackboardEvent) => void;
+}
+
+interface BlackboardEntryInternal {
+  key: string;
+  value: unknown;
+  tags: string[];
+  createdAt: number;
+  updatedAt: number;
+  expiresAt: number | null;
+  version: number;
+}
+
+/**
+ * In-memory, fully deterministic key/value blackboard. Entries can be tagged,
+ * expire after a configurable TTL and are observable through a bounded history
+ * log that powers live watchers. The store purposely keeps mutations
+ * synchronous so it can be exercised with manual clocks in tests.
+ */
+export class BlackboardStore {
+  private readonly entries = new Map<string, BlackboardEntryInternal>();
+  private readonly events: BlackboardEvent[] = [];
+  private readonly emitter = new EventEmitter();
+  private readonly now: () => number;
+  private readonly historyLimit: number;
+  private version = 0;
+
+  constructor(options: BlackboardStoreOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.historyLimit = Math.max(1, options.historyLimit ?? 500);
+  }
+
+  /** Stores or updates an entry and returns the latest snapshot. */
+  set(key: string, value: unknown, options: BlackboardSetOptions = {}): BlackboardEntrySnapshot {
+    this.evictExpired();
+    const timestamp = this.now();
+    const tags = normaliseTags(options.tags ?? []);
+    const ttl = options.ttlMs !== undefined ? Math.max(1, Math.floor(options.ttlMs)) : null;
+    const expiresAt = ttl !== null ? timestamp + ttl : null;
+    const existing = this.entries.get(key);
+    const previous = existing ? this.cloneEntry(existing) : undefined;
+    const version = ++this.version;
+    const entry: BlackboardEntryInternal = {
+      key,
+      value: structuredClone(value),
+      tags,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+      expiresAt,
+      version,
+    };
+    this.entries.set(key, entry);
+    const snapshot = this.cloneEntry(entry);
+    this.recordEvent({
+      version,
+      kind: "set",
+      key,
+      timestamp,
+      entry: snapshot,
+      previous,
+    });
+    return snapshot;
+  }
+
+  /** Retrieves an entry if it exists and has not expired yet. */
+  get(key: string): BlackboardEntrySnapshot | undefined {
+    this.evictExpired();
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    return this.cloneEntry(entry);
+  }
+
+  /**
+   * Deletes an entry when present. The previous snapshot is emitted so
+   * consumers can reconcile derived state. Returns true when a deletion
+   * occurred.
+   */
+  delete(key: string): boolean {
+    this.evictExpired();
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return false;
+    }
+    const timestamp = this.now();
+    const previous = this.cloneEntry(entry);
+    this.entries.delete(key);
+    const version = ++this.version;
+    this.recordEvent({
+      version,
+      kind: "delete",
+      key,
+      timestamp,
+      previous,
+    });
+    return true;
+  }
+
+  /** Returns non-expired entries filtered by keys and/or tags. */
+  query(options: BlackboardQueryOptions = {}): BlackboardEntrySnapshot[] {
+    this.evictExpired();
+    const keysFilter = options.keys ? new Set(options.keys) : null;
+    const tagsFilter = options.tags ? new Set(options.tags.map((tag) => tag.toLowerCase())) : null;
+    const snapshots: BlackboardEntrySnapshot[] = [];
+    for (const entry of this.entries.values()) {
+      if (keysFilter && !keysFilter.has(entry.key)) {
+        continue;
+      }
+      if (tagsFilter && !containsAllTags(entry.tags, tagsFilter)) {
+        continue;
+      }
+      snapshots.push(this.cloneEntry(entry));
+    }
+    return snapshots.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  /**
+   * Removes expired entries, emitting an `expire` event for each key that
+   * reaches its TTL. The emitted events are also returned to help with
+   * diagnostics.
+   */
+  evictExpired(): BlackboardEvent[] {
+    const timestamp = this.now();
+    const expired: BlackboardEvent[] = [];
+    for (const [key, entry] of [...this.entries.entries()]) {
+      if (entry.expiresAt !== null && entry.expiresAt <= timestamp) {
+        const previous = this.cloneEntry(entry);
+        this.entries.delete(key);
+        const version = ++this.version;
+        const event: BlackboardEvent = {
+          version,
+          kind: "expire",
+          key,
+          timestamp,
+          previous,
+          reason: "ttl",
+        };
+        this.recordEvent(event);
+        expired.push(this.cloneEvent(event));
+      }
+    }
+    return expired;
+  }
+
+  /** Highest version observed so far. */
+  getCurrentVersion(): number {
+    return this.version;
+  }
+
+  /** Returns history events with a version strictly greater than the input. */
+  getEventsSince(fromVersion: number, options: { limit?: number } = {}): BlackboardEvent[] {
+    this.evictExpired();
+    const limit = options.limit ?? Number.POSITIVE_INFINITY;
+    const filtered = this.events.filter((event) => event.version > fromVersion);
+    const sliced = filtered.slice(0, Math.max(0, limit));
+    return sliced.map((event) => this.cloneEvent(event));
+  }
+
+  /**
+   * Registers a listener that receives backlog events and live updates. The
+   * returned function detaches the listener.
+   */
+  watch(options: BlackboardWatchOptions): () => void {
+    const fromVersion = options.fromVersion ?? 0;
+    let lastDelivered = fromVersion;
+    const backlog = this.getEventsSince(fromVersion);
+    for (const event of backlog) {
+      options.listener(this.cloneEvent(event));
+      lastDelivered = Math.max(lastDelivered, event.version);
+    }
+    const handler = (event: BlackboardEvent) => {
+      if (event.version <= lastDelivered) {
+        return;
+      }
+      lastDelivered = event.version;
+      options.listener(this.cloneEvent(event));
+    };
+    this.emitter.on("event", handler);
+    return () => {
+      this.emitter.off("event", handler);
+    };
+  }
+
+  /** Clears the internal event log. Intended for tests only. */
+  clearHistory(): void {
+    this.events.length = 0;
+  }
+
+  private recordEvent(event: BlackboardEvent): void {
+    this.events.push(this.cloneEvent(event));
+    if (this.events.length > this.historyLimit) {
+      this.events.splice(0, this.events.length - this.historyLimit);
+    }
+    this.emitter.emit("event", this.cloneEvent(event));
+  }
+
+  private cloneEntry(entry: BlackboardEntryInternal): BlackboardEntrySnapshot {
+    return {
+      key: entry.key,
+      value: structuredClone(entry.value),
+      tags: [...entry.tags],
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+      expiresAt: entry.expiresAt,
+      version: entry.version,
+    };
+  }
+
+  private cloneEvent(event: BlackboardEvent): BlackboardEvent {
+    return {
+      version: event.version,
+      kind: event.kind,
+      key: event.key,
+      timestamp: event.timestamp,
+      reason: event.reason,
+      entry: event.entry ? { ...event.entry, value: structuredClone(event.entry.value) } : undefined,
+      previous: event.previous
+        ? { ...event.previous, value: structuredClone(event.previous.value) }
+        : undefined,
+    };
+  }
+}
+
+function normaliseTags(tags: string[]): string[] {
+  const unique = new Set<string>();
+  for (const raw of tags) {
+    const tag = raw.trim();
+    if (!tag) continue;
+    unique.add(tag.toLowerCase());
+  }
+  return [...unique].sort();
+}
+
+function containsAllTags(entryTags: string[], required: Set<string>): boolean {
+  if (required.size === 0) {
+    return true;
+  }
+  const haystack = new Set(entryTags.map((tag) => tag.toLowerCase()));
+  for (const tag of required) {
+    if (!haystack.has(tag)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/coord/consensus.ts
+++ b/src/coord/consensus.ts
@@ -1,0 +1,223 @@
+import { z } from "zod";
+
+/**
+ * Single vote cast by an agent. `value` identifies the chosen option while the
+ * voter identifier allows deterministic weighting by caller-provided maps.
+ */
+export interface ConsensusVote {
+  voter: string;
+  value: string;
+}
+
+/**
+ * Result returned by the consensus helpers. `outcome` is `null` whenever no
+ * option satisfied the criteria (for instance when a quorum is not met or a tie
+ * remains unresolved). The tally is exposed to aid auditing in tests.
+ */
+export interface ConsensusDecision {
+  mode: "majority" | "quorum" | "weighted";
+  outcome: string | null;
+  satisfied: boolean;
+  tie: boolean;
+  threshold: number | null;
+  totalWeight: number;
+  tally: Record<string, number>;
+}
+
+/**
+ * Configuration shared by the consensus strategies. Callers can provide static
+ * weights, a preferred outcome when breaking ties and determine how unresolved
+ * ties should be reported.
+ */
+export interface ConsensusOptions {
+  weights?: Record<string, number>;
+  preferValue?: string;
+  tieBreaker?: "null" | "first" | "prefer";
+}
+
+/** Additional parameters accepted by quorum-based strategies. */
+export interface QuorumOptions extends ConsensusOptions {
+  quorum: number;
+}
+
+/** Parameters accepted by the weighted strategy. */
+export interface WeightedOptions extends ConsensusOptions {
+  quorum?: number;
+}
+
+/**
+ * Zod schema shared with the plan tools to validate consensus configuration
+ * payloads exposed through MCP.
+ */
+export const ConsensusConfigSchema = z.object({
+  mode: z.enum(["majority", "quorum", "weighted"]).default("majority"),
+  quorum: z.number().int().positive().optional(),
+  weights: z
+    .record(z.number().nonnegative())
+    .optional()
+    .transform((weights) => weights ?? {}),
+  prefer_value: z.string().optional(),
+  tie_breaker: z.enum(["null", "first", "prefer"]).default("null"),
+});
+
+export type ConsensusConfig = z.infer<typeof ConsensusConfigSchema>;
+
+/**
+ * Internal helper tallying the weighted votes. Weight defaults to `1` when
+ * neither the vote nor the options provide an override.
+ */
+function tallyVotes(
+  votes: ConsensusVote[],
+  options: ConsensusOptions | QuorumOptions | WeightedOptions,
+): { tally: Map<string, number>; totalWeight: number } {
+  const tally = new Map<string, number>();
+  let totalWeight = 0;
+
+  for (const vote of votes) {
+    const candidateWeight = options.weights?.[vote.voter];
+    const weight = typeof candidateWeight === "number" && candidateWeight >= 0
+      ? candidateWeight
+      : 1;
+    const current = tally.get(vote.value) ?? 0;
+    tally.set(vote.value, current + weight);
+    totalWeight += weight;
+  }
+
+  return { tally, totalWeight };
+}
+
+/**
+ * Determines the winning value for a tally and resolves ties according to the
+ * provided strategy. Returning `null` signals that the tie is unresolved.
+ */
+function resolveWinner(
+  votes: ConsensusVote[],
+  tally: Map<string, number>,
+  options: ConsensusOptions,
+): { winner: string | null; tie: boolean } {
+  if (tally.size === 0) {
+    return { winner: null, tie: false };
+  }
+
+  let maxWeight = -Infinity;
+  for (const weight of tally.values()) {
+    if (weight > maxWeight) {
+      maxWeight = weight;
+    }
+  }
+
+  const topValues = Array.from(tally.entries())
+    .filter(([, weight]) => weight === maxWeight)
+    .map(([value]) => value);
+
+  if (topValues.length === 1) {
+    return { winner: topValues[0], tie: false };
+  }
+
+  switch (options.tieBreaker) {
+    case "prefer":
+      if (options.preferValue && topValues.includes(options.preferValue)) {
+        return { winner: options.preferValue, tie: false };
+      }
+      break;
+    case "first":
+      for (const vote of votes) {
+        if (topValues.includes(vote.value)) {
+          return { winner: vote.value, tie: false };
+        }
+      }
+      break;
+    default:
+      break;
+  }
+
+  return { winner: null, tie: true };
+}
+
+/**
+ * Computes a simple majority. The decision is satisfied when the winning option
+ * strictly exceeds half of the total weight.
+ */
+export function majority(
+  votes: ConsensusVote[],
+  options: ConsensusOptions = {},
+): ConsensusDecision {
+  const { tally, totalWeight } = tallyVotes(votes, options);
+  const { winner, tie } = resolveWinner(votes, tally, options);
+  const threshold = totalWeight > 0 ? Math.floor(totalWeight / 2) + 1 : 1;
+  const winningWeight = winner ? tally.get(winner) ?? 0 : 0;
+  const satisfied = winner !== null && winningWeight >= threshold;
+
+  return {
+    mode: "majority",
+    outcome: winner,
+    satisfied,
+    tie,
+    threshold,
+    totalWeight,
+    tally: Object.fromEntries(tally.entries()),
+  };
+}
+
+/**
+ * Computes a quorum decision. The highest weighted option must reach the
+ * provided quorum threshold to be considered satisfied.
+ */
+export function quorum(
+  votes: ConsensusVote[],
+  options: QuorumOptions,
+): ConsensusDecision {
+  const { tally, totalWeight } = tallyVotes(votes, options);
+  const { winner, tie } = resolveWinner(votes, tally, options);
+  const winningWeight = winner ? tally.get(winner) ?? 0 : 0;
+  const satisfied = winner !== null && winningWeight >= options.quorum;
+
+  return {
+    mode: "quorum",
+    outcome: winner,
+    satisfied,
+    tie,
+    threshold: options.quorum,
+    totalWeight,
+    tally: Object.fromEntries(tally.entries()),
+  };
+}
+
+/**
+ * Computes a weighted majority. Callers may optionally enforce a quorum on top
+ * of the weighted vote results.
+ */
+export function weighted(
+  votes: ConsensusVote[],
+  options: WeightedOptions,
+): ConsensusDecision {
+  const base = majority(votes, options);
+  if (typeof options.quorum === "number") {
+    const winningWeight = base.outcome ? base.tally[base.outcome] ?? 0 : 0;
+    return {
+      ...base,
+      mode: "weighted",
+      threshold: options.quorum,
+      satisfied: base.outcome !== null && winningWeight >= options.quorum,
+    };
+  }
+  return { ...base, mode: "weighted" };
+}
+
+/**
+ * Shared helper used by consumers to normalise consensus configuration payloads
+ * prior to calling the deterministic vote calculators.
+ */
+export function normaliseConsensusOptions(
+  config: ConsensusConfig | undefined,
+): ConsensusOptions & { quorum?: number } {
+  if (!config) {
+    return {};
+  }
+  return {
+    weights: config.weights,
+    preferValue: config.prefer_value,
+    tieBreaker: config.tie_breaker,
+    quorum: config.quorum,
+  };
+}

--- a/src/coord/contractNet.ts
+++ b/src/coord/contractNet.ts
@@ -1,0 +1,532 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Error raised when the Contract-Net coordinator cannot award a task because no
+ * bids were submitted. The orchestrator surfaces the code so callers can react
+ * (e.g. retry with relaxed constraints) rather than handling a generic error.
+ */
+export class ContractNetNoBidsError extends Error {
+  public readonly code = "E-CNP-NO-BIDS";
+  public readonly details: { callId: string };
+
+  constructor(callId: string) {
+    super(`contract-net call ${callId} has no bids`);
+    this.name = "ContractNetNoBidsError";
+    this.details = { callId };
+  }
+}
+
+/** Kind of bid stored in the coordinator. */
+type ContractNetBidKind = "manual" | "heuristic";
+
+/** Options controlling how the coordinator behaves. */
+export interface ContractNetCoordinatorOptions {
+  /** Clock used for deterministic timestamps in tests. Defaults to {@link Date.now}. */
+  now?: () => number;
+  /** Additional cost applied per active assignment when evaluating bids. */
+  defaultBusyPenalty?: number;
+}
+
+/** Options accepted when registering an agent inside the coordinator. */
+export interface RegisterAgentOptions {
+  /** Baseline cost announced by the agent. Lower values are preferred. */
+  baseCost?: number;
+  /** Reliability ratio in [0,1]. Lower reliability increases the heuristic cost. */
+  reliability?: number;
+  /** Semantic tags describing the agent capabilities. */
+  tags?: string[];
+  /** Additional metadata associated with the agent profile. */
+  metadata?: Record<string, unknown>;
+}
+
+/** Snapshot describing a registered agent. */
+export interface ContractNetAgentSnapshot {
+  agentId: string;
+  baseCost: number;
+  reliability: number;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  activeAssignments: number;
+  registeredAt: number;
+}
+
+/** Heuristic hints influencing the bid evaluation order. */
+export interface ContractNetHeuristics {
+  /** Agents that should receive a negative bias during selection. */
+  preferAgents?: string[];
+  /** Per-agent bias subtracted from their cost (positive favours the agent). */
+  agentBias?: Record<string, number>;
+  /** Overrides the busy penalty applied during evaluation. */
+  busyPenalty?: number;
+  /** Additional cost removed when an agent is inside {@link preferAgents}. */
+  preferenceBonus?: number;
+}
+
+/** Shape describing the task announced to the contract-net. */
+export interface ContractNetTaskAnnouncement {
+  taskId: string;
+  payload?: unknown;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  deadlineMs?: number | null;
+  heuristics?: ContractNetHeuristics;
+  /** Auto-generate heuristic bids for registered agents when true (default). */
+  autoBid?: boolean;
+}
+
+/** Additional metadata attached to a bid. */
+export interface ContractNetBidOptions {
+  metadata?: Record<string, unknown>;
+}
+
+/** Public snapshot representing a bid recorded in a call. */
+export interface ContractNetBidSnapshot {
+  agentId: string;
+  cost: number;
+  submittedAt: number;
+  metadata: Record<string, unknown>;
+  kind: ContractNetBidKind;
+}
+
+/** Structured snapshot returned by {@link ContractNetCoordinator.announce}. */
+export interface ContractNetCallSnapshot {
+  callId: string;
+  taskId: string;
+  payload: unknown;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  deadlineMs: number | null;
+  heuristics: {
+    preferAgents: string[];
+    agentBias: Record<string, number>;
+    busyPenalty: number;
+    preferenceBonus: number;
+  };
+  status: "open" | "awarded" | "completed";
+  announcedAt: number;
+  awardedAgentId: string | null;
+  awardedAt: number | null;
+  bids: ContractNetBidSnapshot[];
+}
+
+/** Result returned by {@link ContractNetCoordinator.award}. */
+export interface ContractNetAwardDecision {
+  callId: string;
+  agentId: string;
+  /** Cost explicitly proposed by the agent. */
+  cost: number;
+  /** Cost after heuristics (biases, busy penalty) have been applied. */
+  effectiveCost: number;
+  awardedAt: number;
+  bids: ContractNetBidSnapshot[];
+}
+
+interface NormalisedHeuristics {
+  preferAgents: string[];
+  agentBias: Map<string, number>;
+  busyPenalty: number;
+  preferenceBonus: number;
+}
+
+interface AgentProfileInternal {
+  agentId: string;
+  baseCost: number;
+  reliability: number;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  registeredAt: number;
+}
+
+interface BidInternal {
+  agentId: string;
+  cost: number;
+  submittedAt: number;
+  metadata: Record<string, unknown>;
+  kind: ContractNetBidKind;
+}
+
+interface CallInternal {
+  callId: string;
+  taskId: string;
+  payload: unknown;
+  tags: string[];
+  metadata: Record<string, unknown>;
+  deadlineMs: number | null;
+  heuristics: NormalisedHeuristics;
+  status: "open" | "awarded" | "completed";
+  announcedAt: number;
+  awardedBid: BidInternal | null;
+  awardedAt: number | null;
+  bids: Map<string, BidInternal>;
+}
+
+/**
+ * Deterministic implementation of a Contract-Net coordinator. The class keeps
+ * track of registered agents, allows callers to announce new tasks, records
+ * bids (manual or heuristic) and deterministically awards the task to the best
+ * suited agent according to the lowest effective cost.
+ */
+export class ContractNetCoordinator {
+  private readonly agents = new Map<string, AgentProfileInternal>();
+  private readonly activeAssignments = new Map<string, number>();
+  private readonly calls = new Map<string, CallInternal>();
+  private readonly now: () => number;
+  private readonly defaultBusyPenalty: number;
+
+  constructor(options: ContractNetCoordinatorOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.defaultBusyPenalty = normalizeBusyPenalty(options.defaultBusyPenalty);
+  }
+
+  /** Lists the registered agents. */
+  listAgents(): ContractNetAgentSnapshot[] {
+    return Array.from(this.agents.values()).map((agent) => this.snapshotAgent(agent));
+  }
+
+  /** Retrieves a single agent snapshot when present. */
+  getAgent(agentId: string): ContractNetAgentSnapshot | undefined {
+    const agent = this.agents.get(agentId);
+    return agent ? this.snapshotAgent(agent) : undefined;
+  }
+
+  /** Registers (or updates) an agent profile so it can participate in auctions. */
+  registerAgent(agentId: string, options: RegisterAgentOptions = {}): ContractNetAgentSnapshot {
+    const existing = this.agents.get(agentId);
+    const profile: AgentProfileInternal = {
+      agentId,
+      baseCost: normalizeBaseCost(options.baseCost ?? existing?.baseCost ?? 100),
+      reliability: normalizeReliability(options.reliability ?? existing?.reliability ?? 1),
+      tags: normaliseTags(options.tags ?? existing?.tags ?? []),
+      metadata: structuredClone(options.metadata ?? existing?.metadata ?? {}),
+      registeredAt: existing?.registeredAt ?? this.now(),
+    };
+    this.agents.set(agentId, profile);
+    if (!this.activeAssignments.has(agentId)) {
+      this.activeAssignments.set(agentId, existing?.agentId === agentId ? this.activeAssignments.get(agentId) ?? 0 : 0);
+    }
+    return this.snapshotAgent(profile);
+  }
+
+  /** Removes an agent from the coordinator. Active assignments are preserved. */
+  unregisterAgent(agentId: string): boolean {
+    return this.agents.delete(agentId);
+  }
+
+  /** Announces a new task and optionally emits heuristic bids for registered agents. */
+  announce(announcement: ContractNetTaskAnnouncement): ContractNetCallSnapshot {
+    if (!announcement.taskId || announcement.taskId.trim().length === 0) {
+      throw new Error("taskId must not be empty");
+    }
+    const callId = `${announcement.taskId}:${randomUUID()}`;
+    const heuristics = normaliseHeuristics(announcement.heuristics, this.defaultBusyPenalty);
+    const call: CallInternal = {
+      callId,
+      taskId: announcement.taskId,
+      payload: structuredClone(announcement.payload ?? null),
+      tags: normaliseTags(announcement.tags ?? []),
+      metadata: structuredClone(announcement.metadata ?? {}),
+      deadlineMs: normalizeDeadline(announcement.deadlineMs ?? null),
+      heuristics,
+      status: "open",
+      announcedAt: this.now(),
+      awardedBid: null,
+      awardedAt: null,
+      bids: new Map(),
+    };
+    this.calls.set(callId, call);
+
+    if (announcement.autoBid !== false) {
+      for (const agent of this.agents.values()) {
+        const cost = computeHeuristicCost(agent);
+        const metadata = { reason: "auto" } as Record<string, unknown>;
+        this.recordBid(call, agent.agentId, cost, metadata, "heuristic");
+      }
+    }
+
+    return this.snapshotCall(call);
+  }
+
+  /** Returns the snapshot of a call when present. */
+  getCall(callId: string): ContractNetCallSnapshot | undefined {
+    const call = this.calls.get(callId);
+    return call ? this.snapshotCall(call) : undefined;
+  }
+
+  /** Places or updates a bid for an agent. */
+  bid(callId: string, agentId: string, cost: number, options: ContractNetBidOptions = {}): ContractNetCallSnapshot {
+    const call = this.requireCall(callId);
+    if (call.status !== "open") {
+      throw new Error(`call ${callId} is not open for bidding`);
+    }
+    if (!this.agents.has(agentId)) {
+      throw new Error(`agent ${agentId} is not registered`);
+    }
+    this.recordBid(call, agentId, normalizeCost(cost), structuredClone(options.metadata ?? {}), "manual");
+    return this.snapshotCall(call);
+  }
+
+  /**
+   * Awards the provided call to the best candidate. When an agent identifier is
+   * supplied the method validates that the agent submitted a bid and marks the
+   * award accordingly.
+   */
+  award(callId: string, preferredAgentId?: string): ContractNetAwardDecision {
+    const call = this.requireCall(callId);
+    if (call.status === "completed") {
+      if (!call.awardedBid) {
+        throw new Error(`call ${callId} has already been completed without award`);
+      }
+      return this.buildDecision(call, call.awardedBid);
+    }
+
+    if (call.awardedBid) {
+      if (preferredAgentId && call.awardedBid.agentId !== preferredAgentId) {
+        throw new Error(`call ${callId} already awarded to ${call.awardedBid.agentId}`);
+      }
+      return this.buildDecision(call, call.awardedBid);
+    }
+
+    const bid = preferredAgentId
+      ? call.bids.get(preferredAgentId) ?? (() => {
+          throw new Error(`agent ${preferredAgentId} has not submitted a bid for ${callId}`);
+        })()
+      : this.selectBestBid(call);
+
+    call.awardedBid = bid;
+    call.status = "awarded";
+    call.awardedAt = this.now();
+    this.incrementAssignments(bid.agentId);
+    return this.buildDecision(call, bid);
+  }
+
+  /** Marks a previously awarded call as completed, releasing the assignment. */
+  complete(callId: string): ContractNetCallSnapshot {
+    const call = this.requireCall(callId);
+    if (!call.awardedBid) {
+      throw new Error(`call ${callId} has not been awarded yet`);
+    }
+    if (call.status === "completed") {
+      return this.snapshotCall(call);
+    }
+    call.status = "completed";
+    this.decrementAssignments(call.awardedBid.agentId);
+    return this.snapshotCall(call);
+  }
+
+  /** Internal helper that snapshots an agent profile. */
+  private snapshotAgent(agent: AgentProfileInternal): ContractNetAgentSnapshot {
+    return {
+      agentId: agent.agentId,
+      baseCost: agent.baseCost,
+      reliability: agent.reliability,
+      tags: [...agent.tags],
+      metadata: structuredClone(agent.metadata),
+      activeAssignments: this.activeAssignments.get(agent.agentId) ?? 0,
+      registeredAt: agent.registeredAt,
+    };
+  }
+
+  /** Internal helper that snapshots a call state. */
+  private snapshotCall(call: CallInternal): ContractNetCallSnapshot {
+    return {
+      callId: call.callId,
+      taskId: call.taskId,
+      payload: structuredClone(call.payload),
+      tags: [...call.tags],
+      metadata: structuredClone(call.metadata),
+      deadlineMs: call.deadlineMs,
+      heuristics: {
+        preferAgents: [...call.heuristics.preferAgents],
+        agentBias: Object.fromEntries(call.heuristics.agentBias.entries()),
+        busyPenalty: call.heuristics.busyPenalty,
+        preferenceBonus: call.heuristics.preferenceBonus,
+      },
+      status: call.status,
+      announcedAt: call.announcedAt,
+      awardedAgentId: call.awardedBid?.agentId ?? null,
+      awardedAt: call.awardedAt,
+      bids: Array.from(call.bids.values())
+        .sort((a, b) => (a.submittedAt === b.submittedAt ? a.agentId.localeCompare(b.agentId) : a.submittedAt - b.submittedAt))
+        .map((bid) => ({
+          agentId: bid.agentId,
+          cost: bid.cost,
+          submittedAt: bid.submittedAt,
+          metadata: structuredClone(bid.metadata),
+          kind: bid.kind,
+        })),
+    };
+  }
+
+  private requireCall(callId: string): CallInternal {
+    const call = this.calls.get(callId);
+    if (!call) {
+      throw new Error(`call ${callId} does not exist`);
+    }
+    return call;
+  }
+
+  private recordBid(
+    call: CallInternal,
+    agentId: string,
+    cost: number,
+    metadata: Record<string, unknown>,
+    kind: ContractNetBidKind,
+  ): void {
+    const bid: BidInternal = {
+      agentId,
+      cost,
+      submittedAt: this.now(),
+      metadata,
+      kind,
+    };
+    call.bids.set(agentId, bid);
+  }
+
+  private selectBestBid(call: CallInternal): BidInternal {
+    if (call.bids.size === 0) {
+      throw new ContractNetNoBidsError(call.callId);
+    }
+    let winner: BidInternal | null = null;
+    let winnerScore = Number.POSITIVE_INFINITY;
+    for (const bid of call.bids.values()) {
+      const score = this.computeEffectiveCost(call, bid);
+      if (winner === null) {
+        winner = bid;
+        winnerScore = score;
+        continue;
+      }
+      if (score < winnerScore) {
+        winner = bid;
+        winnerScore = score;
+        continue;
+      }
+      if (score === winnerScore && this.breakTie(call, bid, winner)) {
+        winner = bid;
+        winnerScore = score;
+      }
+    }
+    return winner ?? (() => {
+      throw new ContractNetNoBidsError(call.callId);
+    })();
+  }
+
+  private computeEffectiveCost(call: CallInternal, bid: BidInternal): number {
+    const busy = this.activeAssignments.get(bid.agentId) ?? 0;
+    const busyPenalty = call.heuristics.busyPenalty * busy;
+    const preferenceBoost = call.heuristics.preferAgents.includes(bid.agentId)
+      ? call.heuristics.preferenceBonus
+      : 0;
+    const bias = call.heuristics.agentBias.get(bid.agentId) ?? 0;
+    return bid.cost + busyPenalty - preferenceBoost - bias;
+  }
+
+  private breakTie(call: CallInternal, challenger: BidInternal, incumbent: BidInternal): boolean {
+    const incumbentBusy = this.activeAssignments.get(incumbent.agentId) ?? 0;
+    const challengerBusy = this.activeAssignments.get(challenger.agentId) ?? 0;
+    if (challengerBusy < incumbentBusy) {
+      return true;
+    }
+    if (challengerBusy > incumbentBusy) {
+      return false;
+    }
+    if (challenger.submittedAt < incumbent.submittedAt) {
+      return true;
+    }
+    if (challenger.submittedAt > incumbent.submittedAt) {
+      return false;
+    }
+    return challenger.agentId.localeCompare(incumbent.agentId) < 0;
+  }
+
+  private incrementAssignments(agentId: string): void {
+    const current = this.activeAssignments.get(agentId) ?? 0;
+    this.activeAssignments.set(agentId, current + 1);
+  }
+
+  private decrementAssignments(agentId: string): void {
+    const current = this.activeAssignments.get(agentId) ?? 0;
+    this.activeAssignments.set(agentId, Math.max(0, current - 1));
+  }
+
+  private buildDecision(call: CallInternal, bid: BidInternal): ContractNetAwardDecision {
+    return {
+      callId: call.callId,
+      agentId: bid.agentId,
+      cost: bid.cost,
+      effectiveCost: this.computeEffectiveCost(call, bid),
+      awardedAt: call.awardedAt ?? this.now(),
+      bids: this.snapshotCall(call).bids,
+    };
+  }
+}
+
+function normalizeBaseCost(cost: number): number {
+  if (!Number.isFinite(cost) || cost <= 0) {
+    return 100;
+  }
+  return Number(cost);
+}
+
+function normalizeReliability(reliability: number): number {
+  if (!Number.isFinite(reliability) || reliability <= 0) {
+    return 0.5;
+  }
+  return Math.max(0.1, Math.min(1, Number(reliability)));
+}
+
+function normaliseTags(tags: string[]): string[] {
+  return Array.from(new Set(tags.map((tag) => tag.trim().toLowerCase()).filter((tag) => tag.length > 0))).sort();
+}
+
+function normalizeDeadline(deadline: number | null): number | null {
+  if (deadline === null) {
+    return null;
+  }
+  if (!Number.isFinite(deadline) || deadline <= 0) {
+    return null;
+  }
+  return Math.floor(deadline);
+}
+
+function normaliseHeuristics(
+  heuristics: ContractNetHeuristics | undefined,
+  defaultBusyPenalty: number,
+): NormalisedHeuristics {
+  const preferAgents = heuristics?.preferAgents ? [...new Set(heuristics.preferAgents.filter((id) => id.trim().length > 0))] : [];
+  const agentBiasEntries = heuristics?.agentBias
+    ? Object.entries(heuristics.agentBias).filter(([, value]) => Number.isFinite(value))
+    : [];
+  return {
+    preferAgents,
+    agentBias: new Map(agentBiasEntries.map(([id, value]) => [id, Number(value)])),
+    busyPenalty: normalizeBusyPenalty(heuristics?.busyPenalty ?? defaultBusyPenalty),
+    preferenceBonus: normalizePreferenceBonus(heuristics?.preferenceBonus ?? 1),
+  };
+}
+
+function normalizeBusyPenalty(value: number | undefined): number {
+  if (!Number.isFinite(value) || value === undefined) {
+    return 1;
+  }
+  return Math.max(0, Number(value));
+}
+
+function normalizePreferenceBonus(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return Math.max(0, Number(value));
+}
+
+function computeHeuristicCost(agent: AgentProfileInternal): number {
+  const reliability = agent.reliability <= 0 ? 0.1 : agent.reliability;
+  const adjusted = agent.baseCost / reliability;
+  return Number.isFinite(adjusted) && adjusted > 0 ? adjusted : agent.baseCost;
+}
+
+function normalizeCost(cost: number): number {
+  if (!Number.isFinite(cost) || cost < 0) {
+    throw new Error("cost must be a non-negative finite number");
+  }
+  return Number(cost);
+}

--- a/src/coord/stigmergy.ts
+++ b/src/coord/stigmergy.ts
@@ -1,0 +1,239 @@
+import { EventEmitter } from "node:events";
+
+/**
+ * Error emitted when callers provide an invalid pheromone type. The server maps
+ * the code to `E-STIG-TYPE` so MCP clients can correct payloads without having
+ * to inspect log files.
+ */
+export class StigmergyInvalidTypeError extends Error {
+  public readonly code = "E-STIG-TYPE";
+  public readonly details: { type: string };
+
+  constructor(type: string) {
+    super("pheromone type must not be empty");
+    this.name = "StigmergyInvalidTypeError";
+    this.details = { type };
+  }
+}
+
+/** Smallest intensity we keep in the field before considering it evaporated. */
+const EPSILON = 1e-6;
+
+/** Options accepted by the {@link StigmergyField} constructor. */
+export interface StigmergyFieldOptions {
+  /** Custom clock leveraged to keep tests deterministic. Defaults to {@link Date.now}. */
+  now?: () => number;
+}
+
+/** Snapshot representing the intensity of a specific pheromone type on a node. */
+export interface StigmergyPointSnapshot {
+  nodeId: string;
+  type: string;
+  intensity: number;
+  updatedAt: number;
+}
+
+/** Aggregated intensity stored per node after accumulating all pheromone types. */
+export interface StigmergyTotalSnapshot {
+  nodeId: string;
+  intensity: number;
+  updatedAt: number;
+}
+
+/** Payload emitted every time the stigmergic field changes. */
+export interface StigmergyChangeEvent {
+  nodeId: string;
+  type: string;
+  intensity: number;
+  totalIntensity: number;
+  updatedAt: number;
+}
+
+/** Complete snapshot of the field combining per-type and aggregated intensities. */
+export interface StigmergyFieldSnapshot {
+  generatedAt: number;
+  points: StigmergyPointSnapshot[];
+  totals: StigmergyTotalSnapshot[];
+}
+
+interface StigmergyEntry {
+  nodeId: string;
+  type: string;
+  intensity: number;
+  updatedAt: number;
+}
+
+interface NodeTotal {
+  intensity: number;
+  updatedAt: number;
+}
+
+/** Listener signature exposed by {@link StigmergyField.onChange}. */
+export type StigmergyChangeListener = (event: StigmergyChangeEvent) => void;
+
+/**
+ * Deterministic stigmergic field storing pheromone intensities per node and type.
+ * The field accumulates markings, supports exponential evaporation and notifies
+ * observers whenever a value changes so schedulers can react in real time.
+ */
+export class StigmergyField {
+  private readonly entries = new Map<string, StigmergyEntry>();
+  private readonly totals = new Map<string, NodeTotal>();
+  private readonly emitter = new EventEmitter();
+  private readonly now: () => number;
+
+  constructor(options: StigmergyFieldOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Adds pheromone to the field and returns the updated point snapshot. */
+  mark(nodeId: string, type: string, intensity: number): StigmergyPointSnapshot {
+    if (!Number.isFinite(intensity) || intensity <= 0) {
+      throw new Error("intensity must be a positive finite number");
+    }
+    const normalisedType = normaliseType(type);
+    const timestamp = this.now();
+    const key = this.makeKey(nodeId, normalisedType);
+    const existing = this.entries.get(key);
+    const previousIntensity = existing?.intensity ?? 0;
+    const nextIntensity = previousIntensity + intensity;
+    const entry: StigmergyEntry = {
+      nodeId,
+      type: normalisedType,
+      intensity: nextIntensity,
+      updatedAt: timestamp,
+    };
+    this.entries.set(key, entry);
+    const total = this.adjustTotal(nodeId, nextIntensity - previousIntensity, timestamp);
+    const snapshot = this.cloneEntry(entry);
+    this.emitChange({
+      nodeId,
+      type: normalisedType,
+      intensity: snapshot.intensity,
+      totalIntensity: total.intensity,
+      updatedAt: snapshot.updatedAt,
+    });
+    return snapshot;
+  }
+
+  /**
+   * Applies exponential decay to all pheromones using the provided half-life.
+   * Entries whose intensity drops below {@link EPSILON} are evicted from the
+   * field. The method returns the list of points that changed so callers can
+   * propagate updates.
+   */
+  evaporate(halfLifeMs: number): StigmergyChangeEvent[] {
+    if (!Number.isFinite(halfLifeMs) || halfLifeMs <= 0) {
+      throw new Error("halfLifeMs must be a positive finite number");
+    }
+    const timestamp = this.now();
+    const changes: StigmergyChangeEvent[] = [];
+    for (const [key, entry] of [...this.entries.entries()]) {
+      const elapsed = Math.max(0, timestamp - entry.updatedAt);
+      if (elapsed === 0) {
+        // Nothing to decay yet but we still advance the reference timestamp.
+        entry.updatedAt = timestamp;
+        continue;
+      }
+      const decayFactor = Math.pow(0.5, elapsed / halfLifeMs);
+      const decayed = entry.intensity * decayFactor;
+      const nextIntensity = decayed <= EPSILON ? 0 : decayed;
+      const delta = nextIntensity - entry.intensity;
+      if (Math.abs(delta) <= EPSILON) {
+        entry.updatedAt = timestamp;
+        continue;
+      }
+
+      if (nextIntensity <= EPSILON) {
+        this.entries.delete(key);
+      } else {
+        entry.intensity = nextIntensity;
+        entry.updatedAt = timestamp;
+        this.entries.set(key, entry);
+      }
+
+      const total = this.adjustTotal(entry.nodeId, delta, timestamp);
+      const change: StigmergyChangeEvent = {
+        nodeId: entry.nodeId,
+        type: entry.type,
+        intensity: Math.max(0, nextIntensity),
+        totalIntensity: total.intensity,
+        updatedAt: timestamp,
+      };
+      changes.push(change);
+      this.emitChange(change);
+    }
+    return changes;
+  }
+
+  /** Returns the aggregated intensity for a node across every pheromone type. */
+  getNodeIntensity(nodeId: string): StigmergyTotalSnapshot | undefined {
+    const total = this.totals.get(nodeId);
+    if (!total) {
+      return undefined;
+    }
+    return { nodeId, intensity: total.intensity, updatedAt: total.updatedAt };
+  }
+
+  /** Produces a deterministic snapshot of the entire field for diagnostics. */
+  fieldSnapshot(): StigmergyFieldSnapshot {
+    const generatedAt = this.now();
+    const points = [...this.entries.values()]
+      .map((entry) => this.cloneEntry(entry))
+      .sort((a, b) => {
+        if (b.intensity === a.intensity) {
+          return a.nodeId.localeCompare(b.nodeId) || a.type.localeCompare(b.type);
+        }
+        return b.intensity - a.intensity;
+      });
+    const totals = [...this.totals.entries()]
+      .map(([nodeId, total]) => ({ nodeId, intensity: total.intensity, updatedAt: total.updatedAt }))
+      .sort((a, b) => {
+        if (b.intensity === a.intensity) {
+          return a.nodeId.localeCompare(b.nodeId);
+        }
+        return b.intensity - a.intensity;
+      });
+    return { generatedAt, points, totals };
+  }
+
+  /** Registers a listener invoked for every mutation of the field. */
+  onChange(listener: StigmergyChangeListener): () => void {
+    this.emitter.on("change", listener);
+    return () => {
+      this.emitter.off("change", listener);
+    };
+  }
+
+  private emitChange(event: StigmergyChangeEvent): void {
+    this.emitter.emit("change", event);
+  }
+
+  private adjustTotal(nodeId: string, delta: number, timestamp: number): NodeTotal {
+    const current = this.totals.get(nodeId) ?? { intensity: 0, updatedAt: timestamp };
+    const nextIntensity = Math.max(0, current.intensity + delta);
+    if (nextIntensity <= EPSILON) {
+      this.totals.delete(nodeId);
+      return { intensity: 0, updatedAt: timestamp };
+    }
+    const updated: NodeTotal = { intensity: nextIntensity, updatedAt: timestamp };
+    this.totals.set(nodeId, updated);
+    return updated;
+  }
+
+  private cloneEntry(entry: StigmergyEntry): StigmergyPointSnapshot {
+    return { nodeId: entry.nodeId, type: entry.type, intensity: entry.intensity, updatedAt: entry.updatedAt };
+  }
+
+  private makeKey(nodeId: string, type: string): string {
+    return `${nodeId}::${type}`;
+  }
+}
+
+function normaliseType(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    throw new StigmergyInvalidTypeError(raw);
+  }
+  return trimmed.toLowerCase();
+}

--- a/src/executor/bt/compiler.ts
+++ b/src/executor/bt/compiler.ts
@@ -1,0 +1,116 @@
+import { flatten, type HierGraph } from "../../graph/hierarchy.js";
+import type { GraphNodeRecord } from "../../graph/types.js";
+import {
+  type BehaviorNodeDefinition,
+  type CompiledBehaviorTree,
+} from "./types.js";
+
+/** Attribute name storing the tool executed by a Behaviour Tree task. */
+const TOOL_ATTRIBUTE = "bt_tool";
+/** Attribute name storing the runtime variable key bound to the task input. */
+const INPUT_KEY_ATTRIBUTE = "bt_input_key";
+
+/** Extract a string attribute or throw when the value is missing/invalid. */
+function requireStringAttribute(node: GraphNodeRecord, key: string): string {
+  const value = node.attributes[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Node ${node.id} is missing required attribute ${key}`);
+  }
+  return value;
+}
+
+/** Extract an optional string attribute returning undefined when absent. */
+function optionalStringAttribute(node: GraphNodeRecord, key: string): string | undefined {
+  const value = node.attributes[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Attribute ${key} on node ${node.id} must be a non-empty string`);
+  }
+  return value;
+}
+
+/**
+ * Compile a hierarchical graph into a Behaviour Tree composed of sequence nodes
+ * and task leaves. The compiler performs a topological sort of the flattened
+ * graph to preserve dependencies between tasks.
+ */
+export function compileHierGraphToBehaviorTree(graph: HierGraph): CompiledBehaviorTree {
+  const normalised = flatten(graph);
+  const adjacency = new Map<string, Set<string>>();
+  const indegree = new Map<string, number>();
+
+  for (const node of normalised.nodes) {
+    adjacency.set(node.id, new Set());
+    indegree.set(node.id, 0);
+  }
+
+  for (const edge of normalised.edges) {
+    const from = adjacency.get(edge.from);
+    const to = indegree.get(edge.to);
+    if (!from || to === undefined) {
+      throw new Error(`Invalid edge referencing missing nodes: ${edge.from} → ${edge.to}`);
+    }
+    if (!from.has(edge.to)) {
+      from.add(edge.to);
+      indegree.set(edge.to, to + 1);
+    }
+  }
+
+  const ready: string[] = Array.from(indegree.entries())
+    .filter(([, value]) => value === 0)
+    .map(([nodeId]) => nodeId)
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  const ordered: string[] = [];
+
+  while (ready.length > 0) {
+    const current = ready.shift()!;
+    ordered.push(current);
+    for (const neighbour of adjacency.get(current) ?? []) {
+      const remaining = (indegree.get(neighbour) ?? 0) - 1;
+      indegree.set(neighbour, remaining);
+      if (remaining === 0) {
+        ready.push(neighbour);
+      }
+    }
+    ready.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  }
+
+  if (ordered.length !== normalised.nodes.length) {
+    throw new Error(`Hierarchical graph ${graph.id} contains cycles and cannot be compiled`);
+  }
+
+  const nodeById = new Map(normalised.nodes.map((node) => [node.id, node] as const));
+  const tasks: BehaviorNodeDefinition[] = ordered.map((nodeId) => {
+    const node = nodeById.get(nodeId);
+    if (!node) {
+      throw new Error(`Node ${nodeId} disappeared during compilation`);
+    }
+    const tool = requireStringAttribute(node, TOOL_ATTRIBUTE);
+    const inputKey = optionalStringAttribute(node, INPUT_KEY_ATTRIBUTE);
+    return {
+      type: "task",
+      id: node.id,
+      node_id: node.id,
+      tool,
+      input_key: inputKey,
+    } satisfies BehaviorNodeDefinition;
+  });
+
+  let root: BehaviorNodeDefinition;
+  if (tasks.length === 1) {
+    root = tasks[0];
+  } else {
+    root = {
+      type: "sequence",
+      id: `${graph.id}:sequence`,
+      children: tasks,
+    } satisfies BehaviorNodeDefinition;
+  }
+
+  return {
+    id: graph.id,
+    root,
+  };
+}

--- a/src/executor/bt/interpreter.ts
+++ b/src/executor/bt/interpreter.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+import {
+  type BehaviorNode,
+  type BehaviorNodeDefinition,
+  type BehaviorTickResult,
+  type TickRuntime,
+  type ToolInvoker,
+} from "./types.js";
+import {
+  GuardNode,
+  ParallelNode,
+  RetryNode,
+  SelectorNode,
+  SequenceNode,
+  TaskLeaf,
+  TimeoutNode,
+} from "./nodes.js";
+
+/** Options accepted while instantiating Behaviour Tree nodes. */
+export interface BuildBehaviorTreeOptions {
+  /** Optional registry resolving the input schema for each tool. */
+  taskSchemas?: Record<string, z.ZodTypeAny>;
+}
+
+/**
+ * Interpreter responsible for ticking a Behaviour Tree. The class is stateless
+ * besides the tree nodes themselves which maintain their cursor/attempt counts.
+ */
+export class BehaviorTreeInterpreter {
+  constructor(private readonly root: BehaviorNode) {}
+
+  /**
+   * Execute a single tick using the provided runtime. Terminal results reset the
+   * tree automatically so callers can trigger another run without manual cleanup.
+   */
+  async tick(runtime: Partial<TickRuntime> & { invokeTool: ToolInvoker }): Promise<BehaviorTickResult> {
+    const resolvedRuntime: TickRuntime = {
+      invokeTool: runtime.invokeTool,
+      now: runtime.now ?? (() => Date.now()),
+      wait: runtime.wait ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms))),
+      variables: runtime.variables ?? {},
+    };
+    const result = await this.root.tick(resolvedRuntime);
+    if (result.status !== "running") {
+      this.root.reset();
+    }
+    return result;
+  }
+
+  /** Reset the underlying tree to its initial state. */
+  reset(): void {
+    this.root.reset();
+  }
+}
+
+/** Build a concrete Behaviour Tree from its serialised definition. */
+export function buildBehaviorTree(
+  definition: BehaviorNodeDefinition,
+  options: BuildBehaviorTreeOptions = {},
+  idPrefix = "root",
+): BehaviorNode {
+  const { taskSchemas = {} } = options;
+  let autoIndex = 0;
+
+  function nextId(prefix: string, provided?: string): string {
+    if (provided && provided.trim().length > 0) {
+      return provided;
+    }
+    const generated = `${prefix}-${autoIndex}`;
+    autoIndex += 1;
+    return generated;
+  }
+
+  function instantiate(node: BehaviorNodeDefinition, prefix: string): BehaviorNode {
+    switch (node.type) {
+      case "sequence": {
+        const id = nextId(`${prefix}-sequence`, node.id);
+        const children = node.children.map((child, index) => instantiate(child, `${id}-${index}`));
+        return new SequenceNode(id, children);
+      }
+      case "selector": {
+        const id = nextId(`${prefix}-selector`, node.id);
+        const children = node.children.map((child, index) => instantiate(child, `${id}-${index}`));
+        return new SelectorNode(id, children);
+      }
+      case "parallel": {
+        const id = nextId(`${prefix}-parallel`, node.id);
+        const children = node.children.map((child, index) => instantiate(child, `${id}-${index}`));
+        return new ParallelNode(id, node.policy, children);
+      }
+      case "retry": {
+        const id = nextId(`${prefix}-retry`, node.id);
+        const child = instantiate(node.child, `${id}-child`);
+        return new RetryNode(id, node.max_attempts, child, node.backoff_ms);
+      }
+      case "timeout": {
+        const id = nextId(`${prefix}-timeout`, node.id);
+        const child = instantiate(node.child, `${id}-child`);
+        return new TimeoutNode(id, node.timeout_ms, child);
+      }
+      case "guard": {
+        const id = nextId(`${prefix}-guard`, node.id);
+        const child = instantiate(node.child, `${id}-child`);
+        return new GuardNode(id, node.condition_key, node.expected, child);
+      }
+      case "task": {
+        const id = nextId(`${prefix}-task`, node.id ?? node.node_id);
+        const schema = taskSchemas[node.tool];
+        return new TaskLeaf(id, node.tool, { inputKey: node.input_key, schema });
+      }
+      default: {
+        const exhaustive: never = node;
+        throw new Error(`Unsupported node type ${(exhaustive as { type: string }).type}`);
+      }
+    }
+  }
+
+  return instantiate(definition, idPrefix);
+}

--- a/src/executor/bt/nodes.ts
+++ b/src/executor/bt/nodes.ts
@@ -1,0 +1,320 @@
+import { z } from "zod";
+
+import {
+  type BTStatus,
+  type BehaviorNode,
+  type BehaviorTickResult,
+  type TickRuntime,
+} from "./types.js";
+
+/** Utility constant representing a successful tick result. */
+const SUCCESS_RESULT: BehaviorTickResult = { status: "success" };
+
+/** Utility constant representing a failed tick result. */
+const FAILURE_RESULT: BehaviorTickResult = { status: "failure" };
+
+/** Delay helper used by {@link RetryNode} when no runtime wait function is provided. */
+async function defaultDelay(ms: number): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/** Determine whether the provided status represents a terminal outcome. */
+function isTerminal(status: BTStatus): boolean {
+  return status === "success" || status === "failure";
+}
+
+/** Behaviour Tree sequence composite node. */
+export class SequenceNode implements BehaviorNode {
+  private currentIndex = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly children: BehaviorNode[],
+  ) {}
+
+  /**
+   * Execute the sequence: each child must succeed for the composite to succeed.
+   * When a child returns {@link BTStatus."running"} the current index is
+   * preserved so the next tick resumes from the same child.
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    while (this.currentIndex < this.children.length) {
+      const child = this.children[this.currentIndex];
+      const result = await child.tick(runtime);
+      if (result.status === "running") {
+        return result;
+      }
+      if (result.status === "failure") {
+        this.reset();
+        return FAILURE_RESULT;
+      }
+      this.currentIndex += 1;
+    }
+    this.reset();
+    return SUCCESS_RESULT;
+  }
+
+  /** Reset the cursor and child nodes. */
+  reset(): void {
+    this.currentIndex = 0;
+    for (const child of this.children) {
+      child.reset();
+    }
+  }
+}
+
+/** Behaviour Tree selector composite node. */
+export class SelectorNode implements BehaviorNode {
+  private currentIndex = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly children: BehaviorNode[],
+  ) {}
+
+  /**
+   * Execute the selector: the first child to succeed wins. The cursor is stored
+   * while waiting on running children so the selector resumes deterministically.
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    while (this.currentIndex < this.children.length) {
+      const child = this.children[this.currentIndex];
+      const result = await child.tick(runtime);
+      if (result.status === "running") {
+        return result;
+      }
+      if (result.status === "success") {
+        this.reset();
+        return SUCCESS_RESULT;
+      }
+      this.currentIndex += 1;
+    }
+    this.reset();
+    return FAILURE_RESULT;
+  }
+
+  /** Reset the cursor and child nodes. */
+  reset(): void {
+    this.currentIndex = 0;
+    for (const child of this.children) {
+      child.reset();
+    }
+  }
+}
+
+/** Behaviour Tree parallel composite node. */
+export class ParallelNode implements BehaviorNode {
+  private readonly childStates: Map<string, BTStatus> = new Map();
+
+  constructor(
+    public readonly id: string,
+    private readonly policy: "all" | "any",
+    private readonly children: BehaviorNode[],
+  ) {}
+
+  /**
+   * Execute all children concurrently. The policy controls the aggregation of
+   * child statuses:
+   * - `all`: success when every child succeeds, failure as soon as one fails
+   * - `any`: success once one child succeeds, failure when all fail
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const results = await Promise.all(
+      this.children.map(async (child) => {
+        const previous = this.childStates.get(child.id);
+        if (previous && isTerminal(previous)) {
+          return { status: previous } satisfies BehaviorTickResult;
+        }
+        const result = await child.tick(runtime);
+        if (isTerminal(result.status)) {
+          this.childStates.set(child.id, result.status);
+        }
+        return result;
+      }),
+    );
+
+    const statuses = results.map((result) => result.status);
+    const successes = statuses.filter((status) => status === "success").length;
+    const failures = statuses.filter((status) => status === "failure").length;
+    const running = statuses.filter((status) => status === "running").length;
+
+    if (this.policy === "all") {
+      if (failures > 0) {
+        this.reset();
+        return FAILURE_RESULT;
+      }
+      if (running === 0 && successes === this.children.length) {
+        this.reset();
+        return SUCCESS_RESULT;
+      }
+      return { status: "running" };
+    }
+
+    if (successes > 0) {
+      this.reset();
+      return SUCCESS_RESULT;
+    }
+    if (running === 0 && failures === this.children.length) {
+      this.reset();
+      return FAILURE_RESULT;
+    }
+    return { status: "running" };
+  }
+
+  /** Reset cached statuses and child nodes. */
+  reset(): void {
+    this.childStates.clear();
+    for (const child of this.children) {
+      child.reset();
+    }
+  }
+}
+
+/** Behaviour Tree retry decorator node. */
+export class RetryNode implements BehaviorNode {
+  private attempts = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly maxAttempts: number,
+    private readonly child: BehaviorNode,
+    private readonly backoffMs = 0,
+  ) {}
+
+  /**
+   * Retry the child node when it fails, waiting for the configured backoff
+   * between attempts.
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const result = await this.child.tick(runtime);
+    if (result.status === "success") {
+      this.reset();
+      return result;
+    }
+    if (result.status === "running") {
+      return result;
+    }
+
+    this.attempts += 1;
+    if (this.attempts >= this.maxAttempts) {
+      this.reset();
+      return FAILURE_RESULT;
+    }
+
+    this.child.reset();
+    const delayFn = runtime.wait ?? defaultDelay;
+    if (this.backoffMs > 0) {
+      await delayFn(this.backoffMs);
+    }
+    return { status: "running" };
+  }
+
+  /** Reset the attempts counter and the child node. */
+  reset(): void {
+    this.attempts = 0;
+    this.child.reset();
+  }
+}
+
+/** Behaviour Tree timeout decorator node. */
+const TIMEOUT_SENTINEL = Symbol("timeout");
+
+export class TimeoutNode implements BehaviorNode {
+  constructor(
+    public readonly id: string,
+    private readonly timeoutMs: number,
+    private readonly child: BehaviorNode,
+  ) {}
+
+  /**
+   * Wrap the child execution inside a timeout. When the timer elapses first the
+   * decorator fails and resets the child.
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const wait = runtime.wait ?? defaultDelay;
+    const timeoutPromise = wait(this.timeoutMs).then(() => TIMEOUT_SENTINEL);
+    const childPromise = this.child.tick(runtime);
+    const winner = await Promise.race([timeoutPromise, childPromise]);
+    if (winner === TIMEOUT_SENTINEL) {
+      this.child.reset();
+      this.reset();
+      return FAILURE_RESULT;
+    }
+    const result = winner as BehaviorTickResult;
+    if (result.status !== "running") {
+      this.reset();
+    }
+    return result;
+  }
+
+  /** Reset simply proxies to the child to clear its state. */
+  reset(): void {
+    this.child.reset();
+  }
+}
+
+/** Behaviour Tree guard decorator node. */
+export class GuardNode implements BehaviorNode {
+  constructor(
+    public readonly id: string,
+    private readonly conditionKey: string,
+    private readonly expected: unknown,
+    private readonly child: BehaviorNode,
+  ) {}
+
+  /**
+   * Evaluate the guard condition using the runtime variables. When the condition
+   * does not hold the guard short-circuits with a failure and resets the child.
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const actual = runtime.variables[this.conditionKey];
+    const matches = this.expected === undefined ? Boolean(actual) : actual === this.expected;
+    if (!matches) {
+      this.child.reset();
+      return FAILURE_RESULT;
+    }
+    const result = await this.child.tick(runtime);
+    if (result.status !== "running") {
+      this.reset();
+    }
+    return result;
+  }
+
+  /** Reset proxies to the child node. */
+  reset(): void {
+    this.child.reset();
+  }
+}
+
+/** Behaviour Tree task leaf calling an orchestrator tool. */
+export class TaskLeaf implements BehaviorNode {
+  private readonly inputKey?: string;
+  private readonly schema?: z.ZodTypeAny;
+
+  constructor(
+    public readonly id: string,
+    private readonly toolName: string,
+    options: { inputKey?: string; schema?: z.ZodTypeAny } = {},
+  ) {
+    this.inputKey = options.inputKey;
+    this.schema = options.schema;
+  }
+
+  /**
+   * Resolve the task input, validate it and invoke the corresponding tool via
+   * the runtime.
+   */
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const rawInput = this.inputKey ? runtime.variables[this.inputKey] : undefined;
+    const parsedInput = this.schema ? this.schema.parse(rawInput ?? {}) : rawInput ?? {};
+    const output = await runtime.invokeTool(this.toolName, parsedInput);
+    return { status: "success", output };
+  }
+
+  /** Task leaves are stateless, nothing to reset. */
+  reset(): void {
+    // no-op
+  }
+}

--- a/src/executor/bt/types.ts
+++ b/src/executor/bt/types.ts
@@ -1,0 +1,185 @@
+import { z } from "zod";
+
+/**
+ * Status returned by every Behaviour Tree node after a tick.
+ */
+export type BTStatus = "success" | "failure" | "running";
+
+/**
+ * Result returned by a Behaviour Tree node once its {@link BehaviorNode.tick}
+ * method completes.
+ */
+export interface BehaviorTickResult {
+  /** Final status produced by the node. */
+  status: BTStatus;
+  /** Optional value propagated to parents for diagnostics or reducers. */
+  output?: unknown;
+}
+
+/**
+ * Function responsible for invoking a concrete orchestrator tool.
+ */
+export type ToolInvoker = (toolName: string, input: unknown) => Promise<unknown>;
+
+/**
+ * Runtime services injected while ticking a Behaviour Tree. The methods are
+ * intentionally simple so tests can provide deterministic fake implementations.
+ */
+export interface TickRuntime {
+  /** Execute a concrete tool and resolve with its output. */
+  invokeTool: ToolInvoker;
+  /** Retrieve the monotonic clock expressed in milliseconds. */
+  now(): number;
+  /** Await for the provided duration while allowing fake timers in tests. */
+  wait(ms: number): Promise<void>;
+  /** Shared map of variables exposed to guards and task leaves. */
+  variables: Record<string, unknown>;
+}
+
+/**
+ * Base contract implemented by every Behaviour Tree node.
+ */
+export interface BehaviorNode {
+  /** Unique identifier used for tracing/debugging. */
+  readonly id: string;
+  /** Execute one tick and resolve with the resulting status/output. */
+  tick(runtime: TickRuntime): Promise<BehaviorTickResult>;
+  /** Reset any internal state so the node can be executed from scratch. */
+  reset(): void;
+}
+
+/**
+ * Definition of a tree serialisable as JSON. The interpreter converts this
+ * representation into concrete {@link BehaviorNode} instances.
+ */
+export type BehaviorNodeDefinition =
+  | SequenceDefinition
+  | SelectorDefinition
+  | ParallelDefinition
+  | RetryDefinition
+  | TimeoutDefinition
+  | GuardDefinition
+  | TaskDefinition;
+
+/** Definition of a sequence composite node. */
+export interface SequenceDefinition {
+  type: "sequence";
+  id?: string;
+  children: BehaviorNodeDefinition[];
+}
+
+/** Definition of a selector composite node. */
+export interface SelectorDefinition {
+  type: "selector";
+  id?: string;
+  children: BehaviorNodeDefinition[];
+}
+
+/** Definition of a parallel composite node. */
+export interface ParallelDefinition {
+  type: "parallel";
+  id?: string;
+  policy: "all" | "any";
+  children: BehaviorNodeDefinition[];
+}
+
+/** Definition of a retry decorator node. */
+export interface RetryDefinition {
+  type: "retry";
+  id?: string;
+  max_attempts: number;
+  backoff_ms?: number;
+  child: BehaviorNodeDefinition;
+}
+
+/** Definition of a timeout decorator node. */
+export interface TimeoutDefinition {
+  type: "timeout";
+  id?: string;
+  timeout_ms: number;
+  child: BehaviorNodeDefinition;
+}
+
+/** Definition of a guard decorator node. */
+export interface GuardDefinition {
+  type: "guard";
+  id?: string;
+  /** Identifier resolved against {@link TickRuntime.variables}. */
+  condition_key: string;
+  expected?: unknown;
+  child: BehaviorNodeDefinition;
+}
+
+/** Definition of a task leaf node. */
+export interface TaskDefinition {
+  type: "task";
+  id?: string;
+  node_id: string;
+  tool: string;
+  /** Optional key used to resolve the input from {@link TickRuntime.variables}. */
+  input_key?: string;
+}
+
+/** Behaviour Tree persisted on disk or exchanged via the API. */
+export interface CompiledBehaviorTree {
+  id: string;
+  root: BehaviorNodeDefinition;
+}
+
+/** Schema validating a serialised Behaviour Tree definition. */
+export const BehaviorNodeDefinitionSchema: z.ZodType<BehaviorNodeDefinition> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal("sequence"),
+      id: z.string().min(1).optional(),
+      children: z.array(BehaviorNodeDefinitionSchema).min(1),
+    }),
+    z.object({
+      type: z.literal("selector"),
+      id: z.string().min(1).optional(),
+      children: z.array(BehaviorNodeDefinitionSchema).min(1),
+    }),
+    z.object({
+      type: z.literal("parallel"),
+      id: z.string().min(1).optional(),
+      policy: z.enum(["all", "any"]),
+      children: z.array(BehaviorNodeDefinitionSchema).min(1),
+    }),
+    z.object({
+      type: z.literal("retry"),
+      id: z.string().min(1).optional(),
+      max_attempts: z.number().int().min(1),
+      backoff_ms: z.number().int().min(0).optional(),
+      child: BehaviorNodeDefinitionSchema,
+    }),
+    z.object({
+      type: z.literal("timeout"),
+      id: z.string().min(1).optional(),
+      timeout_ms: z.number().int().min(1),
+      child: BehaviorNodeDefinitionSchema,
+    }),
+    z.object({
+      type: z.literal("guard"),
+      id: z.string().min(1).optional(),
+      condition_key: z.string().min(1),
+      expected: z.unknown().optional(),
+      child: BehaviorNodeDefinitionSchema,
+    }),
+    z.object({
+      type: z.literal("task"),
+      id: z.string().min(1).optional(),
+      node_id: z.string().min(1),
+      tool: z.string().min(1),
+      input_key: z.string().min(1).optional(),
+    }),
+  ]),
+);
+
+/** Schema validating an entire compiled Behaviour Tree payload. */
+export const CompiledBehaviorTreeSchema = z.object({
+  id: z.string().min(1),
+  root: BehaviorNodeDefinitionSchema,
+});
+
+export type BehaviorNodeDefinitionInput = z.input<typeof BehaviorNodeDefinitionSchema>;
+export type CompiledBehaviorTreeInput = z.input<typeof CompiledBehaviorTreeSchema>;

--- a/src/executor/loop.ts
+++ b/src/executor/loop.ts
@@ -1,0 +1,334 @@
+import { setTimeout as defaultSetTimeout, clearTimeout as defaultClearTimeout } from "node:timers";
+
+/**
+ * Context made available to every tick executed by the {@link ExecutionLoop}.
+ * The loop supplies helpers so ticks can observe time, react to stop signals
+ * and cooperate with the scheduler when work risks exceeding the allotted
+ * budget.
+ */
+export interface LoopTickContext {
+  /** Timestamp at which the tick started, according to {@link now}. */
+  readonly startedAt: number;
+  /** Monotonic clock provided to the loop (defaults to {@link Date.now}). */
+  readonly now: () => number;
+  /** Progressive number identifying the tick order (0-based). */
+  readonly tickIndex: number;
+  /** Signal aborted when {@link ExecutionLoop.stop} is invoked. */
+  readonly signal: AbortSignal;
+  /** Cooperative budget utilities if a per-tick time budget is configured. */
+  readonly budget?: CooperativeBudget;
+}
+
+/** Options accepted by the {@link ExecutionLoop} constructor. */
+export interface ExecutionLoopOptions {
+  /** Interval between two ticks, in milliseconds. */
+  readonly intervalMs: number;
+  /** Function executed at every tick. */
+  readonly tick: (context: LoopTickContext) => Promise<void> | void;
+  /** Optional reconcilers invoked after each tick (autoscaler, monitors…). */
+  readonly reconcilers?: LoopReconciler[];
+  /** Custom clock used for diagnostics (defaults to {@link Date.now}). */
+  readonly now?: () => number;
+  /** Optional budget (in ms) after which ticks should yield cooperatively. */
+  readonly budgetMs?: number;
+  /** Error hook invoked when a tick throws. */
+  readonly onError?: (error: unknown) => void;
+  /** Injection points easing deterministic tests. */
+  readonly setIntervalFn?: (handler: () => void, interval: number) => NodeJS.Timeout;
+  readonly clearIntervalFn?: (handle: NodeJS.Timeout) => void;
+  readonly scheduleYield?: (resume: () => void) => unknown;
+  readonly cancelYield?: (handle: unknown) => void;
+}
+
+/**
+ * Component observing the execution loop after every tick to reconcile
+ * high-level invariants (autoscaling, supervision, metrics collection…).
+ */
+export interface LoopReconciler {
+  /** Reacts to the completion of a tick. */
+  reconcile(context: LoopTickContext): Promise<void> | void;
+}
+
+/**
+ * Cooperative helper used by long-running ticks to voluntarily yield control
+ * when a time budget is exceeded. The loop provides an instance per tick when
+ * a {@link ExecutionLoopOptions.budgetMs} value is configured.
+ */
+export class CooperativeBudget {
+  private checkpoint: number;
+
+  constructor(
+    private readonly budgetMs: number,
+    private readonly now: () => number,
+    private readonly scheduleYield: (resume: () => void) => unknown,
+    private readonly cancelYield: (handle: unknown) => void,
+    private readonly signal: AbortSignal,
+  ) {
+    this.checkpoint = now();
+  }
+
+  /** Timestamp (via {@link now}) when the budget started tracking. */
+  get startedAt(): number {
+    return this.checkpoint;
+  }
+
+  /** Milliseconds elapsed since the last checkpoint. */
+  get elapsed(): number {
+    return this.now() - this.checkpoint;
+  }
+
+  /** Remaining milliseconds before the budget is exceeded (floored at 0). */
+  get remaining(): number {
+    return Math.max(0, this.budgetMs - this.elapsed);
+  }
+
+  /** Whether the budget has been exhausted (optionally with a margin). */
+  shouldYield(marginMs = 0): boolean {
+    return this.elapsed >= Math.max(0, this.budgetMs - marginMs);
+  }
+
+  /**
+   * Requests an asynchronous yield and resets the checkpoint once resumed.
+   * If the loop stops while waiting, the promise resolves silently.
+   */
+  async yield(): Promise<void> {
+    if (this.signal.aborted) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      let finished = false;
+      let handle: unknown | undefined;
+
+      const finalize = () => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        if (handle != null) {
+          this.cancelYield(handle);
+          handle = undefined;
+        }
+        this.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+
+      const onAbort = () => {
+        finalize();
+      };
+
+      this.signal.addEventListener("abort", onAbort, { once: true });
+      handle = this.scheduleYield(() => {
+        handle = undefined;
+        finalize();
+      });
+    });
+
+    this.checkpoint = this.now();
+  }
+
+  /**
+   * Convenience helper combining {@link shouldYield} and {@link yield}.
+   * Returns `true` when a yield actually occurred.
+   */
+  async yieldIfExceeded(marginMs = 0): Promise<boolean> {
+    if (!this.shouldYield(marginMs)) {
+      return false;
+    }
+    await this.yield();
+    return true;
+  }
+}
+
+/** Possible states of the execution loop. */
+type LoopState = "idle" | "running" | "paused";
+
+/**
+ * Periodic execution loop based on {@link setInterval}. The loop provides
+ * pause/resume semantics, exposes cooperative budgets for long ticks and keeps
+ * track of the executed tick count for diagnostics.
+ */
+export class ExecutionLoop {
+  private readonly intervalMs: number;
+  private readonly tick: (context: LoopTickContext) => Promise<void> | void;
+  private readonly now: () => number;
+  private readonly setIntervalFn: (handler: () => void, interval: number) => NodeJS.Timeout;
+  private readonly clearIntervalFn: (handle: NodeJS.Timeout) => void;
+  private readonly scheduleYield: (resume: () => void) => unknown;
+  private readonly cancelYield: (handle: unknown) => void;
+  private readonly budgetMs?: number;
+  private readonly onError?: (error: unknown) => void;
+  private readonly reconcilers: LoopReconciler[];
+
+  private state: LoopState = "idle";
+  private timer: NodeJS.Timeout | null = null;
+  private abortController: AbortController = new AbortController();
+  private processing = false;
+  private idlePromise: Promise<void> | null = null;
+  private idleResolver: (() => void) | null = null;
+  private tickCountInternal = 0;
+
+  constructor(options: ExecutionLoopOptions) {
+    this.intervalMs = Math.max(0, options.intervalMs);
+    this.tick = options.tick;
+    this.now = options.now ?? Date.now;
+    this.budgetMs = options.budgetMs;
+    this.onError = options.onError;
+    this.setIntervalFn = options.setIntervalFn ?? ((handler, interval) => setInterval(handler, interval));
+    this.clearIntervalFn = options.clearIntervalFn ?? ((handle) => clearInterval(handle));
+    this.scheduleYield = options.scheduleYield ?? ((resume) => defaultSetTimeout(resume, 0));
+    this.cancelYield = options.cancelYield ?? ((handle) => defaultClearTimeout(handle as NodeJS.Timeout));
+    this.reconcilers = options.reconcilers ? [...options.reconcilers] : [];
+  }
+
+  /** Total number of ticks successfully executed so far. */
+  get tickCount(): number {
+    return this.tickCountInternal;
+  }
+
+  /** Whether the loop is currently active (not paused nor idle). */
+  get isRunning(): boolean {
+    return this.state === "running";
+  }
+
+  /** Whether the loop is started but temporarily paused. */
+  get isPaused(): boolean {
+    return this.state === "paused";
+  }
+
+  /** Starts the loop. Throws if already running or paused. */
+  start(): void {
+    if (this.state !== "idle") {
+      throw new Error("ExecutionLoop already started");
+    }
+    this.state = "running";
+    this.abortController = new AbortController();
+    this.timer = this.setIntervalFn(() => {
+      void this.runTick();
+    }, this.intervalMs);
+  }
+
+  /** Pauses the loop. Returns `true` when a state change occurred. */
+  pause(): boolean {
+    if (this.state !== "running") {
+      return false;
+    }
+    if (this.timer) {
+      this.clearIntervalFn(this.timer);
+      this.timer = null;
+    }
+    this.state = "paused";
+    return true;
+  }
+
+  /** Resumes the loop after a pause. Returns `true` if the loop was resumed. */
+  resume(): boolean {
+    if (this.state !== "paused") {
+      return false;
+    }
+    this.state = "running";
+    this.timer = this.setIntervalFn(() => {
+      void this.runTick();
+    }, this.intervalMs);
+    return true;
+  }
+
+  /** Stops the loop and waits for the current tick to complete. */
+  async stop(): Promise<void> {
+    if (this.timer) {
+      this.clearIntervalFn(this.timer);
+      this.timer = null;
+    }
+    if (this.state === "idle" && !this.processing) {
+      return;
+    }
+    this.state = "idle";
+    this.abortController.abort();
+    await this.waitForIdle();
+    this.abortController = new AbortController();
+  }
+
+  /** Resolves once the loop finished processing the current tick. */
+  whenIdle(): Promise<void> {
+    return this.waitForIdle();
+  }
+
+  private waitForIdle(): Promise<void> {
+    if (!this.processing) {
+      return Promise.resolve();
+    }
+    if (!this.idlePromise) {
+      this.idlePromise = new Promise((resolve) => {
+        this.idleResolver = resolve;
+      });
+    }
+    return this.idlePromise;
+  }
+
+  private resolveIdle(): void {
+    if (this.idleResolver) {
+      const resolve = this.idleResolver;
+      this.idleResolver = null;
+      this.idlePromise = null;
+      resolve();
+    }
+  }
+
+  private async runTick(): Promise<void> {
+    if (this.processing || this.state !== "running") {
+      return;
+    }
+    this.processing = true;
+    const tickIndex = this.tickCountInternal;
+    const startedAt = this.now();
+    const budget =
+      this.budgetMs !== undefined
+        ? new CooperativeBudget(
+            this.budgetMs,
+            this.now,
+            this.scheduleYield,
+            this.cancelYield,
+            this.abortController.signal,
+          )
+        : undefined;
+
+    const context: LoopTickContext = {
+      startedAt,
+      now: this.now,
+      tickIndex,
+      signal: this.abortController.signal,
+      budget,
+    };
+
+    try {
+      await this.tick(context);
+      this.tickCountInternal += 1;
+    } catch (error) {
+      if (this.onError) {
+        this.onError(error);
+      } else {
+        queueMicrotask(() => {
+          throw error instanceof Error ? error : new Error(String(error));
+        });
+      }
+    } finally {
+      if (this.reconcilers.length > 0) {
+        for (const reconciler of this.reconcilers) {
+          try {
+            await reconciler.reconcile(context);
+          } catch (error) {
+            if (this.onError) {
+              this.onError(error);
+            } else {
+              queueMicrotask(() => {
+                throw error instanceof Error ? error : new Error(String(error));
+              });
+            }
+          }
+        }
+      }
+      this.processing = false;
+      this.resolveIdle();
+    }
+  }
+}

--- a/src/executor/reactiveScheduler.ts
+++ b/src/executor/reactiveScheduler.ts
@@ -1,0 +1,536 @@
+import { EventEmitter } from "node:events";
+
+import { CausalMemory } from "../knowledge/causalMemory.js";
+import { BehaviorTreeInterpreter } from "./bt/interpreter.js";
+import type {
+  BehaviorTickResult,
+  TickRuntime,
+  ToolInvoker,
+} from "./bt/types.js";
+
+/** Payload emitted when a task node becomes ready to execute. */
+export interface TaskReadyEvent {
+  nodeId: string;
+  criticality?: number;
+  pheromone?: number;
+}
+
+/** Payload emitted once a task finished running. */
+export interface TaskDoneEvent {
+  nodeId: string;
+  success: boolean;
+  duration_ms?: number;
+}
+
+/** Payload emitted when the blackboard mutates. */
+export interface BlackboardChangedEvent {
+  key: string;
+  importance?: number;
+}
+
+/** Payload emitted when the stigmergic field evolves. */
+export interface StigmergyChangedEvent {
+  nodeId: string;
+  intensity: number;
+  type?: string;
+}
+
+/** Mapping of every event name handled by the reactive scheduler. */
+export interface SchedulerEventMap {
+  taskReady: TaskReadyEvent;
+  taskDone: TaskDoneEvent;
+  blackboardChanged: BlackboardChangedEvent;
+  stigmergyChanged: StigmergyChangedEvent;
+}
+
+export type SchedulerEventName = keyof SchedulerEventMap;
+
+/**
+ * Event bus used by the scheduler and external components to exchange signals.
+ * The API mirrors Node's {@link EventEmitter} while providing type inference on
+ * event payloads.
+ */
+export class ReactiveEventBus {
+  private readonly emitter = new EventEmitter();
+
+  on<E extends SchedulerEventName>(event: E, listener: (payload: SchedulerEventMap[E]) => void): this {
+    this.emitter.on(event, listener as (payload: unknown) => void);
+    return this;
+  }
+
+  off<E extends SchedulerEventName>(event: E, listener: (payload: SchedulerEventMap[E]) => void): this {
+    this.emitter.off(event, listener as (payload: unknown) => void);
+    return this;
+  }
+
+  once<E extends SchedulerEventName>(event: E, listener: (payload: SchedulerEventMap[E]) => void): this {
+    this.emitter.once(event, listener as (payload: unknown) => void);
+    return this;
+  }
+
+  emit<E extends SchedulerEventName>(event: E, payload: SchedulerEventMap[E]): boolean {
+    return this.emitter.emit(event, payload);
+  }
+
+  removeAllListeners(): void {
+    this.emitter.removeAllListeners();
+  }
+}
+
+/** Metadata tracked for every scheduled tick waiting in the queue. */
+interface ScheduledTick<E extends SchedulerEventName = SchedulerEventName> {
+  id: number;
+  event: E;
+  payload: SchedulerEventMap[E];
+  enqueuedAt: number;
+  basePriority: number;
+  causalEventId?: string;
+}
+
+/**
+ * Information surfaced after each tick so observers can inspect the scheduler
+ * decisions, mainly for debugging and tests.
+ */
+export interface SchedulerTickTrace<E extends SchedulerEventName = SchedulerEventName> {
+  event: E;
+  payload: SchedulerEventMap[E];
+  priority: number;
+  enqueuedAt: number;
+  startedAt: number;
+  finishedAt: number;
+  result: BehaviorTickResult;
+  pendingAfter: number;
+}
+
+/** Options accepted by the {@link ReactiveScheduler} constructor. */
+export interface ReactiveSchedulerOptions {
+  interpreter: BehaviorTreeInterpreter;
+  runtime: Partial<TickRuntime> & { invokeTool: ToolInvoker };
+  eventBus?: ReactiveEventBus;
+  now?: () => number;
+  ageWeight?: number;
+  basePriorities?: Partial<Record<SchedulerEventName, number>>;
+  onTick?: (trace: SchedulerTickTrace) => void;
+  getPheromoneIntensity?: (nodeId: string) => number;
+  causalMemory?: CausalMemory;
+}
+
+/** Default base priority assigned to each event type. */
+const DEFAULT_BASE_PRIORITIES: Record<SchedulerEventName, number> = {
+  taskReady: 100,
+  taskDone: 70,
+  blackboardChanged: 55,
+  stigmergyChanged: 45,
+};
+
+/**
+ * Reactive scheduler driving the Behaviour Tree interpreter whenever external
+ * events indicate that progress can be made. The scheduler maintains a
+ * priority-based queue that balances intrinsic criticality (event type),
+ * user-provided hints (criticality/intensity) and the time spent waiting.
+ */
+export class ReactiveScheduler {
+  readonly events: ReactiveEventBus;
+
+  private readonly interpreter: BehaviorTreeInterpreter;
+  private readonly runtime: Partial<TickRuntime> & { invokeTool: ToolInvoker };
+  private readonly now: () => number;
+  private readonly ageWeight: number;
+  private readonly basePriorities: Record<SchedulerEventName, number>;
+  private readonly onTick?: (trace: SchedulerTickTrace) => void;
+  private readonly getPheromoneIntensity?: (nodeId: string) => number;
+  private readonly causalMemory?: CausalMemory;
+
+  private readonly queue: ScheduledTick[] = [];
+  private processing = false;
+  private scheduled = false;
+  private stopped = false;
+  private sequence = 0;
+  private tickCountInternal = 0;
+  private lastResult: BehaviorTickResult = { status: "running" };
+  private settleResolvers: Array<(result: BehaviorTickResult) => void> = [];
+  private lastTickResultEventId: string | null = null;
+  private currentTickEventId: string | null = null;
+
+  private readonly taskReadyHandler = (payload: TaskReadyEvent) => {
+    this.enqueue("taskReady", payload);
+  };
+  private readonly taskDoneHandler = (payload: TaskDoneEvent) => {
+    this.enqueue("taskDone", payload);
+  };
+  private readonly blackboardChangedHandler = (payload: BlackboardChangedEvent) => {
+    this.enqueue("blackboardChanged", payload);
+  };
+  private readonly stigmergyChangedHandler = (payload: StigmergyChangedEvent) => {
+    this.enqueue("stigmergyChanged", payload);
+  };
+
+  constructor(options: ReactiveSchedulerOptions) {
+    this.interpreter = options.interpreter;
+    this.runtime = options.runtime;
+    this.events = options.eventBus ?? new ReactiveEventBus();
+    this.now = options.now ?? (() => Date.now());
+    this.ageWeight = options.ageWeight ?? 0.01;
+    this.basePriorities = {
+      ...DEFAULT_BASE_PRIORITIES,
+      ...(options.basePriorities ?? {}),
+    };
+    this.onTick = options.onTick;
+    this.getPheromoneIntensity = options.getPheromoneIntensity;
+    this.causalMemory = options.causalMemory;
+
+    this.events.on("taskReady", this.taskReadyHandler);
+    this.events.on("taskDone", this.taskDoneHandler);
+    this.events.on("blackboardChanged", this.blackboardChangedHandler);
+    this.events.on("stigmergyChanged", this.stigmergyChangedHandler);
+  }
+
+  /** Number of ticks executed since the scheduler was created. */
+  get tickCount(): number {
+    return this.tickCountInternal;
+  }
+
+  /** Returns the causal event identifier of the tick currently executing, if any. */
+  getCurrentTickCausalEventId(): string | null {
+    return this.currentTickEventId;
+  }
+
+  /** Stop processing new events and detach listeners from the event bus. */
+  stop(): void {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+    this.events.off("taskReady", this.taskReadyHandler);
+    this.events.off("taskDone", this.taskDoneHandler);
+    this.events.off("blackboardChanged", this.blackboardChangedHandler);
+    this.events.off("stigmergyChanged", this.stigmergyChangedHandler);
+  }
+
+  /** Enqueue a new event manually. Mainly exposed for tests. */
+  emit<E extends SchedulerEventName>(event: E, payload: SchedulerEventMap[E]): void {
+    this.enqueue(event, payload);
+  }
+
+  /** Wait until the current queue drains or a terminal status is reached. */
+  async runUntilSettled<E extends SchedulerEventName>(initialEvent?: {
+    type: E;
+    payload: SchedulerEventMap[E];
+  }): Promise<BehaviorTickResult> {
+    if (initialEvent) {
+      this.enqueue(initialEvent.type, initialEvent.payload);
+    }
+
+    if (!this.processing && !this.scheduled) {
+      this.scheduleProcessing();
+    }
+
+    return new Promise<BehaviorTickResult>((resolve) => {
+      this.settleResolvers.push(resolve);
+      if (!this.processing && this.queue.length === 0) {
+        this.resolveSettlers();
+      }
+    });
+  }
+
+  private enqueue<E extends SchedulerEventName>(event: E, payload: SchedulerEventMap[E]): void {
+    if (this.stopped) {
+      return;
+    }
+    if (event === "taskReady") {
+      const ready = payload as TaskReadyEvent;
+      if (ready.pheromone === undefined && this.getPheromoneIntensity) {
+        ready.pheromone = this.getPheromoneIntensity(ready.nodeId);
+      }
+    }
+    if (event === "stigmergyChanged") {
+      const change = payload as StigmergyChangedEvent;
+      const total = this.getPheromoneIntensity?.(change.nodeId);
+      if (total !== undefined) {
+        change.intensity = total;
+      }
+      this.rebalancePheromone(change.nodeId, change.intensity ?? 0);
+    }
+    const entry: ScheduledTick<E> = {
+      id: this.sequence,
+      event,
+      payload,
+      enqueuedAt: this.now(),
+      basePriority: this.computeBasePriority(event, payload),
+      causalEventId: this.recordCausalEvent(
+        `scheduler.event.${event}`,
+        this.serialiseEventPayload(event, payload),
+        this.buildCauses(this.lastTickResultEventId),
+      ) ?? undefined,
+    };
+    this.sequence += 1;
+    this.queue.push(entry);
+    this.scheduleProcessing();
+  }
+
+  private scheduleProcessing(): void {
+    if (this.processing || this.stopped || this.scheduled || this.queue.length === 0) {
+      return;
+    }
+    this.scheduled = true;
+    queueMicrotask(() => {
+      this.scheduled = false;
+      void this.drainQueue();
+    });
+  }
+
+  private async drainQueue(): Promise<void> {
+    if (this.processing || this.stopped) {
+      return;
+    }
+    this.processing = true;
+    try {
+      while (!this.stopped && this.queue.length > 0) {
+        const now = this.now();
+        const nextIndex = this.selectNextIndex(now);
+        const [next] = this.queue.splice(nextIndex, 1);
+        const pendingBefore = this.queue.length + 1;
+        const tickStartId = this.recordCausalEvent(
+          "scheduler.tick.start",
+          {
+            event: next.event,
+            payload: this.serialiseEventPayload(next.event, next.payload),
+            pending_before: pendingBefore,
+          },
+          this.buildCauses(next.causalEventId, this.lastTickResultEventId),
+        );
+        this.currentTickEventId = tickStartId ?? null;
+        const startedAt = now;
+        const result = await this.interpreter.tick(this.runtime);
+        const finishedAt = this.now();
+        this.tickCountInternal += 1;
+        this.lastResult = result;
+
+        const priority = this.computeEffectivePriority(next, startedAt);
+        const pendingAfter = this.queue.length;
+        this.onTick?.({
+          event: next.event,
+          payload: next.payload,
+          priority,
+          enqueuedAt: next.enqueuedAt,
+          startedAt,
+          finishedAt,
+          result,
+          pendingAfter,
+        });
+
+        const tickResultId = this.recordCausalEvent(
+          "scheduler.tick.result",
+          {
+            event: next.event,
+            status: result.status,
+            output: this.summariseForCausal("output" in result ? result.output : null),
+            priority,
+            pending_after: pendingAfter,
+          },
+          tickStartId ? [tickStartId] : [],
+        );
+        if (tickResultId) {
+          this.lastTickResultEventId = tickResultId;
+        }
+        this.currentTickEventId = null;
+
+        if (result.status !== "running") {
+          this.stop();
+          this.resolveSettlers(result);
+          return;
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+
+    if (this.queue.length > 0) {
+      this.scheduleProcessing();
+      return;
+    }
+
+    this.resolveSettlers();
+  }
+
+  private resolveSettlers(result?: BehaviorTickResult): void {
+    if (this.settleResolvers.length === 0) {
+      return;
+    }
+    const finalResult = result ?? this.lastResult;
+    const pending = [...this.settleResolvers];
+    this.settleResolvers = [];
+    for (const resolver of pending) {
+      resolver(finalResult);
+    }
+  }
+
+  private computeBasePriority<E extends SchedulerEventName>(event: E, payload: SchedulerEventMap[E]): number {
+    const base = this.basePriorities[event];
+    switch (event) {
+      case "taskReady": {
+        const readyPayload = payload as TaskReadyEvent;
+        if (readyPayload.pheromone === undefined && this.getPheromoneIntensity) {
+          readyPayload.pheromone = this.getPheromoneIntensity(readyPayload.nodeId);
+        }
+        const { criticality = 0 } = readyPayload;
+        const pheromone = readyPayload.pheromone ?? 0;
+        return base + criticality * 10 + pheromone;
+      }
+      case "taskDone": {
+        const { success, duration_ms = 0 } = payload as TaskDoneEvent;
+        const penalty = success ? 0 : 20;
+        const reward = Math.max(0, 10 - Math.floor(duration_ms / 100));
+        return base + penalty + reward;
+      }
+      case "blackboardChanged": {
+        const { importance = 0 } = payload as BlackboardChangedEvent;
+        return base + importance * 5;
+      }
+      case "stigmergyChanged": {
+        const { intensity } = payload as StigmergyChangedEvent;
+        return base + (intensity ?? 0);
+      }
+      default: {
+        return base;
+      }
+    }
+  }
+
+  private rebalancePheromone(nodeId: string, intensity: number): void {
+    for (const entry of this.queue) {
+      if (entry.event !== "taskReady") {
+        continue;
+      }
+      const ready = entry.payload as TaskReadyEvent;
+      if (ready.nodeId !== nodeId) {
+        continue;
+      }
+      ready.pheromone = intensity;
+      entry.basePriority = this.computeBasePriority("taskReady", ready);
+    }
+  }
+
+  private selectNextIndex(now: number): number {
+    let bestIndex = 0;
+    let bestPriority = Number.NEGATIVE_INFINITY;
+    for (let index = 0; index < this.queue.length; index += 1) {
+      const entry = this.queue[index];
+      const priority = this.computeEffectivePriority(entry, now);
+      if (priority > bestPriority) {
+        bestPriority = priority;
+        bestIndex = index;
+        continue;
+      }
+      if (priority === bestPriority && entry.id < this.queue[bestIndex]!.id) {
+        bestIndex = index;
+      }
+    }
+    return bestIndex;
+  }
+
+  private computeEffectivePriority(entry: ScheduledTick, now: number): number {
+    const age = Math.max(0, now - entry.enqueuedAt);
+    return entry.basePriority + age * this.ageWeight;
+  }
+
+  private recordCausalEvent(type: string, data: Record<string, unknown>, causes: string[]): string | null {
+    if (!this.causalMemory) {
+      return null;
+    }
+    const snapshot = this.causalMemory.record(
+      {
+        type,
+        data,
+        tags: ["scheduler", type],
+      },
+      causes,
+    );
+    return snapshot.id;
+  }
+
+  private buildCauses(...ids: Array<string | null | undefined>): string[] {
+    const causes: string[] = [];
+    for (const id of ids) {
+      if (typeof id === "string" && id.length > 0 && !causes.includes(id)) {
+        causes.push(id);
+      }
+    }
+    return causes;
+  }
+
+  private serialiseEventPayload<E extends SchedulerEventName>(event: E, payload: SchedulerEventMap[E]): Record<string, unknown> {
+    switch (event) {
+      case "taskReady": {
+        const ready = payload as TaskReadyEvent;
+        return {
+          node_id: ready.nodeId,
+          criticality: ready.criticality ?? null,
+          pheromone: ready.pheromone ?? null,
+        };
+      }
+      case "taskDone": {
+        const done = payload as TaskDoneEvent;
+        return {
+          node_id: done.nodeId,
+          success: done.success,
+          duration_ms: done.duration_ms ?? null,
+        };
+      }
+      case "blackboardChanged": {
+        const change = payload as BlackboardChangedEvent;
+        return {
+          key: change.key,
+          importance: change.importance ?? null,
+        };
+      }
+      case "stigmergyChanged": {
+        const change = payload as StigmergyChangedEvent;
+        return {
+          node_id: change.nodeId,
+          intensity: change.intensity ?? null,
+          type: change.type ?? null,
+        };
+      }
+      default:
+        return {};
+    }
+  }
+
+  private summariseForCausal(value: unknown, depth = 0): unknown {
+    if (value === null || typeof value === "number" || typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      return value.length > 120 ? `${value.slice(0, 120)}…` : value;
+    }
+    if (Array.isArray(value)) {
+      if (depth >= 2) {
+        return `array(${value.length})`;
+      }
+      const preview = value.slice(0, 3).map((item) => this.summariseForCausal(item, depth + 1));
+      if (value.length > 3) {
+        preview.push(`…${value.length - 3} more`);
+      }
+      return preview;
+    }
+    if (typeof value === "object" && value !== undefined) {
+      if (depth >= 2) {
+        return "object";
+      }
+      const entries = Object.entries(value as Record<string, unknown>);
+      const summary: Record<string, unknown> = {};
+      for (const [key, entry] of entries.slice(0, 5)) {
+        summary[key] = this.summariseForCausal(entry, depth + 1);
+      }
+      if (entries.length > 5) {
+        summary.__truncated__ = `${entries.length - 5} more`;
+      }
+      return summary;
+    }
+    if (typeof value === "undefined") {
+      return null;
+    }
+    return String(value);
+  }
+}

--- a/src/graph/subgraphExtract.ts
+++ b/src/graph/subgraphExtract.ts
@@ -1,0 +1,151 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { ensureDirectory, resolveWithin } from "../paths.js";
+import type { GraphDescriptorPayload } from "../tools/graphTools.js";
+import {
+  SUBGRAPH_REGISTRY_KEY,
+  collectMissingSubgraphDescriptors,
+  resolveSubgraphDescriptor,
+} from "./subgraphRegistry.js";
+
+/** Options accepted when persisting a sub-graph descriptor to disk. */
+export interface SubgraphExtractionOptions {
+  /** Graph descriptor containing the registry of hierarchical plans. */
+  graph: GraphDescriptorPayload;
+  /** Identifier of the node flagged as a sub-graph. */
+  nodeId: string;
+  /** Run directory used to version the exported descriptor. */
+  runId: string;
+  /** Root directory hosting every child workspace. */
+  childrenRoot: string;
+  /** Optional directory name inside the run folder (defaults to `subgraphs`). */
+  directoryName?: string;
+  /** Optional clock override used by tests for deterministic timestamps. */
+  now?: () => number;
+}
+
+/** Result returned after exporting a sub-graph descriptor. */
+export interface SubgraphExtractionResult {
+  runId: string;
+  nodeId: string;
+  subgraphRef: string;
+  version: number;
+  extractedAt: number;
+  absolutePath: string;
+  relativePath: string;
+  descriptor: unknown;
+  graphId: string | null;
+  graphVersion: number | null;
+}
+
+/**
+ * Normalise an identifier so it can safely be used within a file name. The
+ * helper replaces characters outside `[a-z0-9_-]` with `-` while collapsing
+ * consecutive separators.
+ */
+function sanitiseForFileName(identifier: string): string {
+  const replaced = identifier.replace(/[^a-z0-9_-]+/gi, "-").replace(/-+/g, "-");
+  const trimmed = replaced.replace(/^[-_]+|[-_]+$/g, "");
+  return trimmed.length > 0 ? trimmed.toLowerCase() : "subgraph";
+}
+
+/**
+ * Persist the descriptor referenced by a sub-graph node inside the run
+ * directory. Each export is versioned to keep an audit trail of the modelling
+ * steps performed by the orchestrator.
+ */
+export async function extractSubgraphToFile(
+  options: SubgraphExtractionOptions,
+): Promise<SubgraphExtractionResult> {
+  if (!options.nodeId.trim()) {
+    throw new Error("subgraph node id must be provided");
+  }
+  if (!options.runId.trim()) {
+    throw new Error("run identifier must be provided");
+  }
+
+  const node = options.graph.nodes.find((candidate) => candidate.id === options.nodeId);
+  if (!node) {
+    throw new Error(`node '${options.nodeId}' does not exist in the provided graph`);
+  }
+  const kind = node.attributes?.kind;
+  if (kind !== "subgraph") {
+    throw new Error(`node '${options.nodeId}' is not flagged as a subgraph node`);
+  }
+  const ref =
+    typeof node.attributes?.ref === "string"
+      ? node.attributes.ref
+      : typeof node.attributes?.subgraph_ref === "string"
+        ? node.attributes.subgraph_ref
+        : null;
+  if (!ref) {
+    throw new Error(`node '${options.nodeId}' does not declare a subgraph reference`);
+  }
+
+  const missing = collectMissingSubgraphDescriptors(options.graph);
+  if (missing.length > 0) {
+    throw new Error(
+      `subgraph descriptors missing for: ${missing.join(", ")}`,
+    );
+  }
+  const descriptor = resolveSubgraphDescriptor(options.graph, ref);
+  if (!descriptor) {
+    throw new Error(`subgraph descriptor '${ref}' is not registered in metadata`);
+  }
+
+  const runDirectory = await ensureDirectory(options.childrenRoot, options.runId);
+  const subdir = options.directoryName ?? "subgraphs";
+  const targetDirectory = await ensureDirectory(options.childrenRoot, options.runId, subdir);
+
+  const safeRef = sanitiseForFileName(ref);
+  const entries = await fs.readdir(targetDirectory).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      return [] as string[];
+    }
+    throw error;
+  });
+  const pattern = new RegExp(`^${safeRef}\\.v(\\d+)\\.json$`);
+  let maxVersion = 0;
+  for (const entry of entries) {
+    const match = entry.match(pattern);
+    if (!match) {
+      continue;
+    }
+    const candidate = Number.parseInt(match[1], 10);
+    if (Number.isFinite(candidate) && candidate > maxVersion) {
+      maxVersion = candidate;
+    }
+  }
+  const nextVersion = maxVersion + 1;
+  const fileName = `${safeRef}.v${String(nextVersion).padStart(3, "0")}.json`;
+  const absolutePath = resolveWithin(targetDirectory, fileName);
+
+  const extractedAt = options.now ? options.now() : Date.now();
+  const payload = {
+    run_id: options.runId,
+    node_id: options.nodeId,
+    subgraph_ref: ref,
+    version: nextVersion,
+    extracted_at: extractedAt,
+    graph_id: options.graph.graph_id ?? null,
+    graph_version: options.graph.graph_version ?? null,
+    descriptor: structuredClone(descriptor),
+    metadata_key: SUBGRAPH_REGISTRY_KEY,
+  };
+
+  await fs.writeFile(absolutePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+
+  return {
+    runId: options.runId,
+    nodeId: options.nodeId,
+    subgraphRef: ref,
+    version: nextVersion,
+    extractedAt,
+    absolutePath,
+    relativePath: path.relative(runDirectory, absolutePath),
+    descriptor: payload.descriptor,
+    graphId: options.graph.graph_id ?? null,
+    graphVersion: options.graph.graph_version ?? null,
+  };
+}

--- a/src/graph/subgraphRegistry.ts
+++ b/src/graph/subgraphRegistry.ts
@@ -1,0 +1,125 @@
+import type { HierGraph } from "./hierarchy.js";
+import type { NormalisedGraph, GraphAttributeValue } from "./types.js";
+import type { GraphDescriptorPayload } from "../tools/graphTools.js";
+
+/**
+ * Metadata key storing the registry of hierarchical sub-graphs referenced by
+ * normalised plans. Keeping the constant centralised avoids hard-coded strings
+ * across modules and simplifies migrations.
+ */
+export const SUBGRAPH_REGISTRY_KEY = "hierarchy:subgraphs";
+
+/** Descriptor persisted alongside a sub-graph entry inside the registry. */
+export interface SubgraphDescriptor {
+  graph: HierGraph | NormalisedGraph;
+  entryPoints?: string[];
+  exitPoints?: string[];
+}
+
+/** Mapping between sub-graph references and their descriptors. */
+export type SubgraphRegistry = Map<string, SubgraphDescriptor>;
+
+/**
+ * Parse a registry serialised in the graph metadata. The helper gracefully
+ * tolerates malformed payloads by returning `null` so callers can surface
+ * actionable diagnostics.
+ */
+export function parseSubgraphRegistry(
+  value: GraphAttributeValue | undefined,
+): SubgraphRegistry | null {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as Record<string, SubgraphDescriptor>;
+    const registry: SubgraphRegistry = new Map();
+    for (const [key, descriptor] of Object.entries(parsed)) {
+      if (!descriptor || typeof descriptor !== "object") {
+        continue;
+      }
+      registry.set(key, descriptor);
+    }
+    return registry;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Serialise a registry so it can be persisted back into the graph metadata.
+ */
+export function stringifySubgraphRegistry(registry: SubgraphRegistry): string {
+  const serialisable: Record<string, SubgraphDescriptor> = {};
+  for (const [key, descriptor] of registry.entries()) {
+    serialisable[key] = descriptor;
+  }
+  return JSON.stringify(serialisable);
+}
+
+/**
+ * Collect the references of every node flagged as a sub-graph.
+ */
+export function collectSubgraphReferences(
+  graph: Pick<GraphDescriptorPayload | NormalisedGraph, "nodes">,
+): Set<string> {
+  const refs = new Set<string>();
+  for (const node of graph.nodes) {
+    const attributes = (node as { attributes?: Record<string, unknown> }).attributes;
+    if (!attributes) {
+      continue;
+    }
+    if (attributes.kind !== "subgraph") {
+      continue;
+    }
+    const ref =
+      typeof attributes.ref === "string"
+        ? attributes.ref
+        : typeof attributes.subgraph_ref === "string"
+          ? attributes.subgraph_ref
+          : null;
+    if (ref) {
+      refs.add(ref);
+    }
+  }
+  return refs;
+}
+
+/**
+ * Determine which sub-graph references currently lack a descriptor entry.
+ */
+export function collectMissingSubgraphDescriptors(
+  graph: Pick<GraphDescriptorPayload | NormalisedGraph, "nodes" | "metadata">,
+): string[] {
+  const refs = collectSubgraphReferences(graph);
+  if (refs.size === 0) {
+    return [];
+  }
+  const metadata = graph.metadata as Record<string, GraphAttributeValue> | undefined;
+  const registry = parseSubgraphRegistry(metadata?.[SUBGRAPH_REGISTRY_KEY]);
+  if (!registry) {
+    return Array.from(refs);
+  }
+  const missing: string[] = [];
+  for (const ref of refs) {
+    if (!registry.has(ref)) {
+      missing.push(ref);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Fetch a descriptor from the registry, returning `null` when the reference is
+ * unknown or the registry cannot be parsed.
+ */
+export function resolveSubgraphDescriptor(
+  graph: Pick<GraphDescriptorPayload | NormalisedGraph, "metadata">,
+  ref: string,
+): SubgraphDescriptor | null {
+  const metadata = graph.metadata as Record<string, GraphAttributeValue> | undefined;
+  const registry = parseSubgraphRegistry(metadata?.[SUBGRAPH_REGISTRY_KEY]);
+  if (!registry) {
+    return null;
+  }
+  return registry.get(ref) ?? null;
+}

--- a/src/graph/tx.ts
+++ b/src/graph/tx.ts
@@ -18,11 +18,15 @@ export class GraphTransactionError extends Error {
 
 /** Error thrown when attempting to commit using a stale base version. */
 export class GraphVersionConflictError extends GraphTransactionError {
+  public readonly code = "E-REWRITE-CONFLICT";
+  public readonly details: { graphId: string; expected: number; found: number };
+
   constructor(graphId: string, expected: number, found: number) {
     super(
       `graph '${graphId}' diverged: expected version ${expected} but received ${found}`,
     );
     this.name = "GraphVersionConflictError";
+    this.details = { graphId, expected, found };
   }
 }
 

--- a/src/knowledge/causalMemory.ts
+++ b/src/knowledge/causalMemory.ts
@@ -1,0 +1,265 @@
+/**
+ * Deterministic in-memory causal memory tracking outcome events and their
+ * dependencies. The store keeps a causal graph so explanations can be derived
+ * without replaying the full execution.
+ */
+export interface CausalMemoryOptions {
+  /** Monotonic clock returning millisecond timestamps (defaults to {@link Date.now}). */
+  now?: () => number;
+  /** Optional identifier prefix easing correlation when multiple stores coexist. */
+  idPrefix?: string;
+}
+
+/** Payload accepted when recording a new causal event. */
+export interface CausalEventInput {
+  /** Machine readable type describing the event category. */
+  type: string;
+  /** Optional human readable label easing diagnostics. */
+  label?: string;
+  /** Structured payload carrying contextual attributes. */
+  data?: Record<string, unknown>;
+  /** Optional set of tags used to query/aggregate events. */
+  tags?: string[];
+}
+
+/** Snapshot returned when inspecting a recorded causal event. */
+export interface CausalEventSnapshot {
+  id: string;
+  type: string;
+  label: string | null;
+  data: Record<string, unknown>;
+  tags: string[];
+  causes: string[];
+  effects: string[];
+  createdAt: number;
+  ordinal: number;
+}
+
+/** Directed edge linking a cause to its effect. */
+export interface CausalEdgeSnapshot {
+  from: string;
+  to: string;
+}
+
+/** Result returned by {@link CausalMemory.explain}. */
+export interface CausalExplanation {
+  outcome: CausalEventSnapshot;
+  ancestors: CausalEventSnapshot[];
+  edges: CausalEdgeSnapshot[];
+  depth: number;
+}
+
+/**
+ * Error emitted when the store cannot reconstruct a causal chain for the
+ * requested outcome. The code is propagated to MCP clients so they can handle
+ * missing paths explicitly instead of treating the absence as a generic
+ * failure.
+ */
+export class CausalPathNotFoundError extends Error {
+  public readonly code = "E-CAUSAL-NO-PATH";
+  public readonly details: { outcomeId: string; causeId?: string };
+
+  constructor(message: string, details: { outcomeId: string; causeId?: string }) {
+    super(message);
+    this.name = "CausalPathNotFoundError";
+    this.details = details;
+  }
+}
+
+interface CausalEventRecord extends CausalEventSnapshot {}
+
+/**
+ * Helper performing a JSON based deep clone. The payloads we persist are
+ * expected to be JSON serialisable which keeps the implementation portable
+ * across runtimes while remaining deterministic.
+ */
+function cloneData<T>(value: T): T {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+/** Normalises and deduplicates an array of tags. */
+function normaliseTags(tags: string[] | undefined): string[] {
+  if (!tags || tags.length === 0) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of tags) {
+    const cleaned = tag.trim();
+    if (!cleaned.length || seen.has(cleaned)) {
+      continue;
+    }
+    seen.add(cleaned);
+    result.push(cleaned);
+  }
+  return result;
+}
+
+/**
+ * In-memory DAG capturing how runtime events lead to observable outcomes. The
+ * class is intentionally lightweight so deterministic tests can assert over the
+ * causal relationships without requiring a backing database.
+ */
+export class CausalMemory {
+  private readonly now: () => number;
+  private readonly idPrefix: string;
+  private sequence = 0;
+  private readonly records = new Map<string, CausalEventRecord>();
+
+  constructor(options: CausalMemoryOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+    this.idPrefix = options.idPrefix ?? "cm-";
+  }
+
+  /** Returns the total number of recorded events. */
+  count(): number {
+    return this.records.size;
+  }
+
+  /** Retrieve a snapshot for a given event identifier. */
+  get(id: string): CausalEventSnapshot | null {
+    const record = this.records.get(id);
+    return record ? cloneRecord(record) : null;
+  }
+
+  /**
+   * Record a new causal event and returns the resulting snapshot. Causes are
+   * optional but when provided they must refer to previously recorded events.
+   */
+  record(input: CausalEventInput, causes: string[] = []): CausalEventSnapshot {
+    const type = input.type.trim();
+    if (!type) {
+      throw new Error("causal event type must not be empty");
+    }
+    const label = input.label?.trim() ?? null;
+    const tags = normaliseTags(input.tags);
+    const timestamp = this.now();
+
+    const uniqueCauses: string[] = [];
+    const seen = new Set<string>();
+    for (const causeId of causes) {
+      if (seen.has(causeId)) {
+        continue;
+      }
+      const cause = this.records.get(causeId);
+      if (!cause) {
+        throw new Error(`unknown cause ${causeId}`);
+      }
+      seen.add(causeId);
+      uniqueCauses.push(causeId);
+    }
+
+    const id = `${this.idPrefix}${++this.sequence}`;
+    const ordinal = this.sequence;
+    const data = cloneData(input.data ?? {});
+
+    const record: CausalEventRecord = {
+      id,
+      type,
+      label,
+      data,
+      tags,
+      causes: [...uniqueCauses],
+      effects: [],
+      createdAt: timestamp,
+      ordinal,
+    };
+
+    this.records.set(id, record);
+    for (const causeId of uniqueCauses) {
+      const cause = this.records.get(causeId);
+      if (!cause) {
+        continue;
+      }
+      cause.effects = [...cause.effects, id];
+    }
+
+    return cloneRecord(record);
+  }
+
+  /**
+   * Returns every recorded event ordered by insertion time. The snapshots are
+   * clones so callers cannot mutate the internal state accidentally.
+   */
+  exportAll(): CausalEventSnapshot[] {
+    return Array.from(this.records.values())
+      .sort((a, b) => a.ordinal - b.ordinal)
+      .map((record) => cloneRecord(record));
+  }
+
+  /**
+   * Traverse the causal graph backwards starting from the provided outcome. The
+   * result enumerates ancestors (ordered by insertion) and edges that can be
+   * used to reconstruct explanation paths.
+   */
+  explain(outcomeId: string, options: { maxDepth?: number } = {}): CausalExplanation {
+    const outcome = this.records.get(outcomeId);
+    if (!outcome) {
+      throw new CausalPathNotFoundError(
+        `No outcome recorded with id ${outcomeId}`,
+        { outcomeId },
+      );
+    }
+    const maxDepth = options.maxDepth ?? Number.POSITIVE_INFINITY;
+    const nodes = new Map<string, CausalEventRecord>();
+    const edges: CausalEdgeSnapshot[] = [];
+
+    nodes.set(outcome.id, outcome);
+    let depthReached = 0;
+    const queue: Array<{ target: string; source: string; depth: number }> = [];
+    for (const source of outcome.causes) {
+      queue.push({ target: outcome.id, source, depth: 1 });
+    }
+
+    const visited = new Set<string>();
+    while (queue.length > 0) {
+      const { target, source, depth } = queue.shift()!;
+      edges.push({ from: source, to: target });
+      depthReached = Math.max(depthReached, depth);
+      if (visited.has(source)) {
+        continue;
+      }
+      visited.add(source);
+      const record = this.records.get(source);
+      if (!record) {
+        throw new CausalPathNotFoundError(
+          `Causal link references missing event ${source}`,
+          { outcomeId, causeId: source },
+        );
+      }
+      nodes.set(source, record);
+      if (depth >= maxDepth) {
+        continue;
+      }
+      for (const parent of record.causes) {
+        queue.push({ target: source, source: parent, depth: depth + 1 });
+      }
+    }
+
+    const ancestors = Array.from(nodes.values())
+      .filter((record) => record.id !== outcome.id)
+      .sort((a, b) => a.ordinal - b.ordinal)
+      .map((record) => cloneRecord(record));
+
+    return {
+      outcome: cloneRecord(outcome),
+      ancestors,
+      edges,
+      depth: depthReached,
+    };
+  }
+}
+
+function cloneRecord(record: CausalEventRecord): CausalEventSnapshot {
+  return {
+    id: record.id,
+    type: record.type,
+    label: record.label,
+    data: cloneData(record.data),
+    tags: [...record.tags],
+    causes: [...record.causes],
+    effects: [...record.effects],
+    createdAt: record.createdAt,
+    ordinal: record.ordinal,
+  };
+}

--- a/src/knowledge/knowledgeGraph.ts
+++ b/src/knowledge/knowledgeGraph.ts
@@ -1,0 +1,385 @@
+/** Options accepted by the {@link KnowledgeGraph} constructor. */
+export interface KnowledgeGraphOptions {
+  /** Clock providing monotonic timestamps. Defaults to {@link Date.now}. */
+  now?: () => number;
+}
+
+/** Representation of a triple persisted in the knowledge graph. */
+export interface KnowledgeTripleSnapshot {
+  /** Stable identifier assigned to the triple. */
+  id: string;
+  /** Subject part of the triple. */
+  subject: string;
+  /** Predicate part of the triple. */
+  predicate: string;
+  /** Object part of the triple. */
+  object: string;
+  /** Optional provenance string describing the data source. */
+  source: string | null;
+  /** Confidence score (0-1) associated with the triple. */
+  confidence: number;
+  /** Creation timestamp emitted by the injected clock. */
+  insertedAt: number;
+  /** Last update timestamp emitted by the injected clock. */
+  updatedAt: number;
+  /** Number of times the triple has been rewritten. */
+  revision: number;
+  /** Deterministic ordinal describing insertion order. */
+  ordinal: number;
+}
+
+/**
+ * Error raised when a caller attempts to persist a triple with blank fields.
+ * The orchestration server relies on the `code` and `details` payload to emit
+ * actionable MCP error responses while keeping logs informative.
+ */
+export class KnowledgeBadTripleError extends Error {
+  public readonly code = "E-KG-BAD-TRIPLE";
+  public readonly details: Record<string, string>;
+
+  constructor(triple: { subject: string; predicate: string; object: string }) {
+    super("Knowledge triples require non-empty subject, predicate and object");
+    this.name = "KnowledgeBadTripleError";
+    this.details = {
+      subject: triple.subject,
+      predicate: triple.predicate,
+      object: triple.object,
+    };
+  }
+}
+
+/** Result returned by {@link KnowledgeGraph.insert}. */
+export interface KnowledgeInsertResult {
+  /** Snapshot describing the persisted triple. */
+  snapshot: KnowledgeTripleSnapshot;
+  /** Whether the operation created a new triple. */
+  created: boolean;
+  /** Whether the operation updated an existing triple. */
+  updated: boolean;
+}
+
+/** Pattern accepted when querying the knowledge graph. */
+export interface KnowledgeQueryPattern {
+  subject?: string;
+  predicate?: string;
+  object?: string;
+  source?: string;
+  minConfidence?: number;
+}
+
+/** Additional options controlling how queries are executed. */
+export interface KnowledgeQueryOptions {
+  /** Maximum number of triples returned. */
+  limit?: number;
+  /** Sort order (ascending by ordinal by default). */
+  order?: "asc" | "desc";
+}
+
+/** Metadata describing a reconstructed plan pattern. */
+export interface KnowledgePlanPattern {
+  /** Name of the plan used when querying the graph. */
+  plan: string;
+  /** Deterministic description of the tasks composing the pattern. */
+  tasks: KnowledgePlanTask[];
+  /** Average confidence derived from the supporting triples. */
+  averageConfidence: number | null;
+  /** Number of unique sources contributing to the pattern. */
+  sourceCount: number;
+}
+
+/** Task descriptor derived from the knowledge graph. */
+export interface KnowledgePlanTask {
+  /** Identifier used by downstream planners. */
+  id: string;
+  /** Optional human readable label. */
+  label?: string;
+  /** Dependencies declared in the knowledge graph. */
+  dependsOn: string[];
+  /** Optional duration (arbitrary unit) extracted from the graph. */
+  duration?: number;
+  /** Optional weight used when balancing edges. */
+  weight?: number;
+  /** Provenance string if provided in the triple linking the task to the plan. */
+  source: string | null;
+  /** Confidence inherited from the triple linking the task to the plan. */
+  confidence: number;
+}
+
+interface KnowledgeTripleRecord extends KnowledgeTripleSnapshot {
+  key: string;
+}
+
+/**
+ * Simple, fully in-memory knowledge graph. Triples are indexed by subject,
+ * predicate and object to make motif based queries deterministic. Confidence
+ * scores stay bounded between 0 and 1 to ease downstream computations.
+ */
+export class KnowledgeGraph {
+  private readonly now: () => number;
+  private readonly records = new Map<string, KnowledgeTripleRecord>();
+  private readonly keyIndex = new Map<string, string>();
+  private readonly subjectIndex = new Map<string, Set<string>>();
+  private readonly predicateIndex = new Map<string, Set<string>>();
+  private readonly objectIndex = new Map<string, Set<string>>();
+  private sequence = 0;
+
+  constructor(options: KnowledgeGraphOptions = {}) {
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Returns the total number of stored triples. */
+  count(): number {
+    return this.records.size;
+  }
+
+  /** Inserts or updates a triple and returns the resulting snapshot. */
+  insert(triple: {
+    subject: string;
+    predicate: string;
+    object: string;
+    source?: string;
+    confidence?: number;
+  }): KnowledgeInsertResult {
+    const subject = triple.subject.trim();
+    const predicate = triple.predicate.trim();
+    const object = triple.object.trim();
+
+    if (!subject || !predicate || !object) {
+      throw new KnowledgeBadTripleError(triple);
+    }
+
+    const source = triple.source?.trim() ?? null;
+    const confidence = clampConfidence(triple.confidence);
+    const timestamp = this.now();
+    const key = makeKey(subject, predicate, object);
+    const existingId = this.keyIndex.get(key);
+
+    if (existingId) {
+      const record = this.records.get(existingId);
+      if (!record) {
+        this.keyIndex.delete(key);
+        return this.insert(triple);
+      }
+      const updated: KnowledgeTripleRecord = {
+        ...record,
+        source,
+        confidence,
+        updatedAt: timestamp,
+        revision: record.revision + 1,
+      };
+      this.records.set(existingId, updated);
+      return { snapshot: cloneRecord(updated), created: false, updated: true };
+    }
+
+    const id = `kg-${++this.sequence}`;
+    const ordinal = this.sequence;
+    const record: KnowledgeTripleRecord = {
+      id,
+      key,
+      subject,
+      predicate,
+      object,
+      source,
+      confidence,
+      insertedAt: timestamp,
+      updatedAt: timestamp,
+      revision: 0,
+      ordinal,
+    };
+    this.records.set(id, record);
+    this.keyIndex.set(key, id);
+    this.index(this.subjectIndex, subject, id);
+    this.index(this.predicateIndex, predicate, id);
+    this.index(this.objectIndex, object, id);
+    return { snapshot: cloneRecord(record), created: true, updated: false };
+  }
+
+  /**
+   * Retrieves triples matching the provided pattern. Wildcards (`*`) are
+   * supported anywhere within the pattern fields and match any sequence.
+   */
+  query(
+    pattern: KnowledgeQueryPattern = {},
+    options: KnowledgeQueryOptions = {},
+  ): KnowledgeTripleSnapshot[] {
+    const candidates = this.collectCandidates(pattern);
+    const ordered = candidates
+      .map((id) => this.records.get(id))
+      .filter((record): record is KnowledgeTripleRecord => Boolean(record))
+      .filter((record) => matchesRecord(record, pattern))
+      .sort((a, b) => (options.order === "desc" ? b.ordinal - a.ordinal : a.ordinal - b.ordinal));
+
+    const limit = options.limit && options.limit > 0 ? Math.min(options.limit, ordered.length) : ordered.length;
+    const sliced = ordered.slice(0, limit);
+    return sliced.map(cloneRecord);
+  }
+
+  /** Returns every triple ordered by insertion time. */
+  exportAll(): KnowledgeTripleSnapshot[] {
+    return this.query({}, { order: "asc" });
+  }
+
+  /**
+   * Reconstructs a plan pattern based on triples shaped as follows:
+   *
+   * - `(plan, "includes", taskId)` defines tasks belonging to the pattern.
+   * - `(task:ID, "label", label)` declares a human readable label.
+   * - `(task:ID, "depends_on", otherTask)` records dependencies.
+   * - `(task:ID, "duration", value)` and `(task:ID, "weight", value)` expose metadata.
+   */
+  buildPlanPattern(plan: string): KnowledgePlanPattern | null {
+    const includes = this.query({ subject: plan, predicate: "includes" });
+    if (!includes.length) {
+      return null;
+    }
+
+    const tasks: KnowledgePlanTask[] = [];
+    const sources = new Set<string>();
+    let confidenceSum = 0;
+
+    for (const include of includes) {
+      const taskId = include.object;
+      const subject = taskSubject(taskId);
+      const taskTriples = this.query({ subject });
+      const dependsOn = taskTriples.filter((triple) => triple.predicate === "depends_on").map((triple) => triple.object);
+      const label = taskTriples.find((triple) => triple.predicate === "label")?.object;
+      const duration = toNumber(taskTriples.find((triple) => triple.predicate === "duration")?.object);
+      const weight = toNumber(taskTriples.find((triple) => triple.predicate === "weight")?.object);
+      const source = include.source;
+      const confidence = include.confidence;
+      if (source) {
+        sources.add(source);
+      }
+      confidenceSum += confidence;
+      tasks.push({
+        id: taskId,
+        label,
+        dependsOn: dedupe(dependsOn),
+        duration: duration ?? undefined,
+        weight: weight ?? undefined,
+        source,
+        confidence,
+      });
+    }
+
+    const averageConfidence = tasks.length > 0 ? confidenceSum / tasks.length : null;
+    return {
+      plan,
+      tasks,
+      averageConfidence,
+      sourceCount: sources.size,
+    };
+  }
+
+  private collectCandidates(pattern: KnowledgeQueryPattern): string[] {
+    const sets: Array<Set<string>> = [];
+    if (pattern.subject && !hasWildcard(pattern.subject)) {
+      const set = this.subjectIndex.get(pattern.subject);
+      if (set) sets.push(set);
+    }
+    if (pattern.predicate && !hasWildcard(pattern.predicate)) {
+      const set = this.predicateIndex.get(pattern.predicate);
+      if (set) sets.push(set);
+    }
+    if (pattern.object && !hasWildcard(pattern.object)) {
+      const set = this.objectIndex.get(pattern.object);
+      if (set) sets.push(set);
+    }
+    if (!sets.length) {
+      return Array.from(this.records.keys());
+    }
+    let intersection = new Set(sets[0]);
+    for (let i = 1; i < sets.length; i += 1) {
+      intersection = intersect(intersection, sets[i]);
+    }
+    return Array.from(intersection);
+  }
+
+  private index(map: Map<string, Set<string>>, key: string, id: string): void {
+    const existing = map.get(key);
+    if (existing) {
+      existing.add(id);
+      return;
+    }
+    map.set(key, new Set([id]));
+  }
+}
+
+function makeKey(subject: string, predicate: string, object: string): string {
+  return `${subject}\u0000${predicate}\u0000${object}`;
+}
+
+function cloneRecord(record: KnowledgeTripleRecord): KnowledgeTripleSnapshot {
+  return { ...record };
+}
+
+function intersect(left: Set<string>, right: Set<string>): Set<string> {
+  const result = new Set<string>();
+  for (const value of left) {
+    if (right.has(value)) {
+      result.add(value);
+    }
+  }
+  return result;
+}
+
+function hasWildcard(value: string): boolean {
+  return value.includes("*");
+}
+
+function wildcardMatch(value: string, pattern: string): boolean {
+  if (!hasWildcard(pattern)) {
+    return value === pattern;
+  }
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escaped.replace(/\\\*/g, ".*")}$`);
+  return regex.test(value);
+}
+
+function matchesRecord(record: KnowledgeTripleRecord, pattern: KnowledgeQueryPattern): boolean {
+  if (pattern.subject && !wildcardMatch(record.subject, pattern.subject)) return false;
+  if (pattern.predicate && !wildcardMatch(record.predicate, pattern.predicate)) return false;
+  if (pattern.object && !wildcardMatch(record.object, pattern.object)) return false;
+  if (pattern.source) {
+    const source = record.source ?? "";
+    if (!wildcardMatch(source, pattern.source)) return false;
+  }
+  if (pattern.minConfidence !== undefined) {
+    const threshold = clampConfidence(pattern.minConfidence);
+    if (record.confidence < threshold) return false;
+  }
+  return true;
+}
+
+function clampConfidence(value: number | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return 1;
+  }
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function dedupe(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+function taskSubject(taskId: string): string {
+  return `task:${taskId}`;
+}
+
+function toNumber(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}

--- a/src/tools/causalTools.ts
+++ b/src/tools/causalTools.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+import type { CausalExplanation, CausalEventSnapshot } from "../knowledge/causalMemory.js";
+import { CausalMemory } from "../knowledge/causalMemory.js";
+import { StructuredLogger } from "../logger.js";
+
+/** Context injected by the server when invoking causal memory tools. */
+export interface CausalToolContext {
+  /** Shared causal memory capturing runtime executions. */
+  causalMemory: CausalMemory;
+  /** Structured logger recording tool usage. */
+  logger: StructuredLogger;
+}
+
+/** Schema validating the payload accepted by the `causal_export` tool. */
+export const CausalExportInputSchema = z.object({}).strict();
+export const CausalExportInputShape = CausalExportInputSchema.shape;
+
+/** Schema validating the payload accepted by the `causal_explain` tool. */
+export const CausalExplainInputSchema = z
+  .object({
+    outcome_id: z.string().min(1),
+    max_depth: z.number().int().min(1).max(32).optional(),
+  })
+  .strict();
+export const CausalExplainInputShape = CausalExplainInputSchema.shape;
+
+/** Result returned by {@link handleCausalExport}. */
+export interface CausalExportResult extends Record<string, unknown> {
+  events: SerializedCausalEvent[];
+  total: number;
+}
+
+/** Result returned by {@link handleCausalExplain}. */
+export interface CausalExplainResult extends Record<string, unknown> {
+  outcome: SerializedCausalEvent;
+  ancestors: SerializedCausalEvent[];
+  edges: CausalEdgePayload[];
+  depth: number;
+}
+
+interface SerializedCausalEvent extends Record<string, unknown> {
+  id: string;
+  type: string;
+  label: string | null;
+  data: Record<string, unknown>;
+  tags: string[];
+  causes: string[];
+  effects: string[];
+  created_at: number;
+  ordinal: number;
+}
+
+interface CausalEdgePayload extends Record<string, unknown> {
+  from: string;
+  to: string;
+}
+
+/** Dumps the entire causal memory for offline audits. */
+export function handleCausalExport(
+  context: CausalToolContext,
+  _input: z.infer<typeof CausalExportInputSchema>,
+): CausalExportResult {
+  const events = context.causalMemory.exportAll().map(serializeEvent);
+  context.logger.info("causal_export", { count: events.length });
+  return { events, total: events.length };
+}
+
+/** Computes an explanation graph for a given outcome event. */
+export function handleCausalExplain(
+  context: CausalToolContext,
+  input: z.infer<typeof CausalExplainInputSchema>,
+): CausalExplainResult {
+  const explanation = context.causalMemory.explain(input.outcome_id, { maxDepth: input.max_depth });
+  context.logger.info("causal_explain", {
+    outcome_id: input.outcome_id,
+    ancestors: explanation.ancestors.length,
+    depth: explanation.depth,
+  });
+  return serializeExplanation(explanation);
+}
+
+function serializeExplanation(explanation: CausalExplanation): CausalExplainResult {
+  return {
+    outcome: serializeEvent(explanation.outcome),
+    ancestors: explanation.ancestors.map(serializeEvent),
+    edges: explanation.edges.map((edge) => ({ from: edge.from, to: edge.to })),
+    depth: explanation.depth,
+  };
+}
+
+function serializeEvent(snapshot: CausalEventSnapshot): SerializedCausalEvent {
+  return {
+    id: snapshot.id,
+    type: snapshot.type,
+    label: snapshot.label,
+    data: snapshot.data,
+    tags: [...snapshot.tags],
+    causes: [...snapshot.causes],
+    effects: [...snapshot.effects],
+    created_at: snapshot.createdAt,
+    ordinal: snapshot.ordinal,
+  };
+}

--- a/src/tools/graphTools.ts
+++ b/src/tools/graphTools.ts
@@ -2,10 +2,20 @@ import { createHash } from "node:crypto";
 
 import { z } from "zod";
 
+import { applyAdaptiveRewrites, type AdaptiveEvaluationResult } from "../graph/adaptive.js";
 import { GraphComputationCache } from "../graph/cache.js";
 import { buildGraphAttributeIndex } from "../graph/index.js";
 import { partitionGraph, type GraphPartitionObjective } from "../graph/partition.js";
+import {
+  applyAll,
+  createInlineSubgraphRule,
+  createRerouteAvoidRule,
+  createSplitParallelRule,
+  type RewriteHistoryEntry,
+  type RewriteRule,
+} from "../graph/rewrite.js";
 import type { NormalisedGraph } from "../graph/types.js";
+import type { KnowledgeGraph } from "../knowledge/knowledgeGraph.js";
 
 interface GraphForgeModelInstance {
   listNodes(): Array<{ id: string }>;
@@ -255,11 +265,24 @@ const PRESET_LIBRARY: Record<string, TaskDefinition[]> = {
  * Generate a labelled dependency graph from textual or structured task
  * descriptions.
  */
+export interface GraphGenerationContext {
+  /** Optional knowledge graph powering plan pattern suggestions. */
+  knowledgeGraph?: KnowledgeGraph | null;
+  /** Explicit flag used to disable knowledge-based suggestions. */
+  knowledgeEnabled?: boolean;
+}
+
+interface DerivedTasksResult {
+  tasks: TaskDefinition[];
+  notes: string[];
+}
+
 export function handleGraphGenerate(
   input: GraphGenerateInput,
+  context?: GraphGenerationContext,
 ): GraphGenerateResult {
-  const tasks = normaliseTasks(input);
   const defaultWeight = input.default_weight ?? 1;
+  const { tasks, notes: knowledgeNotes } = deriveTasks(input, context);
 
   const nodes = new Map<string, TaskDefinition>();
   const order: string[] = [];
@@ -359,13 +382,19 @@ export function handleGraphGenerate(
 
   ensureGraphIdentity(descriptor);
 
+  const notes: string[] = [];
+  if (knowledgeNotes.length > 0) {
+    notes.push(...knowledgeNotes);
+  }
+  if (tasks.some((task) => task.synthetic === true)) {
+    notes.push("synthetic nodes were added for undeclared dependencies");
+  }
+
   return {
     graph: serialiseDescriptor(descriptor),
     task_count: tasks.filter((task) => !task.synthetic).length,
     edge_count: descriptor.edges.length,
-    notes: tasks.some((task) => task.synthetic === true)
-      ? ["synthetic nodes were added for undeclared dependencies"]
-      : [],
+    notes,
   };
 }
 
@@ -465,6 +494,307 @@ export function handleGraphMutate(input: GraphMutateInput): GraphMutateResult {
   }
 
   return { graph: serialiseDescriptor(descriptor), applied };
+}
+
+/** Identifier of rewrite rules that can be triggered via the rewrite tool. */
+const GraphRewriteRuleIdSchema = z.enum(["split_parallel", "inline_subgraph", "reroute_avoid"]);
+
+const GraphRewriteManualOptionsSchema = z
+  .object({
+    stop_on_no_change: z.boolean().optional(),
+    split_parallel_targets: z.array(z.string().min(1)).optional(),
+    reroute_avoid_node_ids: z.array(z.string().min(1)).optional(),
+    reroute_avoid_labels: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+const GraphRewriteAdaptiveOptionsSchema = z
+  .object({
+    stop_on_no_change: z.boolean().optional(),
+    avoid_labels: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+const GraphRewriteInsightMetricsSchema = z
+  .object({
+    successes: z.number().int().nonnegative(),
+    failures: z.number().int().nonnegative(),
+    total_duration_ms: z.number().nonnegative(),
+    total_reward: z.number(),
+    last_updated_at: z.number().int().nonnegative(),
+    attempts: z.number().int().nonnegative(),
+    success_rate: z.number().min(0).max(1),
+    average_duration_ms: z.number().nonnegative(),
+  })
+  .strict();
+
+const GraphRewriteInsightSchema = z
+  .object({
+    edge_key: z.string().min(1),
+    reinforcement: z.number().min(0).max(1),
+    confidence: z.number().min(0).max(1),
+    recommendation: z.enum(["boost", "keep", "prune"]),
+    metrics: GraphRewriteInsightMetricsSchema.optional(),
+  })
+  .strict();
+
+const GraphRewriteAdaptiveEvaluationSchema = z
+  .object({
+    edges_to_boost: z.array(z.string().min(1)).default([]),
+    edges_to_prune: z.array(z.string().min(1)).default([]),
+    insights: z.array(GraphRewriteInsightSchema).default([]),
+  })
+  .strict();
+
+const GraphRewriteApplyManualSchema = z
+  .object({
+    graph: GraphDescriptorSchema,
+    mode: z.literal("manual"),
+    rules: z.array(GraphRewriteRuleIdSchema).min(1, "at least one rewrite rule must be selected"),
+    options: GraphRewriteManualOptionsSchema.optional(),
+  })
+  .strict();
+
+const GraphRewriteApplyAdaptiveSchema = z
+  .object({
+    graph: GraphDescriptorSchema,
+    mode: z.literal("adaptive"),
+    evaluation: GraphRewriteAdaptiveEvaluationSchema,
+    options: GraphRewriteAdaptiveOptionsSchema.optional(),
+  })
+  .strict();
+
+/** Input payload accepted by `graph_rewrite_apply`. */
+export const GraphRewriteApplyInputSchema = z.discriminatedUnion("mode", [
+  GraphRewriteApplyManualSchema,
+  GraphRewriteApplyAdaptiveSchema,
+]);
+
+export const GraphRewriteApplyInputShape = {
+  graph: GraphDescriptorSchema,
+  mode: z.enum(["manual", "adaptive"]),
+  rules: z.array(GraphRewriteRuleIdSchema).optional(),
+  options: z
+    .object({
+      stop_on_no_change: z.boolean().optional(),
+      split_parallel_targets: z.array(z.string().min(1)).optional(),
+      reroute_avoid_node_ids: z.array(z.string().min(1)).optional(),
+      reroute_avoid_labels: z.array(z.string().min(1)).optional(),
+      avoid_labels: z.array(z.string().min(1)).optional(),
+    })
+    .optional(),
+  evaluation: GraphRewriteAdaptiveEvaluationSchema.optional(),
+} as const;
+
+export type GraphRewriteApplyInput = z.infer<typeof GraphRewriteApplyInputSchema>;
+
+export interface GraphRewriteApplyResult extends Record<string, unknown> {
+  graph: GraphDescriptorPayload;
+  history: RewriteHistoryEntry[];
+  total_applied: number;
+  changed: boolean;
+  stop_on_no_change: boolean;
+  mode: "manual" | "adaptive";
+  rules_invoked: string[];
+}
+
+/**
+ * Apply graph rewrite rules either manually selected by the caller or derived
+ * from an adaptive reinforcement evaluation. The helper maintains graph
+ * identity so the transaction manager can reason about optimistic concurrency.
+ */
+export function handleGraphRewriteApply(input: GraphRewriteApplyInput): GraphRewriteApplyResult {
+  const descriptor = normaliseDescriptor(input.graph);
+  const baseVersion = descriptor.graphVersion;
+
+  let rewrittenGraph: NormalisedGraph;
+  let history: RewriteHistoryEntry[];
+  let rulesInvoked: string[];
+  let stopOnNoChange: boolean;
+
+  if (input.mode === "manual") {
+    const manualOptions = input.options;
+    const ruleSet = new Set(input.rules);
+    const rules: RewriteRule[] = [];
+    rulesInvoked = [];
+
+    if (ruleSet.has("split_parallel")) {
+      const targets = normaliseEdgeTargets(manualOptions?.split_parallel_targets);
+      rules.push(createSplitParallelRule(targets));
+      rulesInvoked.push("split-parallel");
+    }
+
+    if (ruleSet.has("inline_subgraph")) {
+      rules.push(createInlineSubgraphRule());
+      rulesInvoked.push("inline-subgraph");
+    }
+
+    if (ruleSet.has("reroute_avoid")) {
+      const avoidNodeIds = normaliseStringSet(manualOptions?.reroute_avoid_node_ids);
+      const avoidLabels = normaliseStringSet(manualOptions?.reroute_avoid_labels);
+      rules.push(
+        createRerouteAvoidRule({
+          avoidNodeIds,
+          avoidLabels,
+        }),
+      );
+      rulesInvoked.push("reroute-avoid");
+    }
+
+    if (rules.length === 0) {
+      throw new Error("no rewrite rules resolved after validating the input");
+    }
+
+    stopOnNoChange = manualOptions?.stop_on_no_change ?? true;
+    const { graph: rewritten, history: rewriteHistory } = applyAll(
+      descriptor,
+      rules,
+      stopOnNoChange,
+    );
+    rewrittenGraph = rewritten;
+    history = rewriteHistory;
+  } else {
+    const adaptiveOptions = input.options;
+    const evaluation = mapAdaptiveEvaluation(input.evaluation);
+    stopOnNoChange = adaptiveOptions?.stop_on_no_change ?? true;
+    const avoidLabels = dedupeStringList(adaptiveOptions?.avoid_labels);
+    const { graph: rewritten, history: rewriteHistory } = applyAdaptiveRewrites(
+      descriptor,
+      evaluation,
+      {
+        stopOnNoChange,
+        avoidLabels: avoidLabels ?? undefined,
+      },
+    );
+    rewrittenGraph = rewritten;
+    history = rewriteHistory;
+    rulesInvoked = Array.from(new Set(history.map((entry) => entry.rule)));
+  }
+
+  const totalApplied = history.reduce((sum, entry) => sum + entry.applied, 0);
+  const changed = totalApplied > 0;
+
+  rewrittenGraph.graphVersion = baseVersion;
+  ensureGraphIdentity(rewrittenGraph, {
+    preferId: input.graph.graph_id ?? null,
+    preferVersion: baseVersion,
+    mutated: changed,
+  });
+
+  if (changed) {
+    computationCache.invalidateGraph(rewrittenGraph.graphId);
+  }
+
+  return {
+    graph: serialiseDescriptor(rewrittenGraph),
+    history,
+    total_applied: totalApplied,
+    changed,
+    stop_on_no_change: stopOnNoChange,
+    mode: input.mode,
+    rules_invoked: rulesInvoked,
+  };
+}
+
+/**
+ * Convert human-friendly edge descriptors into the canonical `from→to`
+ * representation expected by the rewrite rules. The helper validates the
+ * format so the caller receives actionable feedback when a target is malformed.
+ */
+function normaliseEdgeTargets(raw?: string[]): Set<string> | undefined {
+  if (!raw || raw.length === 0) {
+    return undefined;
+  }
+  const targets = new Set<string>();
+  for (const entry of raw) {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const canonical = trimmed.replace(/->/g, "→");
+    const parts = canonical.split("→");
+    if (parts.length !== 2) {
+      throw new Error(
+        "split_parallel_targets entries must follow '<from>→<to>' or '<from>-><to>'",
+      );
+    }
+    const from = parts[0]?.trim();
+    const to = parts[1]?.trim();
+    if (!from || !to) {
+      throw new Error(
+        "split_parallel_targets entries must provide both source and target identifiers",
+      );
+    }
+    targets.add(`${from}→${to}`);
+  }
+  return targets.size > 0 ? targets : undefined;
+}
+
+/** Build a sanitised set from a list of strings, trimming blanks and duplicates. */
+function normaliseStringSet(raw?: string[]): Set<string> | undefined {
+  if (!raw || raw.length === 0) {
+    return undefined;
+  }
+  const values = new Set<string>();
+  for (const entry of raw) {
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    values.add(trimmed);
+  }
+  return values.size > 0 ? values : undefined;
+}
+
+/** Deduplicate and trim an optional list of strings, returning null when empty. */
+function dedupeStringList(raw?: string[]): string[] | null {
+  const set = normaliseStringSet(raw);
+  if (!set) {
+    return null;
+  }
+  return Array.from(set);
+}
+
+/**
+ * Map the caller-provided adaptive evaluation payload to the strongly-typed
+ * structure consumed by the adaptive rewrite helper.
+ */
+function mapAdaptiveEvaluation(
+  evaluation: z.infer<typeof GraphRewriteAdaptiveEvaluationSchema>,
+): AdaptiveEvaluationResult {
+  const insights = evaluation.insights.map((insight) => ({
+    edgeKey: insight.edge_key,
+    reinforcement: insight.reinforcement,
+    confidence: insight.confidence,
+    recommendation: insight.recommendation,
+    metrics: insight.metrics
+      ? {
+          successes: insight.metrics.successes,
+          failures: insight.metrics.failures,
+          totalDurationMs: insight.metrics.total_duration_ms,
+          totalReward: insight.metrics.total_reward,
+          lastUpdatedAt: insight.metrics.last_updated_at,
+          attempts: insight.metrics.attempts,
+          successRate: insight.metrics.success_rate,
+          averageDurationMs: insight.metrics.average_duration_ms,
+        }
+      : {
+          successes: 0,
+          failures: 0,
+          totalDurationMs: 0,
+          totalReward: 0,
+          lastUpdatedAt: 0,
+          attempts: 0,
+          successRate: 0,
+          averageDurationMs: 0,
+        },
+  }));
+
+  return {
+    insights,
+    edgesToBoost: evaluation.edges_to_boost,
+    edgesToPrune: evaluation.edges_to_prune,
+  };
 }
 
 /** Input payload accepted by `graph_validate`. */
@@ -1140,16 +1470,54 @@ export function handleGraphPartition(input: GraphPartitionInput): GraphPartition
   };
 }
 
-function normaliseTasks(input: GraphGenerateInput): TaskDefinition[] {
+function deriveTasks(input: GraphGenerateInput, context?: GraphGenerationContext): DerivedTasksResult {
+  const manual = normaliseTasksFromInput(input);
+  if (manual) {
+    return { tasks: manual, notes: [] };
+  }
+
+  const knowledgeEnabled = context?.knowledgeEnabled ?? true;
+  const knowledgeGraph = knowledgeEnabled ? context?.knowledgeGraph ?? undefined : undefined;
+
+  if (knowledgeGraph) {
+    const pattern = knowledgeGraph.buildPlanPattern(input.name);
+    if (pattern && pattern.tasks.length > 0) {
+      const tasks = pattern.tasks.map((task) => {
+        const metadata: Record<string, string | number | boolean> = {};
+        if (task.source) {
+          metadata.knowledge_source = task.source;
+        }
+        if (Number.isFinite(task.confidence)) {
+          metadata.knowledge_confidence = Number(task.confidence.toFixed(3));
+        }
+        return {
+          id: task.id,
+          label: task.label,
+          dependsOn: task.dependsOn,
+          duration: task.duration,
+          weight: task.weight,
+          metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+        } satisfies TaskDefinition;
+      });
+      const avg = pattern.averageConfidence;
+      const baseNote = `knowledge pattern '${pattern.plan}' applied (${pattern.tasks.length} tasks${
+        avg !== null ? `, avg_confidence=${avg.toFixed(2)}` : ""
+      })`;
+      const notes = pattern.sourceCount > 0 ? [baseNote, `knowledge sources=${pattern.sourceCount}`] : [baseNote];
+      return { tasks, notes };
+    }
+  }
+
+  throw new Error("either preset or tasks must be provided");
+}
+
+function normaliseTasksFromInput(input: GraphGenerateInput): TaskDefinition[] | null {
   const tasks: TaskDefinition[] = [];
   if (input.preset) {
     tasks.push(...(PRESET_LIBRARY[input.preset] ?? []));
   }
   if (!input.tasks) {
-    if (tasks.length === 0) {
-      throw new Error("either preset or tasks must be provided");
-    }
-    return tasks;
+    return tasks.length > 0 ? tasks : null;
   }
   const parsed = parseTaskSource(input.tasks);
   tasks.push(...parsed);

--- a/src/tools/knowledgeTools.ts
+++ b/src/tools/knowledgeTools.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+
+import type { KnowledgeGraph, KnowledgeTripleSnapshot } from "../knowledge/knowledgeGraph.js";
+import { StructuredLogger } from "../logger.js";
+
+/** Context injected by the server when invoking knowledge graph tools. */
+export interface KnowledgeToolContext {
+  /** Shared knowledge graph storing task and plan triples. */
+  knowledgeGraph: KnowledgeGraph;
+  /** Structured logger used for auditability. */
+  logger: StructuredLogger;
+}
+
+/** Schema describing a single triple accepted by the insert tool. */
+const KnowledgeTripleInputSchema = z
+  .object({
+    subject: z.string().min(1, "subject must not be empty"),
+    predicate: z.string().min(1, "predicate must not be empty"),
+    object: z.string().min(1, "object must not be empty"),
+    source: z.string().min(1).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+  })
+  .strict();
+
+/** Schema validating the payload accepted by the `kg_insert` tool. */
+export const KgInsertInputSchema = z
+  .object({
+    triples: z.array(KnowledgeTripleInputSchema).min(1).max(256),
+  })
+  .strict();
+export const KgInsertInputShape = KgInsertInputSchema.shape;
+
+/** Schema validating the payload accepted by the `kg_query` tool. */
+export const KgQueryInputSchema = z
+  .object({
+    subject: z.string().min(1).optional(),
+    predicate: z.string().min(1).optional(),
+    object: z.string().min(1).optional(),
+    source: z.string().min(1).optional(),
+    min_confidence: z.number().min(0).max(1).optional(),
+    limit: z.number().int().min(1).max(500).default(50),
+    order: z.enum(["asc", "desc"]).default("asc"),
+  })
+  .strict();
+export const KgQueryInputShape = KgQueryInputSchema.shape;
+
+/** Schema validating the payload accepted by the `kg_export` tool. */
+export const KgExportInputSchema = z.object({}).strict();
+export const KgExportInputShape = KgExportInputSchema.shape;
+
+interface SerializedTriple extends Record<string, unknown> {
+  id: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  source: string | null;
+  confidence: number;
+  inserted_at: number;
+  updated_at: number;
+  revision: number;
+  ordinal: number;
+}
+
+/** Result returned by {@link handleKgInsert}. */
+export interface KgInsertResult extends Record<string, unknown> {
+  inserted: SerializedTriple[];
+  created: number;
+  updated: number;
+  total: number;
+}
+
+/** Result returned by {@link handleKgQuery}. */
+export interface KgQueryResult extends Record<string, unknown> {
+  triples: SerializedTriple[];
+  total: number;
+  next_cursor: number | null;
+}
+
+/** Result returned by {@link handleKgExport}. */
+export interface KgExportResult extends Record<string, unknown> {
+  triples: SerializedTriple[];
+  total: number;
+}
+
+/** Stores or updates a batch of triples on the knowledge graph. */
+export function handleKgInsert(
+  context: KnowledgeToolContext,
+  input: z.infer<typeof KgInsertInputSchema>,
+): KgInsertResult {
+  let created = 0;
+  let updated = 0;
+  const inserted = input.triples.map((triple) => {
+    const result = context.knowledgeGraph.insert(triple);
+    if (result.created) created += 1;
+    if (result.updated) updated += 1;
+    return serializeTriple(result.snapshot);
+  });
+  const total = context.knowledgeGraph.count();
+  context.logger.info("kg_insert", {
+    triples: input.triples.length,
+    created,
+    updated,
+    total,
+  });
+  return { inserted, created, updated, total };
+}
+
+/** Queries triples matching the provided motif and returns deterministic slices. */
+export function handleKgQuery(
+  context: KnowledgeToolContext,
+  input: z.infer<typeof KgQueryInputSchema>,
+): KgQueryResult {
+  const triples = context.knowledgeGraph.query(
+    {
+      subject: input.subject,
+      predicate: input.predicate,
+      object: input.object,
+      source: input.source,
+      minConfidence: input.min_confidence,
+    },
+    { limit: input.limit, order: input.order },
+  );
+  const serialised = triples.map(serializeTriple);
+  const nextCursor = serialised.length ? serialised[serialised.length - 1].ordinal : null;
+  context.logger.info("kg_query", {
+    subject: input.subject ?? null,
+    predicate: input.predicate ?? null,
+    object: input.object ?? null,
+    source: input.source ?? null,
+    returned: serialised.length,
+    limit: input.limit,
+  });
+  return { triples: serialised, total: serialised.length, next_cursor: nextCursor };
+}
+
+/** Dumps the entire knowledge graph in insertion order. */
+export function handleKgExport(
+  context: KnowledgeToolContext,
+  _input: z.infer<typeof KgExportInputSchema>,
+): KgExportResult {
+  const triples = context.knowledgeGraph.exportAll().map(serializeTriple);
+  context.logger.info("kg_export", { total: triples.length });
+  return { triples, total: triples.length };
+}
+
+function serializeTriple(snapshot: KnowledgeTripleSnapshot): SerializedTriple {
+  return {
+    id: snapshot.id,
+    subject: snapshot.subject,
+    predicate: snapshot.predicate,
+    object: snapshot.object,
+    source: snapshot.source,
+    confidence: snapshot.confidence,
+    inserted_at: snapshot.insertedAt,
+    updated_at: snapshot.updatedAt,
+    revision: snapshot.revision,
+    ordinal: snapshot.ordinal,
+  };
+}

--- a/src/tools/planTools.ts
+++ b/src/tools/planTools.ts
@@ -5,8 +5,36 @@ import { z } from "zod";
 
 import { ChildCollectedOutputs, ChildRuntimeMessage } from "../childRuntime.js";
 import { ChildSupervisor } from "../childSupervisor.js";
+import { compileHierGraphToBehaviorTree } from "../executor/bt/compiler.js";
+import { BehaviorTreeInterpreter, buildBehaviorTree } from "../executor/bt/interpreter.js";
+import {
+  BehaviorNodeDefinitionSchema,
+  CompiledBehaviorTreeSchema,
+  type BTStatus,
+  type BehaviorTickResult,
+  type TickRuntime,
+} from "../executor/bt/types.js";
+import { ReactiveScheduler } from "../executor/reactiveScheduler.js";
+import {
+  ConsensusConfigSchema,
+  majority as computeConsensusMajority,
+  normaliseConsensusOptions,
+  quorum as computeConsensusQuorum,
+  weighted as computeConsensusWeighted,
+  type ConsensusDecision,
+  type ConsensusVote,
+} from "../coord/consensus.js";
+import { StigmergyField } from "../coord/stigmergy.js";
+import type { CausalMemory } from "../knowledge/causalMemory.js";
+import type {
+  ValueFilterDecision,
+  ValueGraph,
+  ValueImpactInput,
+  ValueViolation,
+} from "../values/valueGraph.js";
 import { GraphState } from "../graphState.js";
 import { StructuredLogger } from "../logger.js";
+import { OrchestratorSupervisor } from "../agents/supervisor.js";
 import { ensureDirectory, resolveWithin } from "../paths.js";
 import {
   PromptTemplate,
@@ -30,6 +58,14 @@ export type PlanEventEmitter = (event: {
   payload?: unknown;
 }) => void;
 
+/** Shared runtime injected when the value guard feature is enabled. */
+export interface ValueGuardRuntime {
+  /** Configured value graph storing principles and relations. */
+  graph: ValueGraph;
+  /** Registry keeping the last decision taken for each child id. */
+  registry: Map<string, ValueFilterDecision>;
+}
+
 /**
  * Context shared by the plan tool handlers. The orchestrator injects the
  * supervisor to control child runtimes, the mutable {@link GraphState} and the
@@ -48,10 +84,178 @@ export interface PlanToolContext {
   defaultChildRuntime: string;
   /** Callback used to emit high level orchestration events. */
   emitEvent: PlanEventEmitter;
+  /** Shared stigmergic field used to influence scheduling priorities. */
+  stigmergy: StigmergyField;
+  /** Optional orchestrator supervisor handling loop and stagnation mitigation. */
+  supervisorAgent?: OrchestratorSupervisor;
+  /** Optional causal memory capturing scheduler and Behaviour Tree events. */
+  causalMemory?: CausalMemory;
+  /** Optional value guard filtering unsafe plans before execution. */
+  valueGuard?: ValueGuardRuntime;
+}
+
+/**
+ * Produces a compact JSON-serialisable summary suitable for causal memory
+ * storage. Large strings are truncated and deep objects are collapsed to keep
+ * artefacts lightweight while preserving signal for diagnostics.
+ */
+function summariseForCausalMemory(value: unknown, depth = 0): unknown {
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value.length > 200 ? `${value.slice(0, 200)}…` : value;
+  }
+  if (Array.isArray(value)) {
+    if (depth >= 2) {
+      return `array(${value.length})`;
+    }
+    const window = value.slice(0, 5).map((item) => summariseForCausalMemory(item, depth + 1));
+    if (value.length > 5) {
+      window.push(`…${value.length - 5} more`);
+    }
+    return window;
+  }
+  if (typeof value === "object" && value !== undefined) {
+    if (depth >= 2) {
+      return "object";
+    }
+    const entries = Object.entries(value as Record<string, unknown>);
+    const summary: Record<string, unknown> = {};
+    for (const [key, entry] of entries.slice(0, 6)) {
+      summary[key] = summariseForCausalMemory(entry, depth + 1);
+    }
+    if (entries.length > 6) {
+      summary.__truncated__ = `${entries.length - 6} more`;
+    }
+    return summary;
+  }
+  if (typeof value === "undefined") {
+    return null;
+  }
+  return String(value);
+}
+
+/** Snapshot persisted when surfacing value guard decisions to callers. */
+export interface ValueGuardSnapshot extends Record<string, unknown> {
+  allowed: boolean;
+  score: number;
+  total: number;
+  threshold: number;
+  violations: ValueViolation[];
+}
+
+function serialiseValueGuardDecision(
+  decision: ValueFilterDecision | null | undefined,
+): ValueGuardSnapshot | null {
+  if (!decision) {
+    return null;
+  }
+  return {
+    allowed: decision.allowed,
+    score: decision.score,
+    total: decision.total,
+    threshold: decision.threshold,
+    violations: decision.violations,
+  };
+}
+
+/** Error raised when every fan-out branch violates the configured values. */
+export class ValueGuardRejectionError extends Error {
+  public readonly code = "E-VALUES-VIOLATION";
+  public readonly rejections: Array<{ name: string; decision: ValueFilterDecision }>;
+
+  constructor(rejections: Array<{ name: string; decision: ValueFilterDecision }>) {
+    super("All planned children were rejected by the value guard");
+    this.name = "ValueGuardRejectionError";
+    this.rejections = rejections;
+  }
+}
+
+/**
+ * Error raised when consensus-based reducers cannot reach the required quorum.
+ * The decision payload is embedded so operators can inspect tallies when
+ * debugging the rejection.
+ */
+export class ConsensusNoQuorumError extends Error {
+  public readonly code = "E-CONSENSUS-NO-QUORUM";
+  public readonly details: { decision: ConsensusDecision };
+
+  constructor(decision: ConsensusDecision) {
+    super("Consensus reducer failed to reach the required quorum");
+    this.name = "ConsensusNoQuorumError";
+    this.details = { decision };
+  }
+}
+
+/**
+ * Error raised when Behaviour Tree execution exceeds the configured runtime
+ * budget. The caller receives the timeout so it can adjust thresholds or retry
+ * with a simplified plan.
+ */
+export class BehaviorTreeRunTimeoutError extends Error {
+  public readonly code = "E-BT-RUN-TIMEOUT";
+  public readonly details: { timeoutMs: number };
+
+  constructor(timeoutMs: number) {
+    super(`Behaviour Tree execution timed out after ${timeoutMs}ms`);
+    this.name = "BehaviorTreeRunTimeoutError";
+    this.details = { timeoutMs };
+  }
 }
 
 /** Type of the prompt template payload accepted by the fan-out tool. */
 export type PlanPromptTemplateInput = z.infer<typeof PromptTemplateSchema>;
+
+/** Schema validating scalar graph attribute values used by the BT compiler. */
+const GraphAttributeValueSchema = z.union([z.string(), z.number(), z.boolean()]);
+
+/** Schema describing task nodes within a hierarchical graph. */
+const HierTaskNodeSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal("task"),
+  label: z.string().optional(),
+  attributes: z.record(GraphAttributeValueSchema).default({}),
+  inputs: z.array(z.string()).optional(),
+  outputs: z.array(z.string()).optional(),
+});
+
+/** Schema describing sub-graph nodes within a hierarchical graph. */
+const HierSubgraphNodeSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal("subgraph"),
+  ref: z.string().min(1),
+  params: z.record(z.unknown()).optional(),
+});
+
+/** Schema describing hierarchical graph edges. */
+const HierEdgeSchema = z.object({
+  id: z.string().min(1),
+  from: z.object({ nodeId: z.string().min(1), port: z.string().optional() }),
+  to: z.object({ nodeId: z.string().min(1), port: z.string().optional() }),
+  label: z.string().optional(),
+  attributes: z.record(GraphAttributeValueSchema).optional(),
+});
+
+/** Schema validating hierarchical graph payloads. */
+const HierGraphSchema = z.object({
+  id: z.string().min(1),
+  nodes: z
+    .array(z.discriminatedUnion("kind", [HierTaskNodeSchema, HierSubgraphNodeSchema]))
+    .min(1),
+  edges: z.array(HierEdgeSchema).default([]),
+});
+
+/** Declarative impact payload plugged into the value guard. */
+const ValueImpactSchema = z
+  .object({
+    value: z.string().min(1, "value impact must reference a value id"),
+    impact: z.enum(["support", "risk"]).default("risk"),
+    severity: z.number().min(0).max(1).optional(),
+    rationale: z.string().min(1).max(240).optional(),
+    source: z.string().min(1).optional(),
+  })
+  .strict();
 
 /** Blueprint for a single child produced by the fan-out planner. */
 const ChildPlanSchema = z.object({
@@ -66,6 +270,7 @@ const ChildPlanSchema = z.object({
   manifest_extras: z.record(z.unknown()).optional(),
   prompt_variables: PromptVariablesSchema.optional(),
   ttl_s: z.number().int().positive().optional(),
+  value_impacts: z.array(ValueImpactSchema).max(32).optional(),
 });
 
 /** List-based specification of the clones that must be spawned. */
@@ -83,6 +288,7 @@ const ChildrenCountSpecSchema = z.object({
   metadata: z.record(z.unknown()).optional(),
   manifest_extras: z.record(z.unknown()).optional(),
   prompt_variables: PromptVariablesSchema.optional(),
+  value_impacts: z.array(ValueImpactSchema).max(32).optional(),
 });
 
 /** Union describing the two accepted ways of declaring the fan-out. */
@@ -130,8 +336,13 @@ export interface PlanFanoutResult extends Record<string, unknown> {
     manifest_path: string;
     log_path: string;
     ready_message: unknown | null;
+    value_guard: ValueGuardSnapshot | null;
   }>;
   prompt_template: PlanPromptTemplateInput;
+  rejected_plans: Array<{
+    name: string;
+    value_guard: ValueGuardSnapshot | null;
+  }>;
 }
 
 /** Schema describing the supported join policies. */
@@ -143,6 +354,7 @@ export const PlanJoinInputSchema = z.object({
   join_policy: JoinPolicySchema.default("all"),
   timeout_sec: z.number().int().positive().optional(),
   quorum_count: z.number().int().positive().optional(),
+  consensus: ConsensusConfigSchema.optional(),
 });
 
 export type PlanJoinInput = z.infer<typeof PlanJoinInputSchema>;
@@ -165,6 +377,15 @@ export interface PlanJoinResult extends Record<string, unknown> {
     summary: string | null;
     artifacts: ChildCollectedOutputs["artifacts"];
   }>;
+  consensus?: {
+    mode: "majority" | "quorum" | "weighted";
+    outcome: string | null;
+    satisfied: boolean;
+    tie: boolean;
+    threshold: number | null;
+    total_weight: number;
+    tally: Record<string, number>;
+  };
 }
 
 /** Input payload accepted by the `plan_reduce` tool. */
@@ -186,10 +407,56 @@ export interface PlanReduceResult extends Record<string, unknown> {
       child_id: string;
       summary: string | null;
       artifacts: ChildCollectedOutputs["artifacts"];
+      value_guard?: ValueGuardSnapshot | null;
     }>;
     details?: Record<string, unknown>;
   };
 }
+
+/** Input payload accepted by the `plan_compile_bt` tool. */
+export const PlanCompileBTInputSchema = z.object({
+  graph: HierGraphSchema,
+});
+
+export type PlanCompileBTInput = z.infer<typeof PlanCompileBTInputSchema>;
+export type PlanCompileBTResult = z.infer<typeof CompiledBehaviorTreeSchema>;
+export const PlanCompileBTInputShape = PlanCompileBTInputSchema.shape;
+
+/** Input payload accepted by the `plan_run_bt` tool. */
+export const PlanRunBTInputSchema = z.object({
+  tree: CompiledBehaviorTreeSchema,
+  variables: z.record(z.unknown()).default({}),
+  dry_run: z.boolean().default(false),
+  timeout_ms: z.number().int().min(1).max(60_000).optional(),
+});
+
+export type PlanRunBTInput = z.infer<typeof PlanRunBTInputSchema>;
+export const PlanRunBTInputShape = PlanRunBTInputSchema.shape;
+
+/** Result returned by {@link handlePlanRunBT}. */
+export interface PlanRunBTResult extends Record<string, unknown> {
+  status: BTStatus;
+  ticks: number;
+  last_output: unknown;
+  invocations: Array<{
+    tool: string;
+    input: unknown;
+    output: unknown;
+    executed: boolean;
+  }>;
+}
+
+/** Default schema registry used by the Behaviour Tree interpreter. */
+const BehaviorTaskSchemas: Record<string, z.ZodTypeAny> = {
+  noop: z.any(),
+};
+
+/** Tool handlers executed by the Behaviour Tree interpreter. */
+type BehaviorToolHandler = (context: PlanToolContext, input: unknown) => Promise<unknown>;
+
+const BehaviorToolHandlers: Record<string, BehaviorToolHandler> = {
+  noop: async (_context, input) => input ?? null,
+};
 
 /** Internal representation of a child plan resolved from the input payload. */
 interface ResolvedChildPlan {
@@ -204,6 +471,8 @@ interface ResolvedChildPlan {
   manifestExtras?: Record<string, unknown>;
   promptVariables: Record<string, string | number | boolean>;
   ttlSeconds?: number;
+  valueImpacts?: ValueImpactInput[];
+  valueDecision?: ValueFilterDecision | null;
 }
 
 /** Result returned after spawning a child runtime. */
@@ -217,6 +486,7 @@ interface SpawnedChildInfo {
   manifestPath: string;
   logPath: string;
   readyMessage: unknown | null;
+  valueGuard: ValueGuardSnapshot | null;
 }
 
 function resolveChildrenPlans(
@@ -237,6 +507,7 @@ function resolveChildrenPlans(
         manifestExtras: child.manifest_extras,
         promptVariables: { ...(child.prompt_variables ?? {}) },
         ttlSeconds: child.ttl_s,
+        valueImpacts: child.value_impacts?.map((impact) => ({ ...impact })),
       }));
     }
 
@@ -254,6 +525,7 @@ function resolveChildrenPlans(
           ...(base.prompt_variables ?? {}),
           child_index: index + 1,
         },
+        valueImpacts: base.value_impacts?.map((impact) => ({ ...impact })),
       });
     }
     return plans;
@@ -272,6 +544,7 @@ function resolveChildrenPlans(
       manifestExtras: child.manifest_extras,
       promptVariables: { ...(child.prompt_variables ?? {}) },
       ttlSeconds: child.ttl_s,
+      valueImpacts: child.value_impacts?.map((impact) => ({ ...impact })),
     }));
   }
 
@@ -302,6 +575,8 @@ async function spawnChildWithRetry(
 ): Promise<SpawnedChildInfo> {
   const childId = `child_${randomUUID()}`;
   const createdAt = Date.now();
+  const guardDecision = plan.valueDecision ?? null;
+  const guardSnapshot = serialiseValueGuardDecision(guardDecision);
 
   context.graphState.createChild(
     jobId,
@@ -350,6 +625,7 @@ async function spawnChildWithRetry(
           job_id: jobId,
           child_name: plan.name,
           prompt_variables: variables,
+          value_guard: guardSnapshot,
         },
         manifestExtras: {
           ...(plan.manifestExtras ?? {}),
@@ -384,6 +660,10 @@ async function spawnChildWithRetry(
         waitingFor: "response",
       });
 
+      if (guardDecision && context.valueGuard) {
+        context.valueGuard.registry.set(childId, guardDecision);
+      }
+
       return {
         childId,
         name: plan.name,
@@ -396,6 +676,7 @@ async function spawnChildWithRetry(
         readyMessage: created.readyMessage
           ? created.readyMessage.parsed ?? created.readyMessage.raw
           : null,
+        valueGuard: guardSnapshot,
       };
     } catch (error) {
       context.logger.error("plan_fanout_spawn_failed", {
@@ -457,7 +738,47 @@ export async function handlePlanFanout(
   context: PlanToolContext,
   input: PlanFanoutInput,
 ): Promise<PlanFanoutResult> {
-  const plans = resolveChildrenPlans(input, context.defaultChildRuntime);
+  const resolvedPlans = resolveChildrenPlans(input, context.defaultChildRuntime);
+  const rejectedPlans: Array<{ name: string; decision: ValueFilterDecision }> = [];
+
+  const plans: ResolvedChildPlan[] = [];
+  if (context.valueGuard) {
+    for (const plan of resolvedPlans) {
+      if (!plan.valueImpacts?.length) {
+        plan.valueDecision = null;
+        plans.push(plan);
+        continue;
+      }
+      const decision = context.valueGuard.graph.filter({
+        id: plan.name,
+        label: plan.name,
+        impacts: plan.valueImpacts,
+      });
+      plan.valueDecision = decision;
+      if (!decision.allowed) {
+        rejectedPlans.push({ name: plan.name, decision });
+        context.logger.warn("plan_fanout_value_guard_reject", {
+          child_name: plan.name,
+          score: decision.score,
+          threshold: decision.threshold,
+          violations: decision.violations.length,
+        });
+        continue;
+      }
+      plans.push(plan);
+    }
+    if (plans.length === 0) {
+      throw new ValueGuardRejectionError(rejectedPlans);
+    }
+    if (rejectedPlans.length > 0) {
+      context.logger.warn("plan_fanout_value_guard_filtered", {
+        rejected: rejectedPlans.length,
+        allowed: plans.length,
+      });
+    }
+  } else {
+    plans.push(...resolvedPlans);
+  }
 
   const promptTemplate: PromptTemplate = {
     system: input.prompt_template.system,
@@ -487,6 +808,7 @@ export async function handlePlanFanout(
     payload: {
       run_id: runId,
       children: plans.map((plan) => ({ name: plan.name, runtime: plan.runtime })),
+      rejected: rejectedPlans.map((entry) => entry.name),
     },
   });
 
@@ -519,6 +841,10 @@ export async function handlePlanFanout(
 
   const runDirectory = await ensureDirectory(context.childrenRoot, runId);
   const mappingPath = resolveWithin(runDirectory, "fanout.json");
+  const serialisedRejections = rejectedPlans.map((entry) => ({
+    name: entry.name,
+    value_guard: serialiseValueGuardDecision(entry.decision),
+  }));
   const mappingPayload = {
     run_id: runId,
     created_at: createdAt,
@@ -533,7 +859,9 @@ export async function handlePlanFanout(
       prompt_summary: child.promptSummary,
       manifest_path: child.manifestPath,
       log_path: child.logPath,
+      value_guard: child.valueGuard,
     })),
+    rejected_plans: serialisedRejections,
   };
 
   await writeFile(mappingPath, JSON.stringify(mappingPayload, null, 2), "utf8");
@@ -552,8 +880,10 @@ export async function handlePlanFanout(
       manifest_path: child.manifestPath,
       log_path: child.logPath,
       ready_message: child.readyMessage,
+      value_guard: child.valueGuard,
     })),
     prompt_template: input.prompt_template,
+    rejected_plans: serialisedRejections,
   };
 }
 
@@ -675,6 +1005,52 @@ export async function handlePlanJoin(
     return a.receivedAt - b.receivedAt;
   });
 
+  const statusVotes: ConsensusVote[] = observations.map((obs) => ({
+    voter: obs.childId,
+    value: obs.status,
+  }));
+  const baseQuorum = input.quorum_count ?? Math.ceil(input.children.length / 2);
+  const consensusConfig = input.consensus
+    ? ConsensusConfigSchema.parse(input.consensus)
+    : undefined;
+  let consensusDecision: ConsensusDecision | null = null;
+  if (consensusConfig) {
+    const options = normaliseConsensusOptions(consensusConfig);
+    if (!options.preferValue) {
+      options.preferValue = "success";
+    }
+    const { quorum: configuredQuorum, ...baseOptions } = options;
+    switch (consensusConfig.mode) {
+      case "majority":
+        consensusDecision = computeConsensusMajority(statusVotes, baseOptions);
+        break;
+      case "weighted":
+        consensusDecision = computeConsensusWeighted(statusVotes, {
+          ...baseOptions,
+          quorum: configuredQuorum ?? (input.join_policy === "quorum" ? baseQuorum : undefined),
+        });
+        break;
+      case "quorum":
+      default: {
+        const quorumThreshold = configuredQuorum ?? baseQuorum;
+        consensusDecision = computeConsensusQuorum(statusVotes, {
+          ...baseOptions,
+          quorum: quorumThreshold,
+        });
+        break;
+      }
+    }
+  }
+  if (!consensusDecision && input.join_policy === "quorum") {
+    const defaults = normaliseConsensusOptions(undefined);
+    defaults.preferValue = "success";
+    const { quorum: configuredQuorum, ...baseOptions } = defaults;
+    consensusDecision = computeConsensusQuorum(statusVotes, {
+      ...baseOptions,
+      quorum: configuredQuorum ?? baseQuorum,
+    });
+  }
+
   let satisfied = false;
   let threshold: number | null = null;
   switch (input.join_policy) {
@@ -686,9 +1062,13 @@ export async function handlePlanJoin(
       threshold = 1;
       break;
     case "quorum": {
-      const candidateThreshold = input.quorum_count ?? Math.ceil(input.children.length / 2);
-      threshold = candidateThreshold;
-      satisfied = successes.length >= candidateThreshold;
+      threshold = consensusDecision?.threshold ?? baseQuorum;
+      if (consensusDecision) {
+        satisfied =
+          consensusDecision.outcome === "success" && consensusDecision.satisfied;
+      } else {
+        satisfied = successes.length >= (threshold ?? baseQuorum);
+      }
       break;
     }
     default:
@@ -697,6 +1077,18 @@ export async function handlePlanJoin(
 
   const winningChild = sorted.find((obs) => obs.status === "success")?.childId ?? null;
 
+  const consensusPayload = consensusDecision
+    ? {
+        mode: consensusDecision.mode,
+        outcome: consensusDecision.outcome,
+        satisfied: consensusDecision.satisfied,
+        tie: consensusDecision.tie,
+        threshold: consensusDecision.threshold,
+        total_weight: consensusDecision.totalWeight,
+        tally: consensusDecision.tally,
+      }
+    : undefined;
+
   context.emitEvent({
     kind: "STATUS",
     payload: {
@@ -704,6 +1096,7 @@ export async function handlePlanJoin(
       satisfied,
       successes: successes.length,
       failures: failures.length,
+      consensus: consensusPayload,
     },
   });
 
@@ -713,6 +1106,8 @@ export async function handlePlanJoin(
     successes: successes.length,
     failures: failures.length,
     winning_child_id: winningChild,
+    consensus_mode: consensusPayload?.mode ?? null,
+    consensus_outcome: consensusPayload?.outcome ?? null,
   });
 
   return {
@@ -731,6 +1126,7 @@ export async function handlePlanJoin(
       summary: obs.summary,
       artifacts: obs.outputs?.artifacts ?? [],
     })),
+    consensus: consensusPayload,
   };
 }
 
@@ -751,6 +1147,57 @@ function summariseChildOutputs(outputs: ChildCollectedOutputs): string | null {
 }
 
 /**
+ * Normalises a child summary into a consensus vote value.
+ *
+ * The reducer historically expected children to return JSON objects shaped as
+ * `{ "vote": "A" }`. When the payloads also contain contextual metadata
+ * (indices, timestamps, …) the raw string differs per child which prevents the
+ * majority/quorum helpers from finding a winner. This helper extracts the
+ * stabilised "vote" choice when present while keeping graceful fallbacks:
+ *
+ * - `{ vote: "A" }` ⇒ `"A"`
+ * - `{ value: "B" }` ⇒ `"B"`
+ * - primitive JSON (string/number/boolean) ⇒ canonical string form
+ * - arbitrary string ⇒ trimmed string (kept for backwards compatibility)
+ *
+ * Returning `null` signals that the child response cannot participate in the
+ * vote (for instance when the summary is empty). The caller records the source
+ * used so diagnostics remain explorable in traces.
+ */
+function normaliseVoteSummary(summary: string): { value: string | null; source: string } {
+  const trimmed = summary.trim();
+  if (!trimmed) {
+    return { value: null, source: "empty" };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "string" || typeof parsed === "number" || typeof parsed === "boolean") {
+      return { value: String(parsed), source: typeof parsed };
+    }
+    if (parsed && typeof parsed === "object") {
+      const candidate = parsed as Record<string, unknown>;
+      if (typeof candidate.vote === "string" && candidate.vote.trim().length > 0) {
+        return { value: candidate.vote, source: "json.vote" };
+      }
+      if (typeof candidate.value === "string" && candidate.value.trim().length > 0) {
+        return { value: candidate.value, source: "json.value" };
+      }
+      if (typeof candidate.vote === "number" || typeof candidate.vote === "boolean") {
+        return { value: String(candidate.vote), source: "json.vote" };
+      }
+      if (typeof candidate.value === "number" || typeof candidate.value === "boolean") {
+        return { value: String(candidate.value), source: "json.value" };
+      }
+    }
+  } catch {
+    // Ignore parse failures and fall back to the trimmed string below.
+  }
+
+  return { value: trimmed, source: "raw" };
+}
+
+/**
  * Reduces the responses of multiple children using strategies such as
  * concatenation, JSON merge or majority vote.
  */
@@ -762,10 +1209,24 @@ export async function handlePlanReduce(
     input.children.map((childId) => context.supervisor.collect(childId)),
   );
 
+  const guardDecisions = new Map<string, ValueFilterDecision>();
+  if (context.valueGuard) {
+    for (const childId of input.children) {
+      const decision = context.valueGuard.registry.get(childId);
+      if (decision) {
+        guardDecisions.set(childId, decision);
+        context.valueGuard.registry.delete(childId);
+      }
+    }
+  }
+
   const summaries = outputs.map((output) => ({
     child_id: output.childId,
     summary: summariseChildOutputs(output),
     artifacts: output.artifacts,
+    value_guard: guardDecisions.has(output.childId)
+      ? serialiseValueGuardDecision(guardDecisions.get(output.childId))
+      : null,
   }));
 
   context.logger.info("plan_reduce", {
@@ -828,25 +1289,87 @@ export async function handlePlanReduce(
       break;
     }
     case "vote": {
-      const tally = new Map<string, number>();
+      const voteConfig = ConsensusConfigSchema.parse(input.spec ?? {});
+      const options = normaliseConsensusOptions(voteConfig);
+      const { quorum: configuredQuorum, ...baseOptions } = options;
+      const voteSources: Record<string, { value: string | null; source: string }> = {};
+      const votes: ConsensusVote[] = [];
       for (const item of summaries) {
-        if (!item.summary) continue;
-        tally.set(item.summary, (tally.get(item.summary) ?? 0) + 1);
-      }
-      let winner: { value: string; count: number } | null = null;
-      for (const [value, count] of tally.entries()) {
-        if (!winner || count > winner.count) {
-          winner = { value, count };
+        if (typeof item.summary !== "string") {
+          continue;
         }
+        const { value, source } = normaliseVoteSummary(item.summary);
+        voteSources[item.child_id] = { value, source };
+        if (value !== null) {
+          votes.push({ voter: item.child_id, value });
+        }
+      }
+
+      const adjustedWeights: Record<string, number> = { ...(baseOptions.weights ?? {}) };
+      for (const vote of votes) {
+        const baseWeight = adjustedWeights[vote.voter] ?? baseOptions.weights?.[vote.voter] ?? 1;
+        const guardWeight = guardDecisions.has(vote.voter)
+          ? Math.max(0, guardDecisions.get(vote.voter)!.score)
+          : 1;
+        const weight = baseWeight * guardWeight;
+        adjustedWeights[vote.voter] = Number.isFinite(weight) && weight >= 0 ? weight : 0;
+      }
+
+      const weightFor = (vote: ConsensusVote) => {
+        const candidate = adjustedWeights[vote.voter];
+        return typeof candidate === "number" && candidate >= 0 ? candidate : 1;
+      };
+      const totalWeight = votes.reduce((acc, vote) => acc + weightFor(vote), 0);
+      const defaultQuorum = configuredQuorum ?? (totalWeight > 0 ? Math.floor(totalWeight / 2) + 1 : 1);
+
+      let decision: ConsensusDecision;
+      switch (voteConfig.mode) {
+        case "majority":
+          decision = computeConsensusMajority(votes, { ...baseOptions, weights: adjustedWeights });
+          break;
+        case "weighted":
+          decision = computeConsensusWeighted(votes, {
+            ...baseOptions,
+            quorum: configuredQuorum,
+            weights: adjustedWeights,
+          });
+          break;
+        case "quorum":
+        default:
+          decision = computeConsensusQuorum(votes, {
+            ...baseOptions,
+            quorum: defaultQuorum,
+            weights: adjustedWeights,
+          });
+          break;
+      }
+
+      if (!decision.satisfied) {
+        throw new ConsensusNoQuorumError(decision);
+      }
+
+      const aggregate = {
+        mode: decision.mode,
+        value: decision.outcome,
+        satisfied: decision.satisfied,
+        tie: decision.tie,
+        threshold: decision.threshold,
+        total_weight: decision.totalWeight,
+        tally: decision.tally,
+      };
+      const traceDetails: Record<string, unknown> = { consensus: aggregate };
+      if (guardDecisions.size) {
+        traceDetails.value_guard_weights = adjustedWeights;
+      }
+      if (Object.keys(voteSources).length) {
+        traceDetails.vote_sources = voteSources;
       }
       result = {
         reducer: input.reducer,
-        aggregate: winner,
+        aggregate,
         trace: {
           per_child: summaries,
-          details: {
-            tally: Object.fromEntries(tally.entries()),
-          },
+          details: traceDetails,
         },
       };
       break;
@@ -871,6 +1394,18 @@ export async function handlePlanReduce(
       throw new Error(`Unsupported reducer: ${input.reducer}`);
   }
 
+  if (guardDecisions.size) {
+    const guardTrace = Object.fromEntries(
+      Array.from(guardDecisions.entries()).map(([childId, decision]) => [
+        childId,
+        serialiseValueGuardDecision(decision),
+      ]),
+    );
+    const details = result.trace.details ? { ...result.trace.details } : {};
+    details.value_guard = guardTrace;
+    result.trace.details = details;
+  }
+
   context.logger.info("plan_reduce_completed", {
     reducer: input.reducer,
     aggregate_kind: typeof result.aggregate,
@@ -878,4 +1413,182 @@ export async function handlePlanReduce(
   });
 
   return result;
+}
+
+/**
+ * Compile a hierarchical graph into a serialised Behaviour Tree definition. The
+ * compiler is deterministic which keeps downstream tests and audits reliable.
+ */
+export function handlePlanCompileBT(
+  context: PlanToolContext,
+  input: PlanCompileBTInput,
+): PlanCompileBTResult {
+  context.logger.info("plan_compile_bt", { graph_id: input.graph.id });
+  const compiled = compileHierGraphToBehaviorTree(input.graph);
+  return CompiledBehaviorTreeSchema.parse(compiled);
+}
+
+/**
+ * Execute a Behaviour Tree by delegating leaf nodes to orchestrator tools. The
+ * interpreter records every invocation so tests and operators can trace the
+ * decision flow precisely.
+ */
+export async function handlePlanRunBT(
+  context: PlanToolContext,
+  input: PlanRunBTInput,
+): Promise<PlanRunBTResult> {
+  const schemaRegistry = { ...BehaviorTaskSchemas };
+  const interpreter = new BehaviorTreeInterpreter(
+    buildBehaviorTree(input.tree.root, { taskSchemas: schemaRegistry }),
+  );
+  const invocations: PlanRunBTResult["invocations"] = [];
+  let lastOutput: unknown = null;
+  let lastResultStatus: BTStatus = "running";
+
+  const dryRun = input.dry_run ?? false;
+  context.logger.info("plan_run_bt", {
+    tree_id: input.tree.id,
+    dry_run: dryRun,
+  });
+
+  const causalMemory = context.causalMemory;
+  let scheduler: ReactiveScheduler;
+
+  const runtime = {
+    invokeTool: async (tool: string, taskInput: unknown) => {
+      if (dryRun) {
+        invocations.push({ tool, input: taskInput, output: null, executed: false });
+        return null;
+      }
+      const handler = BehaviorToolHandlers[tool];
+      if (!handler) {
+        throw new Error(`Unknown behaviour tree tool ${tool}`);
+      }
+      const parentId = causalMemory && scheduler ? scheduler.getCurrentTickCausalEventId() : null;
+      const parentCauses = parentId ? [parentId] : [];
+      const invocationEvent = causalMemory
+        ? causalMemory.record(
+            {
+              type: "bt.tool.invoke",
+              data: { tool, input: summariseForCausalMemory(taskInput) },
+              tags: ["bt", "tool", tool],
+            },
+            parentCauses,
+          )
+        : null;
+      try {
+        const output = await handler(context, taskInput);
+        invocations.push({ tool, input: taskInput, output, executed: true });
+        lastOutput = output;
+        if (causalMemory) {
+          causalMemory.record(
+            {
+              type: "bt.tool.success",
+              data: { tool, output: summariseForCausalMemory(output) },
+              tags: ["bt", "tool", "success", tool],
+            },
+            invocationEvent ? [invocationEvent.id] : parentCauses,
+          );
+        }
+        return output;
+      } catch (error) {
+        if (causalMemory) {
+          const message = error instanceof Error ? error.message : String(error);
+          causalMemory.record(
+            {
+              type: "bt.tool.failure",
+              data: { tool, message },
+              tags: ["bt", "tool", "failure", tool],
+            },
+            invocationEvent ? [invocationEvent.id] : parentCauses,
+          );
+        }
+        throw error;
+      }
+    },
+    now: () => Date.now(),
+    wait: async (ms: number) => {
+      if (ms <= 0) {
+        return;
+      }
+      await delay(ms);
+    },
+    variables: input.variables,
+  } satisfies Partial<TickRuntime> & { invokeTool: (tool: string, input: unknown) => Promise<unknown> };
+
+  scheduler = new ReactiveScheduler({
+    interpreter,
+    runtime,
+    now: runtime.now,
+    onTick: ({ result, pendingAfter }) => {
+      lastResultStatus = result.status;
+      context.supervisorAgent?.recordSchedulerSnapshot({
+        schedulerTick: scheduler.tickCount,
+        backlog: pendingAfter,
+        completed: result.status === "success" ? 1 : 0,
+        failed: result.status === "failure" ? 1 : 0,
+      });
+    },
+    getPheromoneIntensity: (nodeId) => context.stigmergy.getNodeIntensity(nodeId)?.intensity ?? 0,
+    causalMemory,
+  });
+
+  const unsubscribeStigmergy = context.stigmergy.onChange((change) => {
+    scheduler.emit("stigmergyChanged", {
+      nodeId: change.nodeId,
+      intensity: change.totalIntensity,
+      type: change.type,
+    });
+  });
+
+  const rootId =
+    ("id" in input.tree.root && input.tree.root.id) ||
+    ("node_id" in input.tree.root && (input.tree.root as { node_id?: string }).node_id) ||
+    input.tree.id;
+
+  const timeoutMs = input.timeout_ms ?? null;
+
+  try {
+    const runPromise = scheduler.runUntilSettled({
+      type: "taskReady",
+      payload: { nodeId: rootId, criticality: 1 },
+    });
+    let result: BehaviorTickResult;
+    if (timeoutMs !== null) {
+      const outcome = await Promise.race([
+        runPromise.then((value) => ({ kind: "result" as const, value })),
+        delay(timeoutMs).then(() => ({ kind: "timeout" as const })),
+      ]);
+      if (outcome.kind === "timeout") {
+        scheduler.stop();
+        await runPromise.catch(() => undefined);
+        throw new BehaviorTreeRunTimeoutError(timeoutMs);
+      }
+      result = outcome.value;
+    } else {
+      result = await runPromise;
+    }
+
+    context.logger.info("plan_run_bt_completed", {
+      tree_id: input.tree.id,
+      status: result.status,
+      invocations: invocations.length,
+      ticks: scheduler.tickCount,
+    });
+
+    return {
+      status: result.status,
+      ticks: scheduler.tickCount,
+      last_output: lastOutput,
+      invocations,
+    };
+  } finally {
+    unsubscribeStigmergy();
+    scheduler.stop();
+    context.logger.info("plan_run_bt_status", {
+      tree_id: input.tree.id,
+      status: lastResultStatus,
+      ticks: scheduler.tickCount,
+    });
+  }
 }

--- a/tests/agents.autoscaler.cooldown.test.ts
+++ b/tests/agents.autoscaler.cooldown.test.ts
@@ -1,0 +1,90 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { Autoscaler, AutoscalerSupervisor } from "../src/agents/autoscaler.js";
+import { ChildrenIndex } from "../src/state/childrenIndex.js";
+import type { LoopTickContext } from "../src/executor/loop.js";
+
+/** Manual clock emulating {@link Date.now} for deterministic cooldown checks. */
+class ManualClock {
+  private value = 0;
+
+  now(): number {
+    return this.value;
+  }
+
+  advance(ms: number): void {
+    this.value += ms;
+  }
+}
+
+/** Minimal supervisor double capturing spawn attempts for assertions. */
+class StubSupervisor implements AutoscalerSupervisor {
+  public readonly childrenIndex = new ChildrenIndex();
+  public readonly created: string[] = [];
+
+  constructor(private readonly clock: ManualClock) {}
+
+  async createChild(): Promise<void> {
+    const childId = `child-${this.created.length + 1}`;
+    this.childrenIndex.registerChild({
+      childId,
+      pid: 1_000 + this.created.length,
+      workdir: `/tmp/${childId}`,
+      startedAt: this.clock.now(),
+      state: "ready",
+    });
+    this.created.push(childId);
+  }
+
+  async cancel(): Promise<void> {
+    /* Cooldown test focuses on scale-up decisions. */
+  }
+}
+
+function buildContext(clock: ManualClock, tickIndex = 0): LoopTickContext {
+  const controller = new AbortController();
+  return {
+    startedAt: clock.now(),
+    now: () => clock.now(),
+    tickIndex,
+    signal: controller.signal,
+    budget: undefined,
+  };
+}
+
+/** Ensures the autoscaler enforces the configured cooldown between actions. */
+describe("agents autoscaler cooldown", () => {
+  it("ignores pressure while the cooldown is active", async () => {
+    const clock = new ManualClock();
+    const supervisor = new StubSupervisor(clock);
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 0, maxChildren: 3, cooldownMs: 2_000 },
+      thresholds: {
+        backlogHigh: 2,
+        backlogLow: 0,
+        latencyHighMs: 1_000,
+        latencyLowMs: 300,
+        failureRateHigh: 0.5,
+        failureRateLow: 0.1,
+      },
+    });
+
+    autoscaler.updateBacklog(4);
+    autoscaler.recordTaskResult({ durationMs: 1_200, success: false });
+    await autoscaler.reconcile(buildContext(clock));
+    expect(supervisor.created).to.deep.equal(["child-1"]);
+
+    autoscaler.updateBacklog(5);
+    clock.advance(500);
+    await autoscaler.reconcile(buildContext(clock, 1));
+    expect(supervisor.created).to.deep.equal(["child-1"]);
+
+    clock.advance(2_100);
+    autoscaler.updateBacklog(6);
+    await autoscaler.reconcile(buildContext(clock, 2));
+    expect(supervisor.created).to.deep.equal(["child-1", "child-2"]);
+  });
+});

--- a/tests/agents.autoscaler.scale-updown.test.ts
+++ b/tests/agents.autoscaler.scale-updown.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { Autoscaler, AutoscalerSupervisor } from "../src/agents/autoscaler.js";
+import { ChildrenIndex } from "../src/state/childrenIndex.js";
+import type { LoopTickContext } from "../src/executor/loop.js";
+
+/** Deterministic clock mirroring the `Date.now` contract. */
+class ManualClock {
+  private value = 0;
+
+  now(): number {
+    return this.value;
+  }
+
+  advance(ms: number): void {
+    this.value += ms;
+  }
+}
+
+/** Lightweight supervisor double tracking creations and cancellations. */
+class StubSupervisor implements AutoscalerSupervisor {
+  public readonly childrenIndex = new ChildrenIndex();
+  public readonly created: string[] = [];
+  public readonly cancelled: string[] = [];
+
+  constructor(private readonly clock: ManualClock) {}
+
+  async createChild(): Promise<void> {
+    const childId = `child-${this.created.length + 1}`;
+    this.childrenIndex.registerChild({
+      childId,
+      pid: 100 + this.created.length,
+      workdir: `/tmp/${childId}`,
+      startedAt: this.clock.now(),
+      state: "ready",
+    });
+    this.created.push(childId);
+  }
+
+  async cancel(childId: string): Promise<void> {
+    const snapshot = this.childrenIndex.getChild(childId);
+    if (!snapshot) {
+      throw new Error(`unknown child ${childId}`);
+    }
+    this.childrenIndex.removeChild(childId);
+    this.cancelled.push(childId);
+  }
+}
+
+/** Builds a minimal loop context compatible with the autoscaler reconciler. */
+function buildContext(clock: ManualClock, tickIndex = 0): LoopTickContext {
+  const controller = new AbortController();
+  return {
+    startedAt: clock.now(),
+    now: () => clock.now(),
+    tickIndex,
+    signal: controller.signal,
+    budget: undefined,
+  };
+}
+
+/** Validates the autoscaler behaviour in nominal pressure and relaxation flows. */
+describe("agents autoscaler scale up/down", () => {
+  it("spawns new children under pressure and retires idle ones once relaxed", async () => {
+    const clock = new ManualClock();
+    const supervisor = new StubSupervisor(clock);
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 1, maxChildren: 3, cooldownMs: 1_000 },
+      thresholds: {
+        backlogHigh: 3,
+        backlogLow: 0,
+        latencyHighMs: 1_200,
+        latencyLowMs: 400,
+        failureRateHigh: 0.6,
+        failureRateLow: 0.2,
+      },
+    });
+    expect(autoscaler.getConfiguration().minChildren).to.equal(1);
+
+    await autoscaler.reconcile(buildContext(clock));
+    expect(supervisor.created).to.deep.equal(["child-1"]);
+
+    autoscaler.updateBacklog(5);
+    autoscaler.recordTaskResult({ durationMs: 1_500, success: true });
+    clock.advance(1_200);
+    await autoscaler.reconcile(buildContext(clock, 1));
+    expect(supervisor.created).to.deep.equal(["child-1", "child-2"]);
+
+    autoscaler.updateBacklog(0);
+    autoscaler.recordTaskResult({ durationMs: 220, success: true });
+    autoscaler.recordTaskResult({ durationMs: 180, success: true });
+    autoscaler.recordTaskResult({ durationMs: 150, success: true });
+    autoscaler.recordTaskResult({ durationMs: 140, success: true });
+    // Additional short-latency samples ensure the average dips below the
+    // relaxation threshold so the scale-down path becomes eligible.
+    autoscaler.recordTaskResult({ durationMs: 120, success: true });
+    autoscaler.recordTaskResult({ durationMs: 110, success: true });
+    const retireCandidate = supervisor.created[0]!;
+    supervisor.childrenIndex.updateState(retireCandidate, "idle");
+    clock.advance(1_200);
+    await autoscaler.reconcile(buildContext(clock, 2));
+
+    expect(supervisor.cancelled).to.deep.equal([retireCandidate]);
+    const remainingIds = supervisor.childrenIndex.list().map((child) => child.childId).sort();
+    expect(remainingIds).to.deep.equal(["child-2"]);
+  });
+});

--- a/tests/agents.supervisor.stagnation.test.ts
+++ b/tests/agents.supervisor.stagnation.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  OrchestratorSupervisor,
+  type SupervisorChildManager,
+  type SupervisorIncident,
+} from "../src/agents/supervisor.js";
+import type { ChildRecordSnapshot } from "../src/state/childrenIndex.js";
+import type { LoopTickContext } from "../src/executor/loop.js";
+
+/** Deterministic manual clock used to advance time explicitly in tests. */
+class ManualClock {
+  private value = 0;
+
+  now(): number {
+    return this.value;
+  }
+
+  advance(ms: number): void {
+    this.value += ms;
+  }
+}
+
+/** Lightweight child manager double exposing the bare minimum for the tests. */
+class StubChildManager implements SupervisorChildManager {
+  public readonly children: ChildRecordSnapshot[] = [];
+
+  public readonly childrenIndex = {
+    list: (): ChildRecordSnapshot[] => this.children.map((child) => ({ ...child })),
+  };
+
+  async cancel(): Promise<void> {
+    /* The stagnation tests never cancel children. */
+  }
+}
+
+function createChild(overrides: Partial<ChildRecordSnapshot>): ChildRecordSnapshot {
+  return {
+    childId: overrides.childId ?? "child-a",
+    pid: overrides.pid ?? 1234,
+    workdir: overrides.workdir ?? "/tmp/child-a",
+    state: overrides.state ?? "idle",
+    startedAt: overrides.startedAt ?? 0,
+    lastHeartbeatAt: overrides.lastHeartbeatAt ?? 0,
+    retries: overrides.retries ?? 0,
+    metadata: { ...(overrides.metadata ?? {}) },
+    endedAt: overrides.endedAt ?? null,
+    exitCode: overrides.exitCode ?? null,
+    exitSignal: overrides.exitSignal ?? null,
+    forcedTermination: overrides.forcedTermination ?? false,
+    stopReason: overrides.stopReason ?? null,
+  };
+}
+
+function buildContext(clock: ManualClock, tickIndex: number): LoopTickContext {
+  const controller = new AbortController();
+  return {
+    startedAt: clock.now(),
+    now: () => clock.now(),
+    tickIndex,
+    signal: controller.signal,
+  };
+}
+
+describe("orchestrator supervisor stagnation", () => {
+  it("requests rewrite and redispatch when backlog stalls", async () => {
+    const clock = new ManualClock();
+    const manager = new StubChildManager();
+    manager.children.push(
+      createChild({
+        childId: "child-primary",
+        state: "idle",
+        startedAt: 0,
+        lastHeartbeatAt: 0,
+      }),
+    );
+
+    const incidents: SupervisorIncident[] = [];
+    const rewrites: SupervisorIncident[] = [];
+    const redispatches: SupervisorIncident[] = [];
+
+    const supervisor = new OrchestratorSupervisor({
+      childManager: manager,
+      now: () => clock.now(),
+      stagnationTickThreshold: 3,
+      stagnationBacklogThreshold: 2,
+      starvationIdleMs: 200,
+      starvationRepeatMs: 500,
+      actions: {
+        emitAlert: async (incident) => {
+          incidents.push(incident);
+        },
+        requestRewrite: async (incident) => {
+          rewrites.push(incident);
+        },
+        requestRedispatch: async (incident) => {
+          redispatches.push(incident);
+        },
+      },
+    });
+
+    for (let tick = 0; tick < 4; tick += 1) {
+      supervisor.recordSchedulerSnapshot({
+        schedulerTick: tick,
+        backlog: 4,
+        completed: 0,
+        failed: 0,
+      });
+      await supervisor.reconcile(buildContext(clock, tick));
+      clock.advance(100);
+    }
+
+    expect(rewrites).to.have.lengthOf(1);
+    expect(redispatches).to.have.lengthOf(1);
+    expect(incidents).to.have.length.greaterThan(0);
+    expect(rewrites[0].type).to.equal("stagnation");
+    expect(redispatches[0].type).to.equal("stagnation");
+
+    supervisor.recordSchedulerSnapshot({
+      schedulerTick: 5,
+      backlog: 1,
+      completed: 1,
+      failed: 0,
+    });
+    await supervisor.reconcile(buildContext(clock, 5));
+
+    supervisor.recordSchedulerSnapshot({
+      schedulerTick: 6,
+      backlog: 3,
+      completed: 0,
+      failed: 0,
+    });
+    await supervisor.reconcile(buildContext(clock, 6));
+
+    expect(rewrites).to.have.lengthOf(1);
+    expect(redispatches).to.have.lengthOf(1);
+  });
+});

--- a/tests/agents.supervisor.unblock.test.ts
+++ b/tests/agents.supervisor.unblock.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  OrchestratorSupervisor,
+  type SupervisorChildManager,
+  type SupervisorIncident,
+} from "../src/agents/supervisor.js";
+import type { ChildRecordSnapshot } from "../src/state/childrenIndex.js";
+import type { LoopAlert } from "../src/guard/loopDetector.js";
+
+class StubChildManager implements SupervisorChildManager {
+  public readonly children: ChildRecordSnapshot[] = [];
+  public readonly cancelled: string[] = [];
+  public readonly killed: string[] = [];
+
+  public readonly childrenIndex = {
+    list: (): ChildRecordSnapshot[] => this.children.map((child) => ({ ...child })),
+  };
+
+  async cancel(childId: string): Promise<void> {
+    this.cancelled.push(childId);
+  }
+
+  async kill(childId: string): Promise<void> {
+    this.killed.push(childId);
+  }
+}
+
+function childSnapshot(childId: string): ChildRecordSnapshot {
+  return {
+    childId,
+    pid: 42,
+    workdir: `/tmp/${childId}`,
+    state: "running",
+    startedAt: 0,
+    lastHeartbeatAt: 0,
+    retries: 0,
+    metadata: {},
+    endedAt: null,
+    exitCode: null,
+    exitSignal: null,
+    forcedTermination: false,
+    stopReason: null,
+  };
+}
+
+function createAlert(overrides: Partial<LoopAlert>): LoopAlert {
+  return {
+    type: "loop_detected",
+    participants: overrides.participants ?? ["orchestrator", "child:alpha"],
+    childIds: overrides.childIds ?? ["child-alpha"],
+    taskIds: overrides.taskIds ?? ["job"],
+    taskTypes: overrides.taskTypes ?? ["analysis"],
+    signature: overrides.signature ?? "sig-1",
+    occurrences: overrides.occurrences ?? 5,
+    windowMs: overrides.windowMs ?? 1_000,
+    firstTimestamp: overrides.firstTimestamp ?? 0,
+    lastTimestamp: overrides.lastTimestamp ?? 1_000,
+    recommendation: overrides.recommendation ?? "kill",
+    reason: overrides.reason ?? "loop detected",
+  };
+}
+
+describe("orchestrator supervisor loop mitigation", () => {
+  it("cancels critical loops and ignores duplicates", async () => {
+    const manager = new StubChildManager();
+    manager.children.push(childSnapshot("child-alpha"));
+    const incidents: SupervisorIncident[] = [];
+
+    const supervisor = new OrchestratorSupervisor({
+      childManager: manager,
+      actions: {
+        emitAlert: async (incident) => {
+          incidents.push(incident);
+        },
+        requestRewrite: async () => {},
+        requestRedispatch: async () => {},
+      },
+    });
+
+    const alert = createAlert({ recommendation: "kill" });
+    await supervisor.recordLoopAlert(alert);
+    await supervisor.recordLoopAlert(alert);
+
+    expect(manager.cancelled).to.deep.equal(["child-alpha"]);
+    expect(incidents).to.have.lengthOf(1);
+    expect(incidents[0].severity).to.equal("critical");
+  });
+
+  it("requests rewrites for warning alerts", async () => {
+    const manager = new StubChildManager();
+    manager.children.push(childSnapshot("child-beta"));
+    const rewrites: SupervisorIncident[] = [];
+
+    const supervisor = new OrchestratorSupervisor({
+      childManager: manager,
+      actions: {
+        emitAlert: async () => {},
+        requestRewrite: async (incident) => {
+          rewrites.push(incident);
+        },
+        requestRedispatch: async () => {},
+      },
+    });
+
+    const alert = createAlert({
+      recommendation: "warn",
+      signature: "sig-warn",
+      childIds: ["child-beta"],
+    });
+    await supervisor.recordLoopAlert(alert);
+
+    expect(manager.cancelled).to.deep.equal([]);
+    expect(rewrites).to.have.lengthOf(1);
+    expect(rewrites[0].type).to.equal("loop");
+  });
+});

--- a/tests/bt.compiler.from-hiergraph.test.ts
+++ b/tests/bt.compiler.from-hiergraph.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { compileHierGraphToBehaviorTree } from "../src/executor/bt/compiler.js";
+import type { HierGraph } from "../src/graph/hierarchy.js";
+
+/**
+ * Unit tests verifying the compilation of hierarchical graphs to Behaviour Tree
+ * definitions. The scenarios keep the graphs intentionally small to favour
+ * determinism and readability.
+ */
+describe("behaviour tree compiler", () => {
+  it("transforms a linear graph into a sequence of task leaves", () => {
+    const graph: HierGraph = {
+      id: "pipeline",
+      nodes: [
+        { id: "fetch", kind: "task", attributes: { bt_tool: "noop", bt_input_key: "fetch" } },
+        { id: "build", kind: "task", attributes: { bt_tool: "noop", bt_input_key: "build" } },
+        { id: "deploy", kind: "task", attributes: { bt_tool: "noop", bt_input_key: "deploy" } },
+      ],
+      edges: [
+        { id: "e1", from: { nodeId: "fetch" }, to: { nodeId: "build" } },
+        { id: "e2", from: { nodeId: "build" }, to: { nodeId: "deploy" } },
+      ],
+    };
+
+    const compiled = compileHierGraphToBehaviorTree(graph);
+    expect(compiled.id).to.equal("pipeline");
+    expect(compiled.root.type).to.equal("sequence");
+    if (compiled.root.type !== "sequence") {
+      return;
+    }
+    expect(compiled.root.children).to.have.length(3);
+    expect(compiled.root.children.map((child) => child.type)).to.deep.equal([
+      "task",
+      "task",
+      "task",
+    ]);
+    const toolNames = compiled.root.children.map((child) =>
+      child.type === "task" ? child.tool : "",
+    );
+    expect(toolNames).to.deep.equal(["noop", "noop", "noop"]);
+  });
+
+  it("detects cycles and raises an error", () => {
+    const graph: HierGraph = {
+      id: "cycle",
+      nodes: [
+        { id: "a", kind: "task", attributes: { bt_tool: "noop" } },
+        { id: "b", kind: "task", attributes: { bt_tool: "noop" } },
+      ],
+      edges: [
+        { id: "e1", from: { nodeId: "a" }, to: { nodeId: "b" } },
+        { id: "e2", from: { nodeId: "b" }, to: { nodeId: "a" } },
+      ],
+    };
+
+    expect(() => compileHierGraphToBehaviorTree(graph)).to.throw(
+      /contains cycles/i,
+    );
+  });
+});

--- a/tests/bt.decorators.retry-timeout.test.ts
+++ b/tests/bt.decorators.retry-timeout.test.ts
@@ -1,0 +1,191 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import type { BehaviorNode, BehaviorTickResult, TickRuntime } from "../src/executor/bt/types.js";
+import { RetryNode, TaskLeaf, TimeoutNode } from "../src/executor/bt/nodes.js";
+
+/** Minimal fake clock driving deterministic wait promises in tests. */
+class TestClock {
+  private current = 0;
+  private readonly scheduled: Array<{ at: number; resolve: () => void }> = [];
+
+  now(): number {
+    return this.current;
+  }
+
+  async wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.scheduled.push({ at: this.current + ms, resolve });
+    });
+  }
+
+  advance(ms: number): void {
+    this.advanceTo(this.current + ms);
+  }
+
+  advanceTo(target: number): void {
+    if (target < this.current) {
+      this.current = target;
+      return;
+    }
+    this.current = target;
+    const remaining: Array<{ at: number; resolve: () => void }> = [];
+    for (const entry of this.scheduled) {
+      if (entry.at <= this.current) {
+        entry.resolve();
+      } else {
+        remaining.push(entry);
+      }
+    }
+    this.scheduled.length = 0;
+    this.scheduled.push(...remaining);
+  }
+}
+
+/** Behaviour node that fails a configurable number of times before succeeding. */
+class FlakyNode implements BehaviorNode {
+  private attempts = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly failBeforeSuccess: number,
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    if (this.attempts < this.failBeforeSuccess) {
+      this.attempts += 1;
+      return { status: "failure" };
+    }
+    return { status: "success" };
+  }
+
+  reset(): void {
+    // Preserve the attempt counter so retry decorators observe cumulative failures.
+  }
+}
+
+/** Behaviour node staying in RUNNING until externally resolved. */
+class DeferredNode implements BehaviorNode {
+  private resolver: ((result: BehaviorTickResult) => void) | null = null;
+  private pending: Promise<BehaviorTickResult> | null = null;
+
+  constructor(public readonly id: string, private readonly result: BehaviorTickResult) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    if (!this.pending) {
+      this.pending = new Promise((resolve) => {
+        this.resolver = resolve;
+      });
+    }
+    return this.pending;
+  }
+
+  resolve(): void {
+    this.resolver?.(this.result);
+    this.resolver = null;
+    this.pending = null;
+  }
+
+  reset(): void {
+    this.pending = null;
+    this.resolver = null;
+  }
+}
+
+const noopRuntime: TickRuntime = {
+  invokeTool: async () => undefined,
+  now: () => 0,
+  wait: async () => {},
+  variables: {},
+};
+
+/**
+ * Unit tests covering retry and timeout decorators. The clock abstraction keeps
+ * the scenarios deterministic and free from real timers so the CI remains stable.
+ */
+describe("behaviour tree decorators", () => {
+  it("retries failing children until success", async () => {
+    const flaky = new FlakyNode("flaky", 2);
+    const runtime: TickRuntime = {
+      ...noopRuntime,
+      wait: async () => {},
+    };
+    const retry = new RetryNode("retry", 5, flaky, 0);
+
+    let result = await retry.tick(runtime);
+    expect(result.status).to.equal("running");
+
+    result = await retry.tick(runtime);
+    expect(result.status).to.equal("running");
+
+    result = await retry.tick(runtime);
+    expect(result.status).to.equal("success");
+  });
+
+  it("fails when retries exceed the configured budget", async () => {
+    const flaky = new FlakyNode("flaky", 5);
+    const runtime: TickRuntime = {
+      ...noopRuntime,
+      wait: async () => {},
+    };
+    const retry = new RetryNode("retry", 2, flaky, 0);
+
+    const first = await retry.tick(runtime);
+    expect(first.status).to.equal("running");
+
+    const result = await retry.tick(runtime);
+    expect(result.status).to.equal("failure");
+  });
+
+  it("returns failure when a timeout elapses before the child completes", async () => {
+    const deferred = new DeferredNode("deferred", { status: "success" });
+    const clock = new TestClock();
+    const runtime: TickRuntime = {
+      ...noopRuntime,
+      now: () => clock.now(),
+      wait: (ms) => clock.wait(ms),
+    };
+    const timeout = new TimeoutNode("timeout", 100, deferred);
+
+    const pending = timeout.tick(runtime);
+    await Promise.resolve();
+    clock.advanceTo(clock.now() + 100);
+    const result = await pending;
+    expect(result.status).to.equal("failure");
+  });
+
+  it("propagates the child result when it resolves before the timeout", async () => {
+    const deferred = new DeferredNode("deferred", { status: "success" });
+    const clock = new TestClock();
+    const runtime: TickRuntime = {
+      ...noopRuntime,
+      now: () => clock.now(),
+      wait: (ms) => clock.wait(ms),
+    };
+    const timeout = new TimeoutNode("timeout", 100, deferred);
+
+    const pending = timeout.tick(runtime);
+    await Promise.resolve();
+    deferred.resolve();
+    const result = await pending;
+    expect(result.status).to.equal("success");
+  });
+
+  it("invokes the runtime tool through task leaves", async () => {
+    let calledWith: unknown = null;
+    const runtime: TickRuntime = {
+      ...noopRuntime,
+      invokeTool: async (_tool, input) => {
+        calledWith = input;
+        return { echoed: input };
+      },
+      variables: { payload: { message: "hello" } },
+    };
+    const leaf = new TaskLeaf("task", "noop", { inputKey: "payload" });
+
+    const result = await leaf.tick(runtime);
+    expect(result.status).to.equal("success");
+    expect(result.output).to.deep.equal({ echoed: { message: "hello" } });
+    expect(calledWith).to.deep.equal({ message: "hello" });
+  });
+});

--- a/tests/bt.nodes.sequence-selector.test.ts
+++ b/tests/bt.nodes.sequence-selector.test.ts
@@ -1,0 +1,119 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import type { BehaviorNode, BehaviorTickResult, TickRuntime } from "../src/executor/bt/types.js";
+import { ParallelNode, SelectorNode, SequenceNode } from "../src/executor/bt/nodes.js";
+
+/**
+ * Stub node returning the provided sequence of results. Each call to
+ * {@link tick} consumes the next result until the array is exhausted.
+ */
+class StubNode implements BehaviorNode {
+  private cursor = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly results: BehaviorTickResult[],
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const result = this.results[Math.min(this.cursor, this.results.length - 1)];
+    if (this.cursor < this.results.length - 1) {
+      this.cursor += 1;
+    }
+    return result;
+  }
+
+  reset(): void {
+    this.cursor = 0;
+  }
+}
+
+const runtime: TickRuntime = {
+  invokeTool: async () => undefined,
+  now: () => 0,
+  wait: async () => {},
+  variables: {},
+};
+
+/**
+ * Unit tests exercising the sequence, selector and parallel behaviour tree
+ * composites. The scenarios ensure cursor management and reset semantics remain
+ * correct even when children yield RUNNING states.
+ */
+describe("behaviour tree composites", () => {
+  it("runs sequence children in order and resets after completion", async () => {
+    const first = new StubNode("first", [{ status: "success" }]);
+    const second = new StubNode("second", [{ status: "success" }]);
+    const sequence = new SequenceNode("sequence", [first, second]);
+
+    const firstTick = await sequence.tick(runtime);
+    expect(firstTick.status).to.equal("success");
+
+    const secondTick = await sequence.tick(runtime);
+    expect(secondTick.status).to.equal("success");
+
+    // After success the sequence resets, therefore the first child is evaluated again.
+    const thirdTick = await sequence.tick(runtime);
+    expect(thirdTick.status).to.equal("success");
+  });
+
+  it("propagates failures from sequence children and resets state", async () => {
+    const first = new StubNode("first", [{ status: "success" }]);
+    const failing = new StubNode("failing", [{ status: "failure" }]);
+    const sequence = new SequenceNode("sequence", [first, failing]);
+
+    const result = await sequence.tick(runtime);
+    expect(result.status).to.equal("failure");
+
+    // Ensure the sequence restarted by checking that the first child executes again.
+    const retryResult = await sequence.tick(runtime);
+    expect(retryResult.status).to.equal("failure");
+  });
+
+  it("evaluates selector children until one succeeds", async () => {
+    const first = new StubNode("first", [{ status: "failure" }]);
+    const second = new StubNode("second", [{ status: "success" }]);
+    const selector = new SelectorNode("selector", [first, second]);
+
+    const result = await selector.tick(runtime);
+    expect(result.status).to.equal("success");
+
+    // The selector resets so the successful child is executed again on the next tick.
+    const retryResult = await selector.tick(runtime);
+    expect(retryResult.status).to.equal("success");
+  });
+
+  it("resumes selector execution when a child is running", async () => {
+    const runningThenFail: BehaviorTickResult[] = [{ status: "running" }, { status: "failure" }];
+    const second = new StubNode("second", [{ status: "success" }]);
+    const selector = new SelectorNode("selector", [new StubNode("first", runningThenFail), second]);
+
+    const firstTick = await selector.tick(runtime);
+    expect(firstTick.status).to.equal("running");
+
+    const secondTick = await selector.tick(runtime);
+    expect(secondTick.status).to.equal("success");
+  });
+
+  it("succeeds only when all parallel children succeed with policy all", async () => {
+    const slow = new StubNode("slow", [{ status: "running" }, { status: "success" }]);
+    const fast = new StubNode("fast", [{ status: "success" }]);
+    const parallel = new ParallelNode("parallel", "all", [slow, fast]);
+
+    const firstTick = await parallel.tick(runtime);
+    expect(firstTick.status).to.equal("running");
+
+    const secondTick = await parallel.tick(runtime);
+    expect(secondTick.status).to.equal("success");
+  });
+
+  it("succeeds when any child succeeds under policy any", async () => {
+    const failing = new StubNode("failing", [{ status: "failure" }]);
+    const succeeding = new StubNode("succeeding", [{ status: "success" }]);
+    const parallel = new ParallelNode("parallel", "any", [failing, succeeding]);
+
+    const result = await parallel.tick(runtime);
+    expect(result.status).to.equal("success");
+  });
+});

--- a/tests/bt.run.integration.test.ts
+++ b/tests/bt.run.integration.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BehaviorTreeInterpreter, buildBehaviorTree } from "../src/executor/bt/interpreter.js";
+import type { BehaviorNodeDefinition } from "../src/executor/bt/types.js";
+
+/**
+ * Integration tests driving the interpreter end-to-end using the JSON
+ * definitions produced by the compiler. The runtime is stubbed so we can assert
+ * which tools were invoked during the execution.
+ */
+describe("behaviour tree interpreter", () => {
+  it("executes tasks sequentially and exposes outputs", async () => {
+    const definition: BehaviorNodeDefinition = {
+      type: "sequence",
+      id: "root",
+      children: [
+        { type: "task", id: "fetch", node_id: "fetch", tool: "noop", input_key: "fetch" },
+        { type: "task", id: "deploy", node_id: "deploy", tool: "noop", input_key: "deploy" },
+      ],
+    };
+
+    const interpreter = new BehaviorTreeInterpreter(buildBehaviorTree(definition));
+    const calls: Array<{ tool: string; input: unknown }> = [];
+
+    const result = await interpreter.tick({
+      invokeTool: async (tool, input) => {
+        calls.push({ tool, input });
+        return { tool, input };
+      },
+      now: () => 0,
+      wait: async () => {},
+      variables: {
+        fetch: { ref: "artifact" },
+        deploy: { environment: "staging" },
+      },
+    });
+
+    expect(result.status).to.equal("success");
+    expect(calls).to.have.length(2);
+    expect(calls[0]).to.deep.equal({ tool: "noop", input: { ref: "artifact" } });
+    expect(calls[1]).to.deep.equal({ tool: "noop", input: { environment: "staging" } });
+  });
+
+  it("halts when a guard condition fails and resumes once satisfied", async () => {
+    const definition: BehaviorNodeDefinition = {
+      type: "sequence",
+      id: "root",
+      children: [
+        { type: "task", id: "fetch", node_id: "fetch", tool: "noop", input_key: "fetch" },
+        {
+          type: "guard",
+          id: "can-deploy",
+          condition_key: "allow_deploy",
+          expected: true,
+          child: { type: "task", id: "deploy", node_id: "deploy", tool: "noop", input_key: "deploy" },
+        },
+      ],
+    };
+
+    const interpreter = new BehaviorTreeInterpreter(buildBehaviorTree(definition));
+    const calls: Array<{ tool: string; input: unknown }> = [];
+
+    const firstResult = await interpreter.tick({
+      invokeTool: async (tool, input) => {
+        calls.push({ tool, input });
+        return null;
+      },
+      now: () => 0,
+      wait: async () => {},
+      variables: {
+        fetch: { ref: "artifact" },
+        deploy: { environment: "prod" },
+        allow_deploy: false,
+      },
+    });
+
+    expect(firstResult.status).to.equal("failure");
+    expect(calls).to.have.length(1);
+
+    const secondResult = await interpreter.tick({
+      invokeTool: async (tool, input) => {
+        calls.push({ tool, input });
+        return null;
+      },
+      now: () => 0,
+      wait: async () => {},
+      variables: {
+        fetch: { ref: "artifact" },
+        deploy: { environment: "prod" },
+        allow_deploy: true,
+      },
+    });
+
+    expect(secondResult.status).to.equal("success");
+    expect(calls).to.have.length(3);
+    expect(calls.map((entry) => entry.tool)).to.deep.equal(["noop", "noop", "noop"]);
+    expect(calls[2].input).to.deep.equal({ environment: "prod" });
+  });
+});

--- a/tests/causal.integration.bt-scheduler.test.ts
+++ b/tests/causal.integration.bt-scheduler.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { handlePlanRunBT, type PlanToolContext } from "../src/tools/planTools.js";
+import { CausalMemory } from "../src/knowledge/causalMemory.js";
+import { StructuredLogger } from "../src/logger.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import type { ChildSupervisor } from "../src/childSupervisor.js";
+import type { GraphState } from "../src/graphState.js";
+
+/** Manual clock controlling timestamps for deterministic assertions. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Integration test verifying that the Behaviour Tree scheduler records causal
+ * events when the feature toggle is enabled.
+ */
+describe("causal memory integration with BT scheduler", () => {
+  it("records scheduler ticks and tool invocations", async () => {
+    const clock = new ManualClock();
+    const memory = new CausalMemory({ now: () => clock.now() });
+    const context = {
+      supervisor: {} as ChildSupervisor,
+      graphState: {} as GraphState,
+      logger: new StructuredLogger(),
+      childrenRoot: "/tmp",
+      defaultChildRuntime: "codex",
+      emitEvent: () => undefined,
+      stigmergy: new StigmergyField({ now: () => clock.now() }),
+      supervisorAgent: undefined,
+      causalMemory: memory,
+    } satisfies PlanToolContext;
+
+    const result = await handlePlanRunBT(context, {
+      tree: {
+        id: "bt-test",
+        root: { type: "task", node_id: "root-task", tool: "noop" },
+      },
+      dry_run: false,
+      variables: {},
+    });
+
+    expect(result.status).to.equal("success");
+    expect(result.invocations).to.have.length(1);
+
+    const events = memory.exportAll();
+    expect(events.map((event) => event.type)).to.deep.equal([
+      "scheduler.event.taskReady",
+      "scheduler.tick.start",
+      "bt.tool.invoke",
+      "bt.tool.success",
+      "scheduler.tick.result",
+    ]);
+
+    const [taskReady, tickStart, toolInvoke, toolSuccess, tickResult] = events;
+    expect(tickStart.causes).to.deep.equal([taskReady.id]);
+    expect(toolInvoke.causes).to.deep.equal([tickStart.id]);
+    expect(toolSuccess.causes).to.deep.equal([toolInvoke.id]);
+    expect(tickResult.causes).to.deep.equal([tickStart.id]);
+
+    const explanation = memory.explain(tickResult.id);
+    expect(explanation.ancestors.map((event) => event.id)).to.deep.equal([
+      taskReady.id,
+      tickStart.id,
+    ]);
+  });
+});

--- a/tests/coord.blackboard.kv.test.ts
+++ b/tests/coord.blackboard.kv.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BlackboardStore } from "../src/coord/blackboard.js";
+
+/** Deterministic manual clock used to drive TTL computations in tests. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Validates that the blackboard honours tag normalisation, TTL expiration and
+ * history tracking for repeated updates.
+ */
+describe("coordination blackboard key/value", () => {
+  it("persists, updates and expires entries deterministically", () => {
+    const clock = new ManualClock();
+    const store = new BlackboardStore({ now: () => clock.now(), historyLimit: 10 });
+
+    const created = store.set(
+      "alpha",
+      { payload: 1 },
+      { tags: ["Goal", "Alpha"], ttlMs: 1_000 },
+    );
+
+    expect(created.key).to.equal("alpha");
+    expect(created.tags).to.deep.equal(["alpha", "goal"]);
+    expect(created.createdAt).to.equal(0);
+    expect(created.updatedAt).to.equal(0);
+    expect(created.expiresAt).to.equal(1_000);
+
+    const fetched = store.get("alpha");
+    expect(fetched?.value).to.deep.equal({ payload: 1 });
+    expect(fetched?.version).to.equal(created.version);
+
+    clock.advance(250);
+    const updated = store.set("alpha", { payload: 2 }, { tags: ["Goal"], ttlMs: 500 });
+    expect(updated.version).to.be.greaterThan(created.version);
+    expect(updated.createdAt).to.equal(created.createdAt);
+    expect(updated.updatedAt).to.equal(clock.now());
+    expect(updated.expiresAt).to.equal(clock.now() + 500);
+
+    const tagged = store.query({ tags: ["goal"] });
+    expect(tagged).to.have.length(1);
+    expect(tagged[0].value).to.deep.equal({ payload: 2 });
+
+    clock.advance(500);
+    const expired = store.evictExpired();
+    expect(expired).to.have.length(1);
+    expect(expired[0].kind).to.equal("expire");
+    expect(expired[0].key).to.equal("alpha");
+
+    expect(store.get("alpha")).to.equal(undefined);
+
+    const history = store.getEventsSince(0);
+    expect(history.map((event) => event.kind)).to.deep.equal(["set", "set", "expire"]);
+    expect(history[1].previous?.value).to.deep.equal({ payload: 1 });
+  });
+});

--- a/tests/coord.blackboard.watch.test.ts
+++ b/tests/coord.blackboard.watch.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BlackboardEvent, BlackboardStore } from "../src/coord/blackboard.js";
+
+/** Manual clock mirroring the deterministic clock used in coordinator tests. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Ensures that watchers receive backlog events and live updates in order while
+ * respecting unsubscribe semantics and pagination.
+ */
+describe("coordination blackboard watch", () => {
+  it("streams backlog and live events with deterministic ordering", () => {
+    const clock = new ManualClock();
+    const store = new BlackboardStore({ now: () => clock.now(), historyLimit: 10 });
+
+    store.set("alpha", { status: "draft" });
+    clock.advance(10);
+    store.set("beta", { status: "todo" }, { tags: ["ops"] });
+
+    const received: BlackboardEvent[] = [];
+    const unsubscribe = store.watch({
+      fromVersion: 1,
+      listener: (event) => {
+        received.push(event);
+      },
+    });
+
+    expect(received.map((event) => event.key)).to.deep.equal(["beta"]);
+
+    clock.advance(5);
+    store.set("gamma", { status: "running" });
+    clock.advance(5);
+    expect(store.delete("beta")).to.equal(true);
+    clock.advance(5);
+    store.set("delta", { status: "cooldown" }, { ttlMs: 20 });
+
+    clock.advance(20);
+    const expired = store.evictExpired();
+    expect(expired).to.have.length(1);
+    expect(expired[0].key).to.equal("delta");
+
+    expect(received.map((event) => event.kind)).to.deep.equal([
+      "set",
+      "set",
+      "delete",
+      "set",
+      "expire",
+    ]);
+    expect(received.map((event) => event.key)).to.deep.equal([
+      "beta",
+      "gamma",
+      "beta",
+      "delta",
+      "delta",
+    ]);
+
+    unsubscribe();
+
+    store.set("epsilon", { status: "archived" });
+    expect(received.some((event) => event.key === "epsilon")).to.equal(false);
+
+    const paged = store.getEventsSince(1, { limit: 3 });
+    expect(paged.map((event) => event.version)).to.deep.equal([2, 3, 4]);
+  });
+});

--- a/tests/coord.consensus.modes.test.ts
+++ b/tests/coord.consensus.modes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  majority,
+  quorum,
+  weighted,
+  type ConsensusVote,
+} from "../src/coord/consensus.js";
+
+const successVote = (voter: string): ConsensusVote => ({
+  voter,
+  value: "success",
+});
+
+const failureVote = (voter: string): ConsensusVote => ({
+  voter,
+  value: "failure",
+});
+
+describe("coordination consensus helpers", () => {
+  it("computes a simple majority and reports ties", () => {
+    const votes: ConsensusVote[] = [
+      successVote("alpha"),
+      successVote("beta"),
+      failureVote("gamma"),
+    ];
+
+    const decision = majority(votes, { tieBreaker: "null" });
+    expect(decision.mode).to.equal("majority");
+    expect(decision.outcome).to.equal("success");
+    expect(decision.satisfied).to.equal(true);
+    expect(decision.tie).to.equal(false);
+    expect(decision.threshold).to.equal(2);
+    expect(decision.tally.success).to.equal(2);
+    expect(decision.tally.failure).to.equal(1);
+
+    const tieDecision = majority(
+      [successVote("alpha"), failureVote("beta")],
+      { tieBreaker: "null" },
+    );
+    expect(tieDecision.outcome).to.equal(null);
+    expect(tieDecision.satisfied).to.equal(false);
+    expect(tieDecision.tie).to.equal(true);
+  });
+
+  it("requires the configured quorum to accept an outcome", () => {
+    const votes: ConsensusVote[] = [
+      successVote("alpha"),
+      successVote("beta"),
+      failureVote("gamma"),
+    ];
+
+    const belowQuorum = quorum(votes, { quorum: 4 });
+    expect(belowQuorum.outcome).to.equal("success");
+    expect(belowQuorum.satisfied).to.equal(false);
+    expect(belowQuorum.threshold).to.equal(4);
+
+    const metQuorum = quorum(votes, { quorum: 2 });
+    expect(metQuorum.satisfied).to.equal(true);
+    expect(metQuorum.threshold).to.equal(2);
+  });
+
+  it("applies custom weights and optional quorum constraints", () => {
+    const votes: ConsensusVote[] = [
+      successVote("alpha"),
+      failureVote("beta"),
+      successVote("gamma"),
+    ];
+    const weights = { alpha: 2, beta: 1, gamma: 1 };
+
+    const weightedMajority = weighted(votes, { weights });
+    expect(weightedMajority.outcome).to.equal("success");
+    expect(weightedMajority.totalWeight).to.equal(4);
+    expect(weightedMajority.threshold).to.equal(3);
+    expect(weightedMajority.satisfied).to.equal(true);
+
+    const weightedQuorum = weighted(votes, { weights, quorum: 3 });
+    expect(weightedQuorum.outcome).to.equal("success");
+    expect(weightedQuorum.satisfied).to.equal(true);
+    expect(weightedQuorum.threshold).to.equal(3);
+
+    const strictWeighted = weighted(votes, { weights, quorum: 5 });
+    expect(strictWeighted.satisfied).to.equal(false);
+    expect(strictWeighted.threshold).to.equal(5);
+  });
+});

--- a/tests/coord.contractnet.basic.test.ts
+++ b/tests/coord.contractnet.basic.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ContractNetCoordinator } from "../src/coord/contractNet.js";
+
+/** Manual clock mirroring {@link Date.now} so bids stay deterministic. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/** Validates the Contract-Net coordinator core flow (announce → bid → award). */
+describe("coordination contract-net basic", () => {
+  it("awards the lowest cost bid and releases the assignment on completion", () => {
+    const clock = new ManualClock();
+    const coordinator = new ContractNetCoordinator({ now: () => clock.now(), defaultBusyPenalty: 2 });
+
+    coordinator.registerAgent("alpha", { baseCost: 8, reliability: 0.8, tags: ["analysis"] });
+    coordinator.registerAgent("beta", { baseCost: 12, reliability: 0.9, tags: ["survey"] });
+
+    const announcement = coordinator.announce({
+      taskId: "survey-1",
+      payload: { priority: 2 },
+      tags: ["survey"],
+      metadata: { hint: "collect samples" },
+    });
+
+    expect(announcement.bids.length).to.equal(2);
+
+    clock.advance(5);
+    coordinator.bid(announcement.callId, "beta", 4, { metadata: { note: "fast" } });
+    clock.advance(3);
+    coordinator.bid(announcement.callId, "alpha", 6);
+
+    const decision = coordinator.award(announcement.callId);
+    expect(decision.agentId).to.equal("beta");
+    expect(decision.cost).to.equal(4);
+    expect(decision.effectiveCost).to.be.lessThanOrEqual(6);
+
+    const awarded = coordinator.getCall(announcement.callId);
+    expect(awarded?.status).to.equal("awarded");
+    expect(awarded?.awardedAgentId).to.equal("beta");
+    expect(coordinator.getAgent("beta")?.activeAssignments).to.equal(1);
+
+    const completed = coordinator.complete(announcement.callId);
+    expect(completed.status).to.equal("completed");
+    expect(coordinator.getAgent("beta")?.activeAssignments).to.equal(0);
+  });
+});

--- a/tests/coord.contractnet.tie-breaker.test.ts
+++ b/tests/coord.contractnet.tie-breaker.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ContractNetCoordinator } from "../src/coord/contractNet.js";
+
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/** Ensures the coordinator favours the least busy or lexicographically stable agent on ties. */
+describe("coordination contract-net tie-breaker", () => {
+  it("prefers the less busy agent when bids tie", () => {
+    const clock = new ManualClock();
+    const coordinator = new ContractNetCoordinator({ now: () => clock.now(), defaultBusyPenalty: 3 });
+
+    coordinator.registerAgent("alpha", { baseCost: 10 });
+    coordinator.registerAgent("beta", { baseCost: 10 });
+
+    const first = coordinator.announce({ taskId: "mission-1", autoBid: false });
+    coordinator.bid(first.callId, "alpha", 2);
+    coordinator.bid(first.callId, "beta", 2);
+    const firstAward = coordinator.award(first.callId, "alpha");
+    expect(firstAward.agentId).to.equal("alpha");
+
+    const second = coordinator.announce({ taskId: "mission-2", autoBid: false });
+    clock.advance(1);
+    coordinator.bid(second.callId, "alpha", 2);
+    clock.advance(1);
+    coordinator.bid(second.callId, "beta", 2);
+    const secondAward = coordinator.award(second.callId);
+    expect(secondAward.agentId).to.equal("beta");
+    expect(coordinator.getAgent("alpha")?.activeAssignments).to.equal(1);
+    expect(coordinator.getAgent("beta")?.activeAssignments).to.equal(1);
+
+    coordinator.complete(first.callId);
+    coordinator.complete(second.callId);
+
+    const third = coordinator.announce({ taskId: "mission-3", autoBid: false });
+    coordinator.bid(third.callId, "alpha", 5);
+    coordinator.bid(third.callId, "beta", 5);
+    const thirdAward = coordinator.award(third.callId);
+    expect(thirdAward.agentId).to.equal("alpha");
+    coordinator.complete(third.callId);
+  });
+});

--- a/tests/coord.stigmergy.field.test.ts
+++ b/tests/coord.stigmergy.field.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { StigmergyField } from "../src/coord/stigmergy.js";
+
+/** Manual clock mirroring {@link Date.now} so evaporation stays deterministic. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Validates that the stigmergic field accumulates markings, exposes snapshots
+ * and evaporates intensities exponentially when instructed to decay.
+ */
+describe("coordination stigmergy field", () => {
+  it("accumulates intensity and evaporates deterministically", () => {
+    const clock = new ManualClock();
+    const field = new StigmergyField({ now: () => clock.now() });
+    const events: Array<{ node: string; total: number }> = [];
+    const unsubscribe = field.onChange((change) => {
+      events.push({ node: change.nodeId, total: change.totalIntensity });
+    });
+
+    const created = field.mark("alpha", "Explore", 5);
+    expect(created.intensity).to.equal(5);
+    expect(field.getNodeIntensity("alpha")?.intensity).to.equal(5);
+
+    clock.advance(500);
+    const updated = field.mark("alpha", "explore", 3);
+    expect(updated.updatedAt).to.equal(clock.now());
+    expect(updated.intensity).to.equal(8);
+
+    const snapshot = field.fieldSnapshot();
+    expect(snapshot.points).to.have.length(1);
+    expect(snapshot.points[0]?.intensity).to.equal(8);
+    expect(snapshot.totals[0]?.intensity).to.equal(8);
+
+    clock.advance(1_000);
+    const decayed = field.evaporate(1_000);
+    expect(decayed).to.have.length(1);
+    expect(decayed[0]?.intensity).to.be.closeTo(4, 1e-6);
+    expect(field.getNodeIntensity("alpha")?.intensity).to.be.closeTo(4, 1e-6);
+
+    clock.advance(2_000);
+    const vanished = field.evaporate(10);
+    expect(vanished[0]?.intensity).to.be.closeTo(0, 1e-6);
+    expect(field.getNodeIntensity("alpha")).to.equal(undefined);
+
+    unsubscribe();
+    expect(events.length).to.be.greaterThan(0);
+  });
+});

--- a/tests/coord.stigmergy.scheduler.test.ts
+++ b/tests/coord.stigmergy.scheduler.test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import type { BehaviorNode, BehaviorTickResult, TickRuntime } from "../src/executor/bt/types.js";
+import { BehaviorTreeInterpreter } from "../src/executor/bt/interpreter.js";
+import {
+  ReactiveScheduler,
+  type StigmergyChangedEvent,
+  type TaskReadyEvent,
+} from "../src/executor/reactiveScheduler.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+
+/** Manual clock exposing {@link wait} so scheduler timings stay reproducible. */
+class ManualClock {
+  private current = 0;
+  private readonly scheduled: Array<{ at: number; resolve: () => void }> = [];
+
+  now(): number {
+    return this.current;
+  }
+
+  wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.scheduled.push({ at: this.current + ms, resolve });
+    });
+  }
+
+  advance(ms: number): void {
+    this.advanceTo(this.current + ms);
+  }
+
+  advanceTo(target: number): void {
+    if (target < this.current) {
+      this.current = target;
+      return;
+    }
+    this.current = target;
+    const remaining: Array<{ at: number; resolve: () => void }> = [];
+    for (const entry of this.scheduled) {
+      if (entry.at <= this.current) {
+        entry.resolve();
+      } else {
+        remaining.push(entry);
+      }
+    }
+    this.scheduled.length = 0;
+    this.scheduled.push(...remaining);
+  }
+}
+
+/** Behaviour node returning scripted results to control interpreter progression. */
+class ScriptedNode implements BehaviorNode {
+  private index = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly results: BehaviorTickResult[],
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const result = this.results[Math.min(this.index, this.results.length - 1)];
+    this.index += 1;
+    return result;
+  }
+
+  reset(): void {
+    // Preserve execution history to keep consuming the scripted results.
+  }
+}
+
+/**
+ * Ensures stigmergy-driven pheromones alter the scheduler priorities so hot nodes
+ * are executed before older but less urgent tasks.
+ */
+describe("coordination stigmergy scheduler integration", () => {
+  it("prioritises taskReady events using the stigmergic field", async () => {
+    const clock = new ManualClock();
+    const field = new StigmergyField({ now: () => clock.now() });
+    const node = new ScriptedNode("root", [
+      { status: "running" },
+      { status: "running" },
+      { status: "success" },
+    ]);
+    const interpreter = new BehaviorTreeInterpreter(node);
+    const processed: Array<{ event: string; nodeId: string }> = [];
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      getPheromoneIntensity: (nodeId) => field.getNodeIntensity(nodeId)?.intensity ?? 0,
+      onTick: ({ event, payload }) => {
+        if (event === "taskReady") {
+          const { nodeId } = payload as TaskReadyEvent;
+          processed.push({ event, nodeId });
+        }
+        if (event === "stigmergyChanged") {
+          const { nodeId } = payload as StigmergyChangedEvent;
+          processed.push({ event, nodeId });
+        }
+      },
+    });
+
+    const unsubscribe = field.onChange((change) => {
+      scheduler.emit("stigmergyChanged", {
+        nodeId: change.nodeId,
+        intensity: change.totalIntensity,
+        type: change.type,
+      });
+    });
+
+    try {
+      const resultPromise = scheduler.runUntilSettled({
+        type: "taskReady",
+        payload: { nodeId: "alpha", criticality: 1 },
+      });
+
+      clock.advance(5);
+      scheduler.emit("taskReady", { nodeId: "beta", criticality: 1 });
+
+      field.mark("beta", "explore", 20);
+
+      const result = await resultPromise;
+      expect(result.status).to.equal("success");
+
+      const taskReadyOrder = processed
+        .filter((entry) => entry.event === "taskReady")
+        .map((entry) => entry.nodeId);
+      expect(taskReadyOrder).to.deep.equal(["beta", "alpha"]);
+      expect(field.getNodeIntensity("beta")?.intensity).to.equal(20);
+    } finally {
+      unsubscribe();
+      scheduler.stop();
+    }
+  });
+});

--- a/tests/executor.loop.budget.test.ts
+++ b/tests/executor.loop.budget.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ExecutionLoop } from "../src/executor/loop.js";
+
+/** Deterministic manual clock so tests can simulate work duration explicitly. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Budget tests verify the cooperative yielding capabilities when the loop is
+ * configured with a per-tick duration budget.
+ */
+describe("execution loop budget", () => {
+  it("requests cooperative yields once the budget is consumed", async () => {
+    const manualClock = new ManualClock();
+    const events: string[] = [];
+
+    const intervalHandlers: Array<() => void> = [];
+    const scheduledResumes: Array<() => void> = [];
+    const fakeTimer = {} as NodeJS.Timeout;
+
+    const loop = new ExecutionLoop({
+      intervalMs: 100,
+      now: () => manualClock.now(),
+      budgetMs: 10,
+      setIntervalFn: (handler) => {
+        intervalHandlers.push(handler);
+        return fakeTimer;
+      },
+      clearIntervalFn: () => {
+        // The manual scheduler does not keep track of handles, no-op.
+      },
+      scheduleYield: (resume) => {
+        scheduledResumes.push(resume);
+        return undefined;
+      },
+      cancelYield: () => {
+        // Manual scheduler has nothing to cancel.
+      },
+      tick: async ({ budget, now }) => {
+        if (!budget) {
+          throw new Error("budget missing");
+        }
+        for (let i = 0; i < 5; i += 1) {
+          manualClock.advance(6);
+          events.push(`work-${i}@${now()}`);
+          if (await budget.yieldIfExceeded()) {
+            events.push(`yield@${now()}`);
+          }
+        }
+      },
+    });
+
+    loop.start();
+    expect(loop.isRunning).to.equal(true);
+    expect(intervalHandlers).to.have.length(1);
+
+    const waitForScheduled = async () => {
+      for (let attempts = 0; attempts < 10 && scheduledResumes.length === 0; attempts += 1) {
+        await Promise.resolve();
+      }
+      expect(scheduledResumes).to.not.be.empty;
+    };
+
+    intervalHandlers[0]!();
+    await waitForScheduled();
+
+    scheduledResumes.shift()!();
+    await Promise.resolve();
+    await waitForScheduled();
+
+    scheduledResumes.shift()!();
+    await Promise.resolve();
+
+    await loop.whenIdle();
+
+    expect(events).to.deep.equal([
+      "work-0@6",
+      "work-1@12",
+      "yield@12",
+      "work-2@18",
+      "work-3@24",
+      "yield@24",
+      "work-4@30",
+    ]);
+    expect(scheduledResumes).to.be.empty;
+    expect(loop.tickCount).to.equal(1);
+
+    await loop.stop();
+    expect(loop.isRunning).to.equal(false);
+  });
+});

--- a/tests/executor.loop.reconciler.test.ts
+++ b/tests/executor.loop.reconciler.test.ts
@@ -1,0 +1,59 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ExecutionLoop, LoopReconciler, LoopTickContext } from "../src/executor/loop.js";
+
+/** Manual timer stub exposing hooks to trigger scheduled ticks deterministically. */
+class ManualTimer {
+  public handler: (() => void) | null = null;
+
+  schedule(handler: () => void): NodeJS.Timeout {
+    this.handler = handler;
+    return {} as NodeJS.Timeout;
+  }
+
+  clear(): void {
+    this.handler = null;
+  }
+}
+
+/** Validates that reconcilers are invoked after every tick with the proper context. */
+describe("executor loop reconcilers", () => {
+  it("calls reconcilers once per tick", async () => {
+    const timer = new ManualTimer();
+    const observedContexts: LoopTickContext[] = [];
+    let clock = 0;
+
+    const reconcilers: LoopReconciler[] = [
+      {
+        async reconcile(context) {
+          observedContexts.push(context);
+        },
+      },
+    ];
+
+    const loop = new ExecutionLoop({
+      intervalMs: 1,
+      tick: () => {
+        clock += 5;
+      },
+      now: () => clock,
+      setIntervalFn: (handler, _interval) => timer.schedule(handler),
+      clearIntervalFn: () => timer.clear(),
+      reconcilers,
+    });
+
+    loop.start();
+    expect(timer.handler).to.be.a("function");
+
+    timer.handler?.();
+    await loop.whenIdle();
+    timer.handler?.();
+    await loop.whenIdle();
+
+    expect(observedContexts.map((ctx) => ctx.tickIndex)).to.deep.equal([0, 1]);
+    expect(observedContexts.every((ctx) => ctx.startedAt <= clock)).to.equal(true);
+
+    await loop.stop();
+  });
+});

--- a/tests/executor.loop.timing.test.ts
+++ b/tests/executor.loop.timing.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ExecutionLoop } from "../src/executor/loop.js";
+
+/** Deterministic clock mirroring the manual scheduler used in the tests. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/** Manual interval runner to mimic {@link setInterval} deterministically. */
+class ManualIntervalController {
+  private handler: (() => void) | undefined;
+  private interval: number | undefined;
+
+  constructor(private readonly clock: ManualClock) {}
+
+  set(handler: () => void, interval: number): NodeJS.Timeout {
+    this.handler = handler;
+    this.interval = interval;
+    return {} as NodeJS.Timeout;
+  }
+
+  clear(): void {
+    this.handler = undefined;
+    this.interval = undefined;
+  }
+
+  /** Advances the clock by one interval and invokes the registered handler. */
+  tick(): void {
+    if (!this.handler || this.interval === undefined) {
+      return;
+    }
+    this.clock.advance(this.interval);
+    this.handler();
+  }
+}
+
+/**
+ * Timing-focused tests ensure the execution loop honours the configured
+ * interval, supports pause/resume semantics and reports consistent timestamps.
+ */
+describe("execution loop timing", () => {
+  it("fires ticks at the configured cadence without drift", async () => {
+    const clock = new ManualClock();
+    const scheduler = new ManualIntervalController(clock);
+    const invocations: number[] = [];
+
+    const loop = new ExecutionLoop({
+      intervalMs: 50,
+      now: () => clock.now(),
+      setIntervalFn: (handler, interval) => scheduler.set(handler, interval),
+      clearIntervalFn: () => scheduler.clear(),
+      tick: ({ now }) => {
+        invocations.push(now());
+      },
+    });
+
+    loop.start();
+
+    scheduler.tick();
+    await loop.whenIdle();
+    expect(invocations).to.deep.equal([50]);
+
+    scheduler.tick();
+    await loop.whenIdle();
+    expect(invocations).to.deep.equal([50, 100]);
+
+    expect(loop.pause()).to.equal(true);
+
+    clock.advance(200);
+    scheduler.tick();
+    expect(invocations).to.deep.equal([50, 100]);
+
+    expect(loop.resume()).to.equal(true);
+
+    scheduler.tick();
+    await loop.whenIdle();
+    expect(invocations).to.deep.equal([50, 100, 350]);
+    expect(loop.tickCount).to.equal(3);
+
+    await loop.stop();
+    expect(loop.isRunning).to.equal(false);
+  });
+});

--- a/tests/executor.scheduler.prio.test.ts
+++ b/tests/executor.scheduler.prio.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import type { BehaviorNode, BehaviorTickResult, TickRuntime } from "../src/executor/bt/types.js";
+import { BehaviorTreeInterpreter } from "../src/executor/bt/interpreter.js";
+import { ReactiveScheduler } from "../src/executor/reactiveScheduler.js";
+
+/** Deterministic manual clock mirroring {@link setTimeout} semantics for tests. */
+class ManualClock {
+  private current = 0;
+  private readonly scheduled: Array<{ at: number; resolve: () => void }> = [];
+
+  now(): number {
+    return this.current;
+  }
+
+  wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.scheduled.push({ at: this.current + ms, resolve });
+    });
+  }
+
+  advance(ms: number): void {
+    this.advanceTo(this.current + ms);
+  }
+
+  advanceTo(target: number): void {
+    if (target < this.current) {
+      this.current = target;
+      return;
+    }
+    this.current = target;
+    const remaining: Array<{ at: number; resolve: () => void }> = [];
+    for (const entry of this.scheduled) {
+      if (entry.at <= this.current) {
+        entry.resolve();
+      } else {
+        remaining.push(entry);
+      }
+    }
+    this.scheduled.length = 0;
+    this.scheduled.push(...remaining);
+  }
+}
+
+/** Behaviour node producing scripted results to emulate long-running plans. */
+class ScriptedNode implements BehaviorNode {
+  private index = 0;
+
+  constructor(
+    public readonly id: string,
+    private readonly results: BehaviorTickResult[],
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const result = this.results[Math.min(this.index, this.results.length - 1)];
+    this.index += 1;
+    return result;
+  }
+
+  reset(): void {
+    // Preserve execution history so the interpreter keeps advancing through the script.
+  }
+}
+
+/**
+ * Priority policy tests ensure that aged events outrank newer but less urgent
+ * ones, which keeps deferred actions progressing even under continuous load.
+ */
+describe("reactive scheduler priority", () => {
+  it("prefers older events when their aging outweighs base priority", async () => {
+    const clock = new ManualClock();
+    const node = new ScriptedNode("script", [
+      { status: "running" },
+      { status: "success" },
+    ]);
+    const interpreter = new BehaviorTreeInterpreter(node);
+    const processed: string[] = [];
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      ageWeight: 0.02,
+      onTick: ({ event }) => {
+        processed.push(event);
+      },
+    });
+
+    scheduler.emit("stigmergyChanged", { nodeId: "alpha", intensity: 5 });
+    clock.advance(5000);
+    scheduler.emit("taskDone", { nodeId: "alpha", success: true });
+
+    const result = await scheduler.runUntilSettled();
+
+    expect(processed).to.deep.equal(["stigmergyChanged", "taskDone"]);
+    expect(result.status).to.equal("success");
+    expect(scheduler.tickCount).to.equal(2);
+
+    scheduler.stop();
+  });
+});

--- a/tests/executor.scheduler.reactivity.test.ts
+++ b/tests/executor.scheduler.reactivity.test.ts
@@ -1,0 +1,107 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import type { BehaviorNode, BehaviorTickResult, TickRuntime } from "../src/executor/bt/types.js";
+import { BehaviorTreeInterpreter } from "../src/executor/bt/interpreter.js";
+import { ReactiveScheduler } from "../src/executor/reactiveScheduler.js";
+
+/**
+ * Minimal deterministic clock used to drive scheduler tests without relying on
+ * real timers. The helpers mimic the behaviour of {@link setTimeout} while
+ * giving the test control over the current time.
+ */
+class ManualClock {
+  private current = 0;
+  private readonly scheduled: Array<{ at: number; resolve: () => void }> = [];
+
+  now(): number {
+    return this.current;
+  }
+
+  wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.scheduled.push({ at: this.current + ms, resolve });
+    });
+  }
+
+  advance(ms: number): void {
+    this.advanceTo(this.current + ms);
+  }
+
+  advanceTo(target: number): void {
+    if (target < this.current) {
+      this.current = target;
+      return;
+    }
+    this.current = target;
+    const remaining: Array<{ at: number; resolve: () => void }> = [];
+    for (const entry of this.scheduled) {
+      if (entry.at <= this.current) {
+        entry.resolve();
+      } else {
+        remaining.push(entry);
+      }
+    }
+    this.scheduled.length = 0;
+    this.scheduled.push(...remaining);
+  }
+}
+
+/** Behaviour node incrementing a counter every time the interpreter ticks. */
+class CountingNode implements BehaviorNode {
+  public readonly id = "counter";
+  public readonly ticks: number[] = [];
+
+  async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+    this.ticks.push(runtime.now());
+    return { status: "running" };
+  }
+
+  reset(): void {
+    // No internal state to reset.
+  }
+}
+
+/**
+ * Scheduler unit tests ensure events trigger interpreter ticks immediately and
+ * that the scheduler keeps counting ticks for diagnostics.
+ */
+describe("reactive scheduler", () => {
+  it("ticks the interpreter whenever events are emitted", async () => {
+    const clock = new ManualClock();
+    const node = new CountingNode();
+    const interpreter = new BehaviorTreeInterpreter(node);
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+    });
+
+    await scheduler.runUntilSettled({
+      type: "taskReady",
+      payload: { nodeId: "root", criticality: 1 },
+    });
+
+    expect(node.ticks).to.have.length(1);
+    expect(node.ticks[0]).to.equal(0);
+
+    clock.advance(25);
+
+    await scheduler.runUntilSettled({
+      type: "blackboardChanged",
+      payload: { key: "status", importance: 2 },
+    });
+
+    expect(node.ticks).to.have.length(2);
+    expect(node.ticks[1]).to.equal(25);
+    expect(scheduler.tickCount).to.equal(2);
+
+    scheduler.stop();
+  });
+});

--- a/tests/graph.generate.from-kg.test.ts
+++ b/tests/graph.generate.from-kg.test.ts
@@ -1,0 +1,44 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { KnowledgeGraph } from "../src/knowledge/knowledgeGraph.js";
+import { handleGraphGenerate } from "../src/tools/graphTools.js";
+
+/**
+ * Ensures that graph generation can leverage knowledge graph patterns when no
+ * preset or explicit tasks are provided.
+ */
+describe("graph generate knowledge integration", () => {
+  it("derives tasks and notes from knowledge graph patterns", () => {
+    const knowledge = new KnowledgeGraph({ now: () => 0 });
+
+    knowledge.insert({ subject: "incident_response", predicate: "includes", object: "detect", source: "kb", confidence: 0.92 });
+    knowledge.insert({ subject: "incident_response", predicate: "includes", object: "contain", source: "kb", confidence: 0.84 });
+    knowledge.insert({ subject: "task:detect", predicate: "label", object: "Detect incident" });
+    knowledge.insert({ subject: "task:contain", predicate: "label", object: "Contain incident" });
+    knowledge.insert({ subject: "task:contain", predicate: "depends_on", object: "detect" });
+    knowledge.insert({ subject: "task:contain", predicate: "weight", object: "3" });
+    knowledge.insert({ subject: "task:contain", predicate: "duration", object: "5" });
+
+    const result = handleGraphGenerate(
+      { name: "incident_response" },
+      { knowledgeGraph: knowledge, knowledgeEnabled: true },
+    );
+
+    expect(result.task_count).to.equal(2);
+    expect(result.edge_count).to.equal(1);
+    expect(result.notes[0]).to.contain("knowledge pattern 'incident_response' applied");
+    expect(result.notes[0]).to.contain("avg_confidence=0.88");
+    expect(result.notes[1]).to.equal("knowledge sources=1");
+
+    const detect = result.graph.nodes.find((node) => node.id === "detect");
+    const contain = result.graph.nodes.find((node) => node.id === "contain");
+    expect(detect?.attributes?.knowledge_source).to.equal("kb");
+    expect(contain?.attributes?.knowledge_confidence).to.equal(0.84);
+    expect(contain?.attributes?.duration).to.equal(5);
+    expect(contain?.attributes?.weight).to.equal(3);
+
+    const edge = result.graph.edges.find((item) => item.from === "detect" && item.to === "contain");
+    expect(edge?.weight).to.equal(3);
+  });
+});

--- a/tests/graph.rewrite.apply.test.ts
+++ b/tests/graph.rewrite.apply.test.ts
@@ -1,0 +1,159 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  GraphRewriteApplyInputSchema,
+  handleGraphRewriteApply,
+} from "../src/tools/graphTools.js";
+import type { GraphDescriptorPayload } from "../src/tools/graphTools.js";
+
+/**
+ * Unit test suite covering the rewrite application tool. The scenarios exercise
+ * both manual rule selection and adaptive orchestration while asserting that
+ * graph identity remains stable for downstream transactions.
+ */
+describe("graph rewrite apply - tool behaviour", () => {
+  it("splits parallel edges exactly once when requested manually", () => {
+    const baseGraph: GraphDescriptorPayload = {
+      name: "pipeline",
+      graph_id: "g-manual",
+      graph_version: 1,
+      nodes: [
+        { id: "build", label: "Build", attributes: { kind: "task" } },
+        { id: "deploy", label: "Deploy", attributes: { kind: "task" } },
+      ],
+      edges: [
+        {
+          from: "build",
+          to: "deploy",
+          label: "build→deploy",
+          attributes: { parallel: true },
+        },
+      ],
+      metadata: {},
+    };
+
+    const input = GraphRewriteApplyInputSchema.parse({
+      graph: baseGraph,
+      mode: "manual" as const,
+      rules: ["split_parallel"],
+    });
+
+    const result = handleGraphRewriteApply(input);
+
+    expect(result.changed).to.equal(true);
+    expect(result.total_applied).to.equal(1);
+    expect(result.graph.graph_version).to.equal(2);
+    expect(result.rules_invoked).to.deep.equal(["split-parallel"]);
+
+    const branchNode = result.graph.nodes.find((node) => node.id.startsWith("build∥deploy"));
+    expect(branchNode, "expected a synthetic branch node to be introduced").to.exist;
+    expect(result.graph.edges).to.have.length(2);
+    expect(
+      result.graph.edges.some(
+        (edge) => edge.from === "build" && edge.to === branchNode?.id && edge.attributes?.role === "fanout",
+      ),
+    ).to.equal(true);
+    expect(
+      result.graph.edges.some(
+        (edge) => edge.from === branchNode?.id && edge.to === "deploy" && edge.attributes?.role === "branch",
+      ),
+    ).to.equal(true);
+  });
+
+  it("keeps the version stable when no rewrite matches", () => {
+    const baseGraph: GraphDescriptorPayload = {
+      name: "unchanged",
+      graph_id: "g-static",
+      graph_version: 3,
+      nodes: [
+        { id: "lint", label: "Lint", attributes: {} },
+        { id: "test", label: "Test", attributes: {} },
+      ],
+      edges: [
+        { from: "lint", to: "test", label: "lint→test", attributes: {} },
+      ],
+      metadata: {},
+    };
+
+    const input = GraphRewriteApplyInputSchema.parse({
+      graph: baseGraph,
+      mode: "manual" as const,
+      rules: ["split_parallel"],
+    });
+
+    const result = handleGraphRewriteApply(input);
+
+    expect(result.changed).to.equal(false);
+    expect(result.total_applied).to.equal(0);
+    expect(result.graph.graph_version).to.equal(3);
+    expect(result.rules_invoked).to.deep.equal(["split-parallel"]);
+    expect(result.graph.nodes.map((node) => node.id)).to.deep.equal(["lint", "test"]);
+    expect(result.graph.edges).to.have.length(1);
+    expect(result.graph.edges[0]).to.include({ from: "lint", to: "test", label: "lint→test" });
+    expect(result.graph.edges[0].attributes?.rewritten_split_parallel ?? false).to.equal(false);
+  });
+
+  it("reroutes around weak nodes when guided by adaptive evaluation", () => {
+    const baseGraph: GraphDescriptorPayload = {
+      name: "adaptive",
+      graph_id: "g-adaptive",
+      graph_version: 5,
+      nodes: [
+        { id: "start", label: "Start", attributes: {} },
+        { id: "review", label: "Review", attributes: {} },
+        { id: "end", label: "End", attributes: {} },
+      ],
+      edges: [
+        { from: "start", to: "review", label: "start→review", attributes: {} },
+        { from: "review", to: "end", label: "review→end", attributes: {} },
+      ],
+      metadata: {},
+    };
+
+    const input = GraphRewriteApplyInputSchema.parse({
+      graph: baseGraph,
+      mode: "adaptive" as const,
+      evaluation: {
+        edges_to_boost: [],
+        edges_to_prune: ["start→review"],
+        insights: [
+          {
+            edge_key: "start→review",
+            reinforcement: 0.1,
+            confidence: 0.9,
+            recommendation: "prune" as const,
+            metrics: {
+              successes: 0,
+              failures: 3,
+              total_duration_ms: 900,
+              total_reward: 0,
+              last_updated_at: 1_000,
+              attempts: 3,
+              success_rate: 0,
+              average_duration_ms: 300,
+            },
+          },
+        ],
+      },
+      options: { stop_on_no_change: true },
+    });
+
+    const result = handleGraphRewriteApply(input);
+
+    expect(result.changed).to.equal(true);
+    expect(result.total_applied).to.be.greaterThan(0);
+    expect(result.graph.graph_version).to.equal(6);
+    expect(result.rules_invoked).to.include("reroute-avoid");
+    expect(result.graph.nodes.map((node) => node.id)).to.not.include("review");
+    expect(
+      result.graph.edges.some(
+        (edge) =>
+          edge.from === "start" &&
+          edge.to === "end" &&
+          edge.attributes?.rewritten_reroute_avoid === true &&
+          edge.attributes?.avoided === "review",
+      ),
+    ).to.equal(true);
+  });
+});

--- a/tests/graph.subgraph.extract.test.ts
+++ b/tests/graph.subgraph.extract.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { extractSubgraphToFile } from "../src/graph/subgraphExtract.js";
+import { SUBGRAPH_REGISTRY_KEY } from "../src/graph/subgraphRegistry.js";
+import type { GraphDescriptorPayload } from "../src/tools/graphTools.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "subgraph-extract-"));
+  try {
+    return await fn(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("graph subgraph extract", () => {
+  it("serialises subgraph descriptors into a versioned run directory", async () => {
+    await withTempDir(async (root) => {
+      const graph: GraphDescriptorPayload = {
+        name: "pipeline",
+        nodes: [
+          { id: "alpha", attributes: { kind: "task" } },
+          { id: "beta", attributes: { kind: "subgraph", ref: "analysis" } },
+          { id: "omega", attributes: { kind: "task" } },
+        ],
+        edges: [],
+        metadata: {
+          [SUBGRAPH_REGISTRY_KEY]: JSON.stringify({
+            analysis: {
+              graph: { id: "analysis", nodes: [], edges: [] },
+              entryPoints: ["start"],
+              exitPoints: ["finish"],
+            },
+          }),
+        },
+        graph_id: "pipeline",
+        graph_version: 2,
+      };
+
+      const times = [1000, 2000];
+      let cursor = 0;
+      const originalNow = Date.now;
+      Date.now = () => times[Math.min(cursor++, times.length - 1)];
+      try {
+        const first = await extractSubgraphToFile({
+          graph,
+          nodeId: "beta",
+          runId: "run-alpha",
+          childrenRoot: root,
+        });
+        expect(first.version).to.equal(1);
+        expect(first.subgraphRef).to.equal("analysis");
+        expect(first.extractedAt).to.equal(1000);
+        const firstPayload = JSON.parse(await readFile(first.absolutePath, "utf8"));
+        expect(firstPayload.version).to.equal(1);
+        expect(firstPayload.subgraph_ref).to.equal("analysis");
+        expect(firstPayload.graph_id).to.equal("pipeline");
+
+        const second = await extractSubgraphToFile({
+          graph,
+          nodeId: "beta",
+          runId: "run-alpha",
+          childrenRoot: root,
+        });
+        expect(second.version).to.equal(2);
+        expect(second.extractedAt).to.equal(2000);
+        expect(path.dirname(second.absolutePath)).to.equal(path.dirname(first.absolutePath));
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+  });
+
+  it("rejects graphs missing the referenced descriptor", async () => {
+    await withTempDir(async (root) => {
+      const graph: GraphDescriptorPayload = {
+        name: "incomplete",
+        nodes: [
+          { id: "alpha", attributes: { kind: "subgraph", ref: "missing" } },
+        ],
+        edges: [],
+        metadata: {},
+      };
+
+      let error: Error | null = null;
+      try {
+        await extractSubgraphToFile({
+          graph,
+          nodeId: "alpha",
+          runId: "run-beta",
+          childrenRoot: root,
+        });
+      } catch (err) {
+        error = err as Error;
+      }
+      expect(error).to.not.equal(null);
+      expect(error?.message).to.match(/missing/i);
+    });
+  });
+});

--- a/tests/graph.tx.rewrite-integration.test.ts
+++ b/tests/graph.tx.rewrite-integration.test.ts
@@ -1,0 +1,105 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import {
+  GraphRewriteApplyInputSchema,
+  handleGraphRewriteApply,
+  normaliseGraphPayload,
+  serialiseNormalisedGraph,
+} from "../src/tools/graphTools.js";
+import type { GraphDescriptorPayload } from "../src/tools/graphTools.js";
+
+/** Utility restoring the global clock after deterministic timer overrides. */
+function restoreNow(original: () => number): void {
+  Date.now = original;
+}
+
+describe("graph transactions - rewrite integration", () => {
+  it("commits rewritten graphs with a single optimistic increment", () => {
+    const manager = new GraphTransactionManager();
+    const baseGraph: GraphDescriptorPayload = {
+      name: "tx-manual",
+      graph_id: "tx-manual",
+      graph_version: 4,
+      nodes: [
+        { id: "plan", label: "Plan", attributes: {} },
+        { id: "execute", label: "Execute", attributes: {} },
+      ],
+      edges: [
+        {
+          from: "plan",
+          to: "execute",
+          label: "plan→execute",
+          attributes: { parallel: true },
+        },
+      ],
+      metadata: {},
+    };
+    const baseline = normaliseGraphPayload(baseGraph);
+
+    const times = [50_000, 51_000, 52_000, 53_000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => times[Math.min(cursor++, times.length - 1)];
+
+    try {
+      const begin = manager.begin(baseline);
+      const rewriteInput = GraphRewriteApplyInputSchema.parse({
+        graph: serialiseNormalisedGraph(begin.workingCopy),
+        mode: "manual" as const,
+        rules: ["split_parallel"],
+      });
+      const result = handleGraphRewriteApply(rewriteInput);
+      const committed = manager.commit(begin.txId, normaliseGraphPayload(result.graph));
+
+      expect(committed.version).to.equal(begin.baseVersion + 1);
+      expect(committed.graph.graphVersion).to.equal(committed.version);
+      expect(committed.graph.metadata.__txCommittedAt).to.equal(52_000);
+      expect(result.changed).to.equal(true);
+    } finally {
+      restoreNow(originalNow);
+    }
+  });
+
+  it("preserves the base version when no rewrite is applied", () => {
+    const manager = new GraphTransactionManager();
+    const baseGraph: GraphDescriptorPayload = {
+      name: "tx-stable",
+      graph_id: "tx-stable",
+      graph_version: 7,
+      nodes: [
+        { id: "ingest", label: "Ingest", attributes: {} },
+        { id: "store", label: "Store", attributes: {} },
+      ],
+      edges: [
+        { from: "ingest", to: "store", label: "ingest→store", attributes: {} },
+      ],
+      metadata: {},
+    };
+    const baseline = normaliseGraphPayload(baseGraph);
+
+    const times = [60_000, 61_000, 62_000];
+    let cursor = 0;
+    const originalNow = Date.now;
+    Date.now = () => times[Math.min(cursor++, times.length - 1)];
+
+    try {
+      const begin = manager.begin(baseline);
+      const rewriteInput = GraphRewriteApplyInputSchema.parse({
+        graph: serialiseNormalisedGraph(begin.workingCopy),
+        mode: "manual" as const,
+        rules: ["split_parallel"],
+      });
+      const result = handleGraphRewriteApply(rewriteInput);
+      const committed = manager.commit(begin.txId, normaliseGraphPayload(result.graph));
+
+      expect(result.changed).to.equal(false);
+      expect(committed.version).to.equal(begin.baseVersion);
+      expect(committed.graph.graphVersion).to.equal(begin.baseVersion);
+      expect(committed.graph.metadata.__txCommittedAt ?? null).to.equal(null);
+    } finally {
+      restoreNow(originalNow);
+    }
+  });
+});

--- a/tests/knowledge.causal.record-explain.test.ts
+++ b/tests/knowledge.causal.record-explain.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { CausalMemory } from "../src/knowledge/causalMemory.js";
+
+/** Deterministic clock so snapshots remain stable across tests. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Validates that the causal memory records deterministic edges and produces
+ * bounded explanations when depth constraints are provided.
+ */
+describe("causal memory record and explain", () => {
+  it("records events, enforces cause existence and explains ancestry", () => {
+    const clock = new ManualClock();
+    const memory = new CausalMemory({ now: () => clock.now() });
+
+    const ready = memory.record({ type: "scheduler.event.taskReady", data: { node_id: "root" } });
+    clock.advance(5);
+    const tickStart = memory.record(
+      { type: "scheduler.tick.start", data: { event: "taskReady" } },
+      [ready.id],
+    );
+    clock.advance(5);
+    const tickResult = memory.record(
+      { type: "scheduler.tick.result", data: { status: "success" } },
+      [tickStart.id],
+    );
+    const toolSuccess = memory.record(
+      { type: "bt.tool.success", data: { tool: "noop" } },
+      [tickStart.id],
+    );
+
+    const exported = memory.exportAll();
+    expect(exported.map((event) => event.id)).to.deep.equal([
+      ready.id,
+      tickStart.id,
+      tickResult.id,
+      toolSuccess.id,
+    ]);
+    expect(exported[0]?.effects).to.deep.equal([tickStart.id]);
+    expect(exported[1]?.causes).to.deep.equal([ready.id]);
+
+    const explanation = memory.explain(tickResult.id);
+    expect(explanation.outcome.id).to.equal(tickResult.id);
+    expect(explanation.ancestors.map((event) => event.id)).to.deep.equal([ready.id, tickStart.id]);
+    expect(explanation.edges).to.deep.include({ from: tickStart.id, to: tickResult.id });
+    expect(explanation.edges).to.deep.include({ from: ready.id, to: tickStart.id });
+    expect(explanation.depth).to.equal(2);
+
+    const truncated = memory.explain(tickResult.id, { maxDepth: 1 });
+    expect(truncated.ancestors.map((event) => event.id)).to.deep.equal([tickStart.id]);
+
+    expect(() => memory.record({ type: "scheduler.tick.result" }, ["missing"])).to.throw("unknown cause");
+  });
+});

--- a/tests/knowledge.kg.insert-query.test.ts
+++ b/tests/knowledge.kg.insert-query.test.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { KnowledgeGraph } from "../src/knowledge/knowledgeGraph.js";
+import {
+  handleKgExport,
+  handleKgInsert,
+  handleKgQuery,
+  type KnowledgeToolContext,
+} from "../src/tools/knowledgeTools.js";
+import { StructuredLogger } from "../src/logger.js";
+
+/** Deterministic manual clock to control knowledge graph timestamps. */
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+/**
+ * Validates that the knowledge graph deterministically stores, updates and
+ * queries triples via the dedicated tool handlers.
+ */
+describe("knowledge graph storage and queries", () => {
+  it("inserts, updates, filters and exports triples deterministically", () => {
+    const clock = new ManualClock();
+    const graph = new KnowledgeGraph({ now: () => clock.now() });
+    const logger = new StructuredLogger();
+    const context: KnowledgeToolContext = { knowledgeGraph: graph, logger };
+
+    const initial = handleKgInsert(context, {
+      triples: [
+        { subject: "incident", predicate: "includes", object: "detect", source: "playbook", confidence: 0.9 },
+        { subject: "incident", predicate: "includes", object: "contain", source: "playbook", confidence: 0.8 },
+        { subject: "task:contain", predicate: "depends_on", object: "detect" },
+      ],
+    });
+
+    expect(initial.created).to.equal(3);
+    expect(initial.updated).to.equal(0);
+    expect(initial.total).to.equal(3);
+    expect(initial.inserted.map((triple) => triple.ordinal)).to.deep.equal([1, 2, 3]);
+
+    clock.advance(100);
+
+    const second = handleKgInsert(context, {
+      triples: [
+        { subject: "incident", predicate: "includes", object: "detect", source: "library", confidence: 0.95 },
+        { subject: "task:contain", predicate: "label", object: "Contain incident" },
+      ],
+    });
+
+    expect(second.created).to.equal(1);
+    expect(second.updated).to.equal(1);
+    expect(second.total).to.equal(4);
+
+    const updatedTriple = second.inserted.find((triple) => triple.object === "detect");
+    expect(updatedTriple?.revision).to.equal(1);
+    expect(updatedTriple?.confidence).to.equal(0.95);
+
+    const queryAll = handleKgQuery(context, {
+      subject: "incident",
+      predicate: "includes",
+      limit: 10,
+      order: "asc",
+    });
+
+    expect(queryAll.triples).to.have.length(2);
+    expect(queryAll.next_cursor).to.equal(queryAll.triples[1].ordinal);
+    expect(queryAll.triples.map((triple) => triple.source)).to.deep.equal(["library", "playbook"]);
+
+    const confident = handleKgQuery(context, {
+      subject: "incident",
+      predicate: "includes",
+      min_confidence: 0.9,
+      limit: 10,
+      order: "asc",
+    });
+
+    expect(confident.triples).to.have.length(1);
+    expect(confident.triples[0].object).to.equal("detect");
+
+    const wildcard = handleKgQuery(context, {
+      object: "cont*",
+      limit: 10,
+      order: "asc",
+    });
+
+    expect(wildcard.triples).to.have.length(1);
+    expect(wildcard.triples[0].object).to.equal("contain");
+
+    const exported = handleKgExport(context, {});
+    expect(exported.total).to.equal(4);
+    expect(exported.triples.map((triple) => triple.ordinal)).to.deep.equal([1, 2, 3, 4]);
+  });
+});

--- a/tests/options.flags.wiring.test.ts
+++ b/tests/options.flags.wiring.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Ces tests vérifient que les drapeaux de configuration exposés par
+ * `serverOptions` peuvent être appliqués dynamiquement au serveur et récupérés
+ * par les helpers d'export. Cela garantit qu'un opérateur peut activer les
+ * modules optionnels puis ajuster les délais sans redémarrer.
+ */
+import { describe, it, afterEach, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import {
+  configureRuntimeFeatures,
+  configureRuntimeTimings,
+  getRuntimeFeatures,
+  getRuntimeTimings,
+} from "../src/server.js";
+import type { FeatureToggles, RuntimeTimingOptions } from "../src/serverOptions.js";
+
+describe("runtime feature flags wiring", () => {
+  let originalFeatures: FeatureToggles;
+  let originalTimings: RuntimeTimingOptions;
+
+  beforeEach(() => {
+    originalFeatures = getRuntimeFeatures();
+    originalTimings = getRuntimeTimings();
+  });
+
+  afterEach(() => {
+    configureRuntimeFeatures(originalFeatures);
+    configureRuntimeTimings(originalTimings);
+  });
+
+  it("applique les toggles fournis", () => {
+    const toggles: FeatureToggles = {
+      ...originalFeatures,
+      enableBT: !originalFeatures.enableBT,
+      enableReactiveScheduler: !originalFeatures.enableReactiveScheduler,
+      enableBlackboard: true,
+      enableStigmergy: true,
+      enableCNP: true,
+      enableConsensus: true,
+      enableAutoscaler: true,
+      enableSupervisor: true,
+      enableKnowledge: true,
+      enableCausalMemory: true,
+      enableValueGuard: true,
+    };
+
+    configureRuntimeFeatures(toggles);
+
+    expect(getRuntimeFeatures()).to.deep.equal(toggles);
+  });
+
+  it("met à jour les délais runtime", () => {
+    const timings: RuntimeTimingOptions = {
+      btTickMs: originalTimings.btTickMs + 10,
+      stigHalfLifeMs: originalTimings.stigHalfLifeMs + 5_000,
+      supervisorStallTicks: originalTimings.supervisorStallTicks + 2,
+    };
+
+    configureRuntimeTimings(timings);
+
+    expect(getRuntimeTimings()).to.deep.equal(timings);
+  });
+});

--- a/tests/plan.join.vote.integration.test.ts
+++ b/tests/plan.join.vote.integration.test.ts
@@ -1,0 +1,157 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { ChildSupervisor } from "../src/childSupervisor.js";
+import type {
+  ChildCollectedOutputs,
+  ChildRuntimeMessage,
+} from "../src/childRuntime.js";
+import { GraphState } from "../src/graphState.js";
+import { StructuredLogger } from "../src/logger.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import {
+  PlanJoinInputSchema,
+  PlanReduceInputSchema,
+  type PlanToolContext,
+  handlePlanJoin,
+  handlePlanReduce,
+} from "../src/tools/planTools.js";
+
+interface StubMessageOptions {
+  type: "response" | "error";
+  content: string;
+  receivedAt: number;
+}
+
+function createStubOutputs(
+  childId: string,
+  options: StubMessageOptions,
+): ChildCollectedOutputs {
+  const message: ChildRuntimeMessage<{ type: string; content: string }> = {
+    raw: JSON.stringify({ type: options.type, content: options.content }),
+    parsed: { type: options.type, content: options.content },
+    stream: "stdout",
+    receivedAt: options.receivedAt,
+    sequence: 1,
+  };
+  return {
+    childId,
+    manifestPath: path.join(tmpdir(), `${childId}-manifest.json`),
+    logPath: path.join(tmpdir(), `${childId}-child.log`),
+    messages: [message],
+    artifacts: [],
+  };
+}
+
+describe("plan_join consensus integration", () => {
+  it("applies weighted consensus when joining and reducing results", async () => {
+    const supervisorStub = {
+      collect: async (childId: string) => {
+        switch (childId) {
+          case "childA":
+            return createStubOutputs("childA", {
+              type: "response",
+              content: "approve",
+              receivedAt: 1,
+            });
+          case "childB":
+            return createStubOutputs("childB", {
+              type: "error",
+              content: "reject",
+              receivedAt: 2,
+            });
+          case "childC":
+            return createStubOutputs("childC", {
+              type: "response",
+              content: "approve",
+              receivedAt: 3,
+            });
+          default:
+            throw new Error(`unexpected child ${childId}`);
+        }
+      },
+      waitForMessage: async () => {
+        throw new Error("waitForMessage should not be called in this stub");
+      },
+    } as unknown as ChildSupervisor;
+
+    const logger = {
+      info: () => {},
+      debug: () => {},
+      warn: () => {},
+      error: () => {},
+      flush: async () => {},
+    } as unknown as StructuredLogger;
+
+    const events: Array<{ kind: string; payload?: unknown }> = [];
+    const context: PlanToolContext = {
+      supervisor: supervisorStub,
+      graphState: new GraphState(),
+      logger,
+      childrenRoot: tmpdir(),
+      defaultChildRuntime: "codex",
+      emitEvent: (event) => {
+        events.push({ kind: event.kind, payload: event.payload });
+      },
+      stigmergy: new StigmergyField(),
+    };
+
+    const joinInput = PlanJoinInputSchema.parse({
+      children: ["childA", "childB", "childC"],
+      join_policy: "quorum",
+      quorum_count: 3,
+      timeout_sec: 1,
+      consensus: {
+        mode: "weighted",
+        quorum: 3,
+        weights: { childA: 2, childB: 1, childC: 1 },
+        tie_breaker: "prefer",
+        prefer_value: "success",
+      },
+    });
+
+    const joinResult = await handlePlanJoin(context, joinInput);
+    expect(joinResult.satisfied).to.equal(true);
+    expect(joinResult.quorum_threshold).to.equal(3);
+    expect(joinResult.consensus?.outcome).to.equal("success");
+    expect(joinResult.consensus?.total_weight).to.equal(4);
+    expect(joinResult.consensus?.tally).to.deep.equal({ success: 3, error: 1 });
+    expect(joinResult.winning_child_id).to.equal("childA");
+    expect(events.some((event) => event.kind === "STATUS")).to.equal(true);
+
+    const reduceInput = PlanReduceInputSchema.parse({
+      children: ["childA", "childB", "childC"],
+      reducer: "vote",
+      spec: {
+        mode: "weighted",
+        quorum: 3,
+        weights: { childA: 2, childB: 1, childC: 1 },
+        tie_breaker: "first",
+      },
+    });
+
+    const reduceResult = await handlePlanReduce(context, reduceInput);
+    expect(reduceResult.aggregate).to.deep.equal({
+      mode: "weighted",
+      value: "approve",
+      satisfied: true,
+      tie: false,
+      threshold: 3,
+      total_weight: 4,
+      tally: { approve: 3, reject: 1 },
+    });
+    expect(reduceResult.trace.details).to.deep.equal({
+      consensus: {
+        mode: "weighted",
+        value: "approve",
+        satisfied: true,
+        tie: false,
+        threshold: 3,
+        total_weight: 4,
+        tally: { approve: 3, reject: 1 },
+      },
+    });
+  });
+});

--- a/tests/server.tools.errors.test.ts
+++ b/tests/server.tools.errors.test.ts
@@ -1,0 +1,177 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { StructuredLogger } from "../src/logger.js";
+import { KnowledgeGraph, KnowledgeBadTripleError } from "../src/knowledge/knowledgeGraph.js";
+import { handleKgInsert } from "../src/tools/knowledgeTools.js";
+import { CausalMemory, CausalPathNotFoundError } from "../src/knowledge/causalMemory.js";
+import { handleCausalExplain } from "../src/tools/causalTools.js";
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import {
+  BlackboardEntryNotFoundError,
+  CoordinationToolContext,
+  handleBbGet,
+  handleStigMark,
+  handleCnpAnnounce,
+} from "../src/tools/coordTools.js";
+import { StigmergyField, StigmergyInvalidTypeError } from "../src/coord/stigmergy.js";
+import { ContractNetCoordinator, ContractNetNoBidsError } from "../src/coord/contractNet.js";
+import { handlePlanReduce, handlePlanRunBT, PlanReduceInputSchema } from "../src/tools/planTools.js";
+import { GraphState } from "../src/graphState.js";
+import { ConsensusNoQuorumError, BehaviorTreeRunTimeoutError } from "../src/tools/planTools.js";
+import type { PlanToolContext } from "../src/tools/planTools.js";
+import type { ChildCollectedOutputs } from "../src/childRuntime.js";
+
+/** Creates a no-op structured logger for test contexts. */
+function createLogger(): StructuredLogger {
+  return new StructuredLogger();
+}
+
+/** Builds a coordination context backed by fresh in-memory stores. */
+function createCoordinationContext(): CoordinationToolContext {
+  return {
+    blackboard: new BlackboardStore(),
+    stigmergy: new StigmergyField(),
+    contractNet: new ContractNetCoordinator(),
+    logger: createLogger(),
+  };
+}
+
+describe("server tool error codes", () => {
+  it("surfaced knowledge graph validation errors with E-KG-BAD-TRIPLE", () => {
+    const context = { knowledgeGraph: new KnowledgeGraph(), logger: createLogger() };
+    expect(() =>
+      handleKgInsert(context, {
+        triples: [
+          { subject: "   ", predicate: "related_to", object: "task" },
+        ],
+      }),
+    ).to.throw(KnowledgeBadTripleError).that.has.property("code", "E-KG-BAD-TRIPLE");
+  });
+
+  it("surfaces causal path misses with E-CAUSAL-NO-PATH", () => {
+    const memory = new CausalMemory();
+    const context = { causalMemory: memory, logger: createLogger() };
+    expect(() => handleCausalExplain(context, { outcome_id: "missing" })).to.throw(
+      CausalPathNotFoundError,
+    ).that.has.property("code", "E-CAUSAL-NO-PATH");
+  });
+
+  it("surfaces blackboard misses with E-BB-NOTFOUND", () => {
+    const context = createCoordinationContext();
+    expect(() => handleBbGet(context, { key: "absent" })).to.throw(
+      BlackboardEntryNotFoundError,
+    ).that.has.property("code", "E-BB-NOTFOUND");
+  });
+
+  it("surfaces stigmergy type errors with E-STIG-TYPE", () => {
+    const context = createCoordinationContext();
+    expect(() =>
+      handleStigMark(context, { node_id: "n", type: "   ", intensity: 1 }),
+    ).to.throw(StigmergyInvalidTypeError).that.has.property("code", "E-STIG-TYPE");
+  });
+
+  it("surfaces contract-net award errors with E-CNP-NO-BIDS", () => {
+    const context = createCoordinationContext();
+    expect(() =>
+      handleCnpAnnounce(context, { task_id: "alpha", auto_bid: false, tags: [] }),
+    ).to.throw(ContractNetNoBidsError).that.has.property("code", "E-CNP-NO-BIDS");
+  });
+
+  it("surfaces consensus quorum failures with E-CONSENSUS-NO-QUORUM", async () => {
+    const votes: Record<string, string> = {
+      "child-a": "approve",
+      "child-b": "reject",
+    };
+    const planContext: PlanToolContext = {
+      supervisor: {
+        async collect(childId: string): Promise<ChildCollectedOutputs> {
+          return {
+            childId,
+            manifestPath: path.join(tmpdir(), `${childId}.manifest.json`),
+            logPath: path.join(tmpdir(), `${childId}.log`),
+            messages: [
+              {
+                raw: "",
+                parsed: { type: "response", content: votes[childId] },
+                stream: "stdout",
+                receivedAt: 0,
+                sequence: 0,
+              },
+            ],
+            artifacts: [],
+          };
+        },
+      } as unknown as PlanToolContext["supervisor"],
+      graphState: new GraphState(),
+      logger: createLogger(),
+      childrenRoot: tmpdir(),
+      defaultChildRuntime: "codex",
+      emitEvent: () => {},
+      stigmergy: new StigmergyField(),
+      supervisorAgent: undefined,
+      causalMemory: undefined,
+      valueGuard: undefined,
+    };
+
+    const input = PlanReduceInputSchema.parse({
+      children: Object.keys(votes),
+      reducer: "vote",
+      spec: { mode: "majority" },
+    });
+
+    try {
+      await handlePlanReduce(planContext, input);
+      expect.fail("expected a ConsensusNoQuorumError to be thrown");
+    } catch (error) {
+      expect(error).to.be.instanceOf(ConsensusNoQuorumError);
+      expect((error as ConsensusNoQuorumError).code).to.equal("E-CONSENSUS-NO-QUORUM");
+    }
+  });
+
+  it("surfaces Behaviour Tree runtime timeouts with E-BT-RUN-TIMEOUT", async () => {
+    const planContext: PlanToolContext = {
+      supervisor: {} as PlanToolContext["supervisor"],
+      graphState: new GraphState(),
+      logger: createLogger(),
+      childrenRoot: await mkdtemp(path.join(tmpdir(), "plan-run-timeout-")),
+      defaultChildRuntime: "codex",
+      emitEvent: () => {},
+      stigmergy: new StigmergyField(),
+      supervisorAgent: undefined,
+      causalMemory: undefined,
+      valueGuard: undefined,
+    };
+
+    try {
+      await handlePlanRunBT(planContext, {
+        tree: {
+          id: "bt-timeout",
+          root: {
+            type: "retry",
+            max_attempts: 3,
+            backoff_ms: 25,
+            child: {
+              type: "guard",
+              condition_key: "allow",
+              expected: true,
+              child: { type: "task", node_id: "noop", tool: "noop" },
+            },
+          },
+        },
+        variables: { allow: false },
+        dry_run: false,
+        timeout_ms: 10,
+      });
+      expect.fail("expected BehaviourTreeRunTimeoutError");
+    } catch (error) {
+      expect(error).to.be.instanceOf(BehaviorTreeRunTimeoutError);
+      expect((error as BehaviorTreeRunTimeoutError).code).to.equal("E-BT-RUN-TIMEOUT");
+    } finally {
+      await rm(planContext.childrenRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/server.tools.schemas.test.ts
+++ b/tests/server.tools.schemas.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  PlanCompileBTInputSchema,
+  PlanRunBTInputSchema,
+} from "../src/tools/planTools.js";
+import { CausalExplainInputSchema } from "../src/tools/causalTools.js";
+import {
+  ValuesFilterInputSchema,
+  ValuesSetInputSchema,
+} from "../src/tools/valueTools.js";
+
+/**
+ * Validation-focused regression tests ensuring the server-facing schemas reject
+ * malformed payloads deterministically. Keeping those checks centralised avoids
+ * relying on MCP integration tests to catch regressions.
+ */
+describe("server tool schemas", () => {
+  it("rejects Behaviour Tree compilation payloads lacking a graph", () => {
+    const result = PlanCompileBTInputSchema.safeParse({});
+    expect(result.success).to.equal(false);
+  });
+
+  it("rejects Behaviour Tree run payloads with an invalid timeout", () => {
+    const definition = {
+      id: "bt-test",
+      root: { type: "task", node_id: "noop", tool: "noop" },
+    };
+    const result = PlanRunBTInputSchema.safeParse({
+      tree: definition,
+      timeout_ms: 0,
+    });
+    expect(result.success).to.equal(false);
+  });
+
+  it("rejects causal explanations without an outcome id", () => {
+    const result = CausalExplainInputSchema.safeParse({ outcome_id: "" });
+    expect(result.success).to.equal(false);
+  });
+
+  it("rejects value graph updates that omit node definitions", () => {
+    const result = ValuesSetInputSchema.safeParse({ nodes: [] });
+    expect(result.success).to.equal(false);
+  });
+
+  it("rejects value guard evaluations without impacts", () => {
+    const result = ValuesFilterInputSchema.safeParse({
+      impacts: [],
+    });
+    expect(result.success).to.equal(false);
+  });
+});

--- a/tests/serverOptions.parse.test.ts
+++ b/tests/serverOptions.parse.test.ts
@@ -24,6 +24,24 @@ describe("parseOrchestratorRuntimeOptions", () => {
     expect(result.enableReflection).to.equal(true);
     expect(result.enableQualityGate).to.equal(true);
     expect(result.qualityThreshold).to.equal(70);
+    expect(result.features).to.deep.equal({
+      enableBT: false,
+      enableReactiveScheduler: false,
+      enableBlackboard: false,
+      enableStigmergy: false,
+      enableCNP: false,
+      enableConsensus: false,
+      enableAutoscaler: false,
+      enableSupervisor: false,
+      enableKnowledge: false,
+      enableCausalMemory: false,
+      enableValueGuard: false,
+    });
+    expect(result.timings).to.deep.equal({
+      btTickMs: 50,
+      stigHalfLifeMs: 30_000,
+      supervisorStallTicks: 6,
+    });
   });
 
   it("accepte les options HTTP explicites", () => {
@@ -83,6 +101,53 @@ describe("parseOrchestratorRuntimeOptions", () => {
     const result = parseOrchestratorRuntimeOptions(["--no-reflection", "--no-quality-gate"]);
     expect(result.enableReflection).to.equal(false);
     expect(result.enableQualityGate).to.equal(false);
+  });
+
+  it("active sélectivement les modules optionnels", () => {
+    const result = parseOrchestratorRuntimeOptions([
+      "--enable-bt",
+      "--enable-reactive-scheduler",
+      "--enable-blackboard",
+      "--enable-stigmergy",
+      "--enable-cnp",
+      "--enable-consensus",
+      "--enable-autoscaler",
+      "--enable-supervisor",
+      "--enable-knowledge",
+      "--enable-causal-memory",
+      "--enable-value-guard",
+    ]);
+
+    expect(result.features).to.deep.equal({
+      enableBT: true,
+      enableReactiveScheduler: true,
+      enableBlackboard: true,
+      enableStigmergy: true,
+      enableCNP: true,
+      enableConsensus: true,
+      enableAutoscaler: true,
+      enableSupervisor: true,
+      enableKnowledge: true,
+      enableCausalMemory: true,
+      enableValueGuard: true,
+    });
+  });
+
+  it("applique les délais personnalisés", () => {
+    const result = parseOrchestratorRuntimeOptions([
+      "--bt-tick-ms",
+      "75",
+      "--stig-half-life-ms",
+      "45000",
+      "--supervisor-stall-ticks",
+      "9",
+    ]);
+
+    expect(result.timings).to.deep.equal({
+      btTickMs: 75,
+      stigHalfLifeMs: 45_000,
+      supervisorStallTicks: 9,
+    });
   });
 
   it("applique le seuil qualité lorsque fourni", () => {


### PR DESCRIPTION
## Summary
- normalise the `plan_reduce` vote aggregator so JSON summaries yield stable vote values and trace diagnostics
- assert the winning consensus value in `tests/plan.fanout-join.test.ts`
- record the fix in `AGENTS.md` for future iterations

## Testing
- node --loader ./node_modules/ts-node/esm.mjs ./node_modules/mocha/bin/mocha.js --reporter tap tests/plan.fanout-join.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd30495c68832fb555f886e95accbe