### PR TITLE
Add cancellation registry and MCP cancellation tools

### DIFF
--- a/dist/events/bus.js
+++ b/dist/events/bus.js
@@ -1,0 +1,171 @@
+import { EventEmitter } from "node:events";
+/** Internal event emitted whenever the bus records a new envelope. */
+const BUS_EVENT = "event";
+/** Utility ensuring categories remain normalised for lookups. */
+function normaliseCategory(cat) {
+    return cat.trim().toLowerCase();
+}
+/** Utility ensuring event messages are compact and predictable. */
+function normaliseMessage(msg) {
+    const trimmed = msg.trim();
+    return trimmed.length > 0 ? trimmed : "event";
+}
+/**
+ * Async iterator used to expose live streams. The iterator buffers events until
+ * a consumer reads them, mirroring the behaviour of a JSON Lines stream.
+ */
+class EventStream {
+    emitter;
+    matcher;
+    buffer = [];
+    resolve;
+    closed = false;
+    constructor(emitter, matcher, seed) {
+        this.emitter = emitter;
+        this.matcher = matcher;
+        for (const event of seed) {
+            if (this.matcher(event)) {
+                this.buffer.push(event);
+            }
+        }
+        this.emitter.on(BUS_EVENT, this.handleEvent);
+    }
+    [Symbol.asyncIterator]() {
+        return this;
+    }
+    async next() {
+        if (this.buffer.length > 0) {
+            return { value: this.buffer.shift(), done: false };
+        }
+        if (this.closed) {
+            return { value: undefined, done: true };
+        }
+        return new Promise((resolve) => {
+            this.resolve = resolve;
+        });
+    }
+    async return() {
+        this.close();
+        return { value: undefined, done: true };
+    }
+    close() {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+        this.emitter.removeListener(BUS_EVENT, this.handleEvent);
+        if (this.resolve) {
+            this.resolve({ value: undefined, done: true });
+            this.resolve = undefined;
+        }
+    }
+    handleEvent = (event) => {
+        if (this.closed || !this.matcher(event)) {
+            return;
+        }
+        if (this.resolve) {
+            this.resolve({ value: event, done: false });
+            this.resolve = undefined;
+            return;
+        }
+        this.buffer.push(event);
+    };
+}
+/**
+ * Unified event bus buffering orchestration events in memory. The bus offers
+ * both random access (via {@link list}) and live streaming (via
+ * {@link subscribe}) which keeps downstream MCP tools deterministic and easy
+ * to test.
+ */
+export class EventBus {
+    emitter = new EventEmitter();
+    history = [];
+    historyLimit;
+    now;
+    seq = 0;
+    constructor(options = {}) {
+        this.historyLimit = Math.max(1, options.historyLimit ?? 1_000);
+        this.now = options.now ?? (() => Date.now());
+    }
+    /** Adjust the history limit at runtime and trim existing entries accordingly. */
+    setHistoryLimit(limit) {
+        this.historyLimit = Math.max(1, limit);
+        while (this.history.length > this.historyLimit) {
+            this.history.shift();
+        }
+    }
+    /** Determine whether an event matches the provided filters. */
+    matches(event, filter) {
+        const normalisedCats = filter.cats?.map(normaliseCategory);
+        const normalisedLevels = filter.levels?.map((level) => level.toLowerCase());
+        if (normalisedCats && normalisedCats.length > 0 && !normalisedCats.includes(event.cat)) {
+            return false;
+        }
+        if (normalisedLevels && normalisedLevels.length > 0 && !normalisedLevels.includes(event.level)) {
+            return false;
+        }
+        if (filter.jobId && event.jobId !== filter.jobId) {
+            return false;
+        }
+        if (filter.runId && event.runId !== filter.runId) {
+            return false;
+        }
+        if (filter.opId && event.opId !== filter.opId) {
+            return false;
+        }
+        if (filter.graphId && event.graphId !== filter.graphId) {
+            return false;
+        }
+        if (filter.childId && event.childId !== filter.childId) {
+            return false;
+        }
+        if (filter.nodeId && event.nodeId !== filter.nodeId) {
+            return false;
+        }
+        if (typeof filter.afterSeq === "number" && !(event.seq > filter.afterSeq)) {
+            return false;
+        }
+        return true;
+    }
+    /** Publish a new event on the bus. */
+    publish(input) {
+        const envelope = {
+            seq: ++this.seq,
+            ts: input.ts ?? this.now(),
+            cat: normaliseCategory(input.cat),
+            level: input.level ?? "info",
+            jobId: input.jobId ?? null,
+            runId: input.runId ?? null,
+            opId: input.opId ?? null,
+            graphId: input.graphId ?? null,
+            nodeId: input.nodeId ?? null,
+            childId: input.childId ?? null,
+            msg: normaliseMessage(input.msg),
+            data: input.data,
+        };
+        this.history.push(envelope);
+        if (this.history.length > this.historyLimit) {
+            this.history.shift();
+        }
+        this.emitter.emit(BUS_EVENT, envelope);
+        return envelope;
+    }
+    /**
+     * Returns a snapshot of events matching the provided filters. The snapshot is
+     * sorted chronologically and truncated to `limit` when specified.
+     */
+    list(filter = {}) {
+        const sliced = this.history.filter((event) => this.matches(event, filter));
+        const limit = filter.limit && filter.limit > 0 ? Math.min(filter.limit, this.historyLimit) : this.historyLimit;
+        return sliced.slice(-limit);
+    }
+    /**
+     * Creates an async iterator streaming live events. Consumers should call
+     * {@link EventStream.close} once finished to avoid leaking listeners.
+     */
+    subscribe(filter = {}) {
+        const matcher = (event) => this.matches(event, filter);
+        const seed = this.list(filter);
+        return new EventStream(this.emitter, matcher, seed);
+    }
+}

--- a/dist/executor/bt/types.js
+++ b/dist/executor/bt/types.js
@@ -41,6 +41,11 @@ export const BehaviorNodeDefinitionSchema = z.lazy(() => z
         child: BehaviorNodeDefinitionSchema,
     }),
     z.object({
+        type: z.literal("cancellable"),
+        id: z.string().min(1).optional(),
+        child: BehaviorNodeDefinitionSchema,
+    }),
+    z.object({
         type: z.literal("task"),
         id: z.string().min(1).optional(),
         node_id: z.string().min(1),

--- a/dist/executor/cancel.js
+++ b/dist/executor/cancel.js
@@ -1,0 +1,171 @@
+import { EventEmitter } from "node:events";
+/** Event emitted whenever a cancellation is requested. */
+const EVENT_CANCELLED = "cancelled";
+/** Shared emitter used to fan-out cancellation notifications. */
+const cancellationEmitter = new EventEmitter();
+/** Registry storing the lifecycle of every cancellable operation. */
+const operations = new Map();
+/** Reverse index mapping run identifiers to their active operations. */
+const runIndex = new Map();
+/**
+ * Error raised when an operation observes a cancellation signal. The error is
+ * structured so the orchestrator can propagate consistent MCP payloads.
+ */
+export class OperationCancelledError extends Error {
+    code = "E-CANCEL-OP";
+    hint = "operation_cancelled";
+    details;
+    constructor(opId, runId, reason) {
+        super(reason ? `operation ${opId} cancelled: ${reason}` : `operation ${opId} cancelled`);
+        this.name = "OperationCancelledError";
+        this.details = { opId, runId, reason };
+    }
+}
+/**
+ * Register a new cancellable operation. Consumers should ensure
+ * {@link unregisterCancellation} is called once the work completes to avoid
+ * leaking book-keeping data.
+ */
+export function registerCancellation(opId, options = {}) {
+    if (operations.has(opId)) {
+        throw new Error(`cancellation handle already registered for ${opId}`);
+    }
+    const controller = new AbortController();
+    const runId = options.runId ?? null;
+    const createdAt = options.createdAt ?? Date.now();
+    const entry = {
+        opId,
+        controller,
+        runId,
+        createdAt,
+        cancelledAt: null,
+        reason: null,
+        handle: undefined,
+    };
+    const handle = {
+        get opId() {
+            return entry.opId;
+        },
+        get runId() {
+            return entry.runId;
+        },
+        get createdAt() {
+            return entry.createdAt;
+        },
+        get cancelledAt() {
+            return entry.cancelledAt;
+        },
+        get reason() {
+            return entry.reason;
+        },
+        get signal() {
+            return entry.controller.signal;
+        },
+        isCancelled() {
+            return entry.controller.signal.aborted;
+        },
+        throwIfCancelled() {
+            if (entry.controller.signal.aborted) {
+                throw handle.toError();
+            }
+        },
+        onCancel(listener) {
+            const wrapped = (payload) => {
+                if (payload.opId === entry.opId) {
+                    listener({ reason: payload.reason, at: payload.at });
+                }
+            };
+            cancellationEmitter.on(EVENT_CANCELLED, wrapped);
+            return () => {
+                cancellationEmitter.off(EVENT_CANCELLED, wrapped);
+            };
+        },
+        toError() {
+            return new OperationCancelledError(entry.opId, entry.runId, entry.reason);
+        },
+    };
+    entry.handle = handle;
+    operations.set(opId, entry);
+    if (runId) {
+        if (!runIndex.has(runId)) {
+            runIndex.set(runId, new Set());
+        }
+        runIndex.get(runId).add(opId);
+    }
+    return handle;
+}
+/** Retrieve a handle previously registered with {@link registerCancellation}. */
+export function getCancellation(opId) {
+    return operations.get(opId)?.handle;
+}
+/** Remove the bookkeeping for an operation once it settles. */
+export function unregisterCancellation(opId) {
+    const entry = operations.get(opId);
+    if (!entry) {
+        return;
+    }
+    operations.delete(opId);
+    if (entry.runId) {
+        const bucket = runIndex.get(entry.runId);
+        if (bucket) {
+            bucket.delete(opId);
+            if (bucket.size === 0) {
+                runIndex.delete(entry.runId);
+            }
+        }
+    }
+}
+/** Determine whether an operation has observed a cancellation request. */
+export function isCancelled(opId) {
+    return operations.get(opId)?.controller.signal.aborted ?? false;
+}
+/**
+ * Request the cancellation of a specific operation.
+ */
+export function requestCancellation(opId, options = {}) {
+    const entry = operations.get(opId);
+    if (!entry) {
+        return "not_found";
+    }
+    const alreadyCancelled = entry.controller.signal.aborted;
+    if (!alreadyCancelled) {
+        entry.reason = options.reason ?? entry.reason;
+        entry.cancelledAt = options.at ?? Date.now();
+        entry.controller.abort();
+        cancellationEmitter.emit(EVENT_CANCELLED, {
+            opId: entry.opId,
+            reason: entry.reason,
+            at: entry.cancelledAt ?? Date.now(),
+        });
+        return "requested";
+    }
+    if (options.reason && !entry.reason) {
+        entry.reason = options.reason;
+    }
+    return "already_cancelled";
+}
+/**
+ * Request the cancellation of every operation associated with the provided run
+ * identifier. The function returns the list of affected operations along with
+ * their individual outcomes so callers can report partial failures.
+ */
+export function cancelRun(runId, options = {}) {
+    const bucket = runIndex.get(runId);
+    if (!bucket || bucket.size === 0) {
+        return [];
+    }
+    const results = [];
+    for (const opId of bucket) {
+        const outcome = requestCancellation(opId, options);
+        results.push({ opId, outcome });
+    }
+    return results;
+}
+/**
+ * Utility mainly exposed for unit tests so they can isolate registry state
+ * without relying on implicit global ordering.
+ */
+export function resetCancellationRegistry() {
+    operations.clear();
+    runIndex.clear();
+}

--- a/dist/mcp/info.js
+++ b/dist/mcp/info.js
@@ -1,0 +1,172 @@
+/** Default values mirroring the conservative bootstrap configuration. */
+const DEFAULT_RUNTIME_SNAPSHOT = {
+    server: { name: "self-codex", version: "0.0.0", mcpVersion: "1.0" },
+    transports: {
+        stdio: { enabled: true },
+        http: {
+            enabled: false,
+            host: null,
+            port: null,
+            path: null,
+            enableJson: true,
+            stateless: false,
+        },
+    },
+    features: {
+        enableBT: false,
+        enableReactiveScheduler: false,
+        enableBlackboard: false,
+        enableStigmergy: false,
+        enableCNP: false,
+        enableConsensus: false,
+        enableAutoscaler: false,
+        enableSupervisor: false,
+        enableKnowledge: false,
+        enableCausalMemory: false,
+        enableValueGuard: false,
+        enableMcpIntrospection: false,
+        enableResources: false,
+        enableEventsBus: false,
+        enableCancellation: false,
+        enableTx: false,
+        enableBulk: false,
+        enableIdempotency: false,
+        enableLocks: false,
+        enableDiffPatch: false,
+        enablePlanLifecycle: false,
+        enableChildOpsFine: false,
+        enableValuesExplain: false,
+        enableAssist: false,
+    },
+    timings: {
+        btTickMs: 50,
+        stigHalfLifeMs: 30_000,
+        supervisorStallTicks: 6,
+        defaultTimeoutMs: 60_000,
+        autoscaleCooldownMs: 10_000,
+    },
+    safety: {
+        maxChildren: 16,
+        memoryLimitMb: 512,
+        cpuPercent: 100,
+    },
+    limits: {
+        maxInputBytes: 512 * 1024,
+        defaultTimeoutMs: 60_000,
+        maxEventHistory: 1_000,
+    },
+};
+/** Internal mutable reference storing the current snapshot. */
+let runtimeSnapshot = cloneSnapshot(DEFAULT_RUNTIME_SNAPSHOT);
+/**
+ * Creates a deep copy of the provided snapshot to prevent external mutation.
+ */
+function cloneSnapshot(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+/**
+ * Returns the current MCP runtime snapshot. A defensive copy is returned so
+ * callers cannot accidentally mutate the internal state.
+ */
+export function getMcpRuntimeSnapshot() {
+    return cloneSnapshot(runtimeSnapshot);
+}
+/**
+ * Replaces the runtime snapshot with a new value. Primarily used by tests so
+ * they can restore the previous state between assertions.
+ */
+export function setMcpRuntimeSnapshot(next) {
+    runtimeSnapshot = cloneSnapshot(next);
+}
+/**
+ * Applies a partial update to the runtime snapshot. Only the provided sections
+ * are updated which keeps the function lightweight for frequent calls.
+ */
+export function updateMcpRuntimeSnapshot(update) {
+    const next = cloneSnapshot(runtimeSnapshot);
+    if (update.server) {
+        next.server = { ...next.server, ...update.server };
+    }
+    if (update.transports?.stdio) {
+        next.transports.stdio = { ...next.transports.stdio, ...update.transports.stdio };
+    }
+    if (update.transports?.http) {
+        next.transports.http = { ...next.transports.http, ...update.transports.http };
+    }
+    if (update.features) {
+        next.features = { ...update.features };
+    }
+    if (update.timings) {
+        next.timings = { ...update.timings };
+    }
+    if (update.safety) {
+        next.safety = { ...update.safety };
+    }
+    if (update.limits) {
+        next.limits = { ...next.limits, ...update.limits };
+    }
+    runtimeSnapshot = next;
+}
+/**
+ * Computes the list of namespaces that should be advertised given the current
+ * feature toggles. The mapping is intentionally explicit so that future
+ * modules can extend the handshake in a single location.
+ */
+function computeCapabilityNamespaces(features) {
+    const definitions = [
+        { name: "core.jobs", description: "Gestion des jobs orchestrateur" },
+        { name: "graph.core", description: "Inspection et mutations de graphes" },
+        { name: "plan.bt", description: "Compilation et exécution Behaviour Tree", feature: "enableBT" },
+        { name: "plan.reactive", description: "Boucle scheduler réactif", feature: "enableReactiveScheduler" },
+        { name: "coord.blackboard", description: "Coordination via blackboard", feature: "enableBlackboard" },
+        { name: "coord.stigmergy", description: "Champ stigmergique", feature: "enableStigmergy" },
+        { name: "coord.contract-net", description: "Protocole Contract-Net", feature: "enableCNP" },
+        { name: "coord.consensus", description: "Vote par consensus", feature: "enableConsensus" },
+        { name: "agents.autoscaler", description: "Autoscaler d'enfants", feature: "enableAutoscaler" },
+        { name: "agents.supervisor", description: "Superviseur orchestrateur", feature: "enableSupervisor" },
+        { name: "memory.knowledge", description: "Graphe de connaissance", feature: "enableKnowledge" },
+        { name: "memory.causal", description: "Mémoire causale", feature: "enableCausalMemory" },
+        { name: "values.guard", description: "Filtre par valeurs", feature: "enableValueGuard" },
+    ];
+    return definitions
+        .filter((definition) => {
+        if (!definition.feature) {
+            return true;
+        }
+        return Boolean(features[definition.feature]);
+    })
+        .map(({ name, description }) => ({ name, description }));
+}
+/**
+ * Builds a JSON friendly summary for each namespace so clients can display the
+ * available areas without having to understand the full schema definitions.
+ */
+function buildSchemaSummaries(namespaces) {
+    const summaries = {};
+    for (const entry of namespaces) {
+        summaries[entry.name] = {
+            namespace: entry.name,
+            summary: entry.description,
+        };
+    }
+    return summaries;
+}
+/**
+ * Returns the current MCP information payload mirrored by the `mcp_info` tool.
+ */
+export function getMcpInfo() {
+    return cloneSnapshot(runtimeSnapshot);
+}
+/**
+ * Returns the capability listing derived from the runtime snapshot. The
+ * function recomputes namespaces on the fly to ensure feature toggles are
+ * honoured.
+ */
+export function getMcpCapabilities() {
+    const namespaces = computeCapabilityNamespaces(runtimeSnapshot.features);
+    return {
+        namespaces,
+        schemas: buildSchemaSummaries(namespaces),
+        limits: { maxEventHistory: runtimeSnapshot.limits.maxEventHistory },
+    };
+}

--- a/dist/resources/registry.js
+++ b/dist/resources/registry.js
@@ -1,0 +1,447 @@
+import { EventEmitter } from "node:events";
+/** Base error emitted by the resource registry. */
+export class ResourceRegistryError extends Error {
+    code;
+    hint;
+    details;
+    constructor(code, message, hint, details) {
+        super(message);
+        this.code = code;
+        this.hint = hint;
+        this.details = details;
+        this.name = "ResourceRegistryError";
+    }
+}
+/** Error raised when attempting to resolve an unknown resource. */
+export class ResourceNotFoundError extends ResourceRegistryError {
+    constructor(uri) {
+        super("E-RES-NOT_FOUND", `resource '${uri}' does not exist`);
+        this.name = "ResourceNotFoundError";
+    }
+}
+/** Error raised when a watch operation is not supported for the URI. */
+export class ResourceWatchUnsupportedError extends ResourceRegistryError {
+    constructor(uri) {
+        super("E-RES-UNSUPPORTED", `resource '${uri}' cannot be watched`, "watch_not_supported");
+        this.name = "ResourceWatchUnsupportedError";
+    }
+}
+/** Utility ensuring limits remain sane. */
+function clampPositive(value, fallback) {
+    if (!value || !Number.isFinite(value) || value <= 0) {
+        return fallback;
+    }
+    return Math.floor(value);
+}
+/** Creates a defensive deep clone so callers cannot mutate stored state. */
+function clone(value) {
+    return structuredClone(value);
+}
+/** Extract the namespace portion of a blackboard key. */
+function extractNamespace(key) {
+    const separators = [":", "/", "|"]; // keep flexible to accommodate multiple conventions
+    for (const separator of separators) {
+        const index = key.indexOf(separator);
+        if (index > 0) {
+            return key.slice(0, index);
+        }
+    }
+    return key;
+}
+/** Maintains deterministic MCP resource metadata and snapshots. */
+export class ResourceRegistry {
+    graphHistories = new Map();
+    graphSnapshots = new Map();
+    runHistories = new Map();
+    childHistories = new Map();
+    runHistoryLimit;
+    childLogHistoryLimit;
+    blackboard;
+    constructor(options = {}) {
+        this.runHistoryLimit = clampPositive(options.runHistoryLimit, 500);
+        this.childLogHistoryLimit = clampPositive(options.childLogHistoryLimit, 500);
+        this.blackboard = options.blackboard ?? null;
+    }
+    /**
+     * Records a transaction snapshot so clients can inspect the base version even
+     * if the transaction later aborts.
+     */
+    recordGraphSnapshot(input) {
+        const normalised = this.getOrCreateSnapshotBucket(input.graphId);
+        const snapshot = {
+            txId: input.txId,
+            graphId: input.graphId,
+            baseVersion: input.baseVersion,
+            startedAt: input.startedAt,
+            state: "pending",
+            committedAt: null,
+            finalVersion: null,
+            baseGraph: clone(input.graph),
+            finalGraph: null,
+        };
+        normalised.set(input.txId, snapshot);
+    }
+    /** Marks a transaction snapshot as committed and stores the resulting graph. */
+    markGraphSnapshotCommitted(input) {
+        const bucket = this.graphSnapshots.get(input.graphId);
+        if (!bucket) {
+            return;
+        }
+        const snapshot = bucket.get(input.txId);
+        if (!snapshot) {
+            return;
+        }
+        snapshot.state = "committed";
+        snapshot.committedAt = input.committedAt;
+        snapshot.finalVersion = input.finalVersion;
+        snapshot.finalGraph = clone(input.finalGraph);
+        bucket.set(input.txId, snapshot);
+    }
+    /** Marks a transaction snapshot as rolled back. */
+    markGraphSnapshotRolledBack(graphId, txId) {
+        const bucket = this.graphSnapshots.get(graphId);
+        if (!bucket) {
+            return;
+        }
+        const snapshot = bucket.get(txId);
+        if (!snapshot) {
+            return;
+        }
+        snapshot.state = "rolled_back";
+        snapshot.committedAt = null;
+        snapshot.finalVersion = null;
+        snapshot.finalGraph = null;
+        bucket.set(txId, snapshot);
+    }
+    /** Records a committed graph version. */
+    recordGraphVersion(input) {
+        if (!input.graphId) {
+            return;
+        }
+        const history = this.getOrCreateGraphHistory(input.graphId);
+        const record = {
+            version: input.version,
+            committedAt: input.committedAt,
+            graph: clone(input.graph),
+        };
+        history.versions.set(input.version, record);
+        if (input.version >= history.latestVersion) {
+            history.latestVersion = input.version;
+        }
+        this.graphHistories.set(input.graphId, history);
+    }
+    /** Records an orchestrator event correlated with a run identifier. */
+    recordRunEvent(runId, event) {
+        if (!runId.trim()) {
+            return;
+        }
+        const history = this.getOrCreateRunHistory(runId);
+        const payload = {
+            seq: event.seq,
+            ts: event.ts,
+            kind: event.kind,
+            level: event.level,
+            jobId: event.jobId ?? null,
+            childId: event.childId ?? null,
+            payload: clone(event.payload ?? null),
+        };
+        history.events.push(payload);
+        history.lastSeq = Math.max(history.lastSeq, payload.seq);
+        if (history.events.length > this.runHistoryLimit) {
+            history.events.splice(0, history.events.length - this.runHistoryLimit);
+        }
+        history.emitter.emit("event", payload);
+    }
+    /** Records a log entry produced by a child runtime. */
+    recordChildLogEntry(childId, entry) {
+        if (!childId.trim()) {
+            return;
+        }
+        const history = this.getOrCreateChildHistory(childId);
+        const seq = history.lastSeq + 1;
+        const record = {
+            seq,
+            ts: entry.ts,
+            stream: entry.stream,
+            message: entry.message,
+        };
+        history.entries.push(record);
+        history.lastSeq = seq;
+        if (history.entries.length > this.childLogHistoryLimit) {
+            history.entries.splice(0, history.entries.length - this.childLogHistoryLimit);
+        }
+        history.emitter.emit("event", record);
+    }
+    /**
+     * Returns a deterministic list of URIs. The entries are sorted to guarantee a
+     * stable contract for clients performing prefix scans.
+     */
+    list(prefix) {
+        const entries = [];
+        for (const [graphId, history] of this.graphHistories.entries()) {
+            entries.push({
+                uri: `sc://graphs/${graphId}`,
+                kind: "graph",
+                metadata: { latest_version: history.latestVersion },
+            });
+            for (const version of history.versions.keys()) {
+                entries.push({
+                    uri: `sc://graphs/${graphId}@v${version}`,
+                    kind: "graph_version",
+                });
+            }
+        }
+        for (const [graphId, bucket] of this.graphSnapshots.entries()) {
+            for (const snapshot of bucket.values()) {
+                entries.push({
+                    uri: `sc://snapshots/${graphId}/${snapshot.txId}`,
+                    kind: "snapshot",
+                    metadata: { state: snapshot.state, base_version: snapshot.baseVersion },
+                });
+            }
+        }
+        for (const runId of this.runHistories.keys()) {
+            entries.push({ uri: `sc://runs/${runId}/events`, kind: "run_events" });
+        }
+        for (const childId of this.childHistories.keys()) {
+            entries.push({ uri: `sc://children/${childId}/logs`, kind: "child_logs" });
+        }
+        for (const namespace of this.listBlackboardNamespaces()) {
+            entries.push({ uri: `sc://blackboard/${namespace}`, kind: "blackboard_namespace" });
+        }
+        const filtered = prefix ? entries.filter((entry) => entry.uri.startsWith(prefix)) : entries;
+        return filtered.sort((a, b) => a.uri.localeCompare(b.uri));
+    }
+    /** Returns the materialised payload for the requested URI. */
+    read(uri) {
+        const parsed = this.parseUri(uri);
+        switch (parsed.kind) {
+            case "graph": {
+                const history = this.graphHistories.get(parsed.graphId);
+                if (!history || history.latestVersion === 0) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                const record = history.versions.get(history.latestVersion);
+                if (!record) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return {
+                    uri,
+                    kind: "graph",
+                    payload: {
+                        graphId: parsed.graphId,
+                        version: record.version,
+                        committedAt: record.committedAt,
+                        graph: clone(record.graph),
+                    },
+                };
+            }
+            case "graph_version": {
+                const history = this.graphHistories.get(parsed.graphId);
+                const record = history?.versions.get(parsed.version ?? -1);
+                if (!record) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return {
+                    uri,
+                    kind: "graph_version",
+                    payload: {
+                        graphId: parsed.graphId,
+                        version: record.version,
+                        committedAt: record.committedAt,
+                        graph: clone(record.graph),
+                    },
+                };
+            }
+            case "snapshot": {
+                const bucket = this.graphSnapshots.get(parsed.graphId);
+                const snapshot = bucket?.get(parsed.txId ?? "");
+                if (!snapshot) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return {
+                    uri,
+                    kind: "snapshot",
+                    payload: clone(snapshot),
+                };
+            }
+            case "run_events": {
+                const history = this.runHistories.get(parsed.runId ?? "");
+                if (!history) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return {
+                    uri,
+                    kind: "run_events",
+                    payload: { runId: parsed.runId, events: history.events.map((evt) => clone(evt)) },
+                };
+            }
+            case "child_logs": {
+                const history = this.childHistories.get(parsed.childId ?? "");
+                if (!history) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return {
+                    uri,
+                    kind: "child_logs",
+                    payload: { childId: parsed.childId, logs: history.entries.map((entry) => clone(entry)) },
+                };
+            }
+            case "blackboard_namespace": {
+                if (!this.blackboard) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                const entries = this.blackboard
+                    .query()
+                    .filter((entry) => extractNamespace(entry.key) === parsed.namespace)
+                    .map((entry) => clone(entry));
+                if (entries.length === 0) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return {
+                    uri,
+                    kind: "blackboard_namespace",
+                    payload: { namespace: parsed.namespace, entries },
+                };
+            }
+            default:
+                throw new ResourceNotFoundError(uri);
+        }
+    }
+    /**
+     * Returns a monotonic slice of events/logs associated with the resource.
+     * Unsupported resources raise {@link ResourceWatchUnsupportedError}.
+     */
+    watch(uri, options = {}) {
+        const fromSeq = options.fromSeq ?? 0;
+        const limit = clampPositive(options.limit, 250);
+        const parsed = this.parseUri(uri);
+        switch (parsed.kind) {
+            case "run_events": {
+                const history = this.runHistories.get(parsed.runId ?? "");
+                if (!history) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                const events = history.events
+                    .filter((event) => event.seq > fromSeq)
+                    .sort((a, b) => a.seq - b.seq)
+                    .slice(0, limit)
+                    .map((event) => clone(event));
+                const nextSeq = events.length > 0 ? events[events.length - 1].seq : Math.max(fromSeq, history.lastSeq);
+                return { uri, kind: "run_events", events, nextSeq };
+            }
+            case "child_logs": {
+                const history = this.childHistories.get(parsed.childId ?? "");
+                if (!history) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                const events = history.entries
+                    .filter((entry) => entry.seq > fromSeq)
+                    .sort((a, b) => a.seq - b.seq)
+                    .slice(0, limit)
+                    .map((entry) => clone(entry));
+                const nextSeq = events.length > 0 ? events[events.length - 1].seq : Math.max(fromSeq, history.lastSeq);
+                return { uri, kind: "child_logs", events, nextSeq };
+            }
+            default:
+                throw new ResourceWatchUnsupportedError(uri);
+        }
+    }
+    getOrCreateGraphHistory(graphId) {
+        const existing = this.graphHistories.get(graphId);
+        if (existing) {
+            return existing;
+        }
+        const history = { latestVersion: 0, versions: new Map() };
+        this.graphHistories.set(graphId, history);
+        return history;
+    }
+    getOrCreateSnapshotBucket(graphId) {
+        const existing = this.graphSnapshots.get(graphId);
+        if (existing) {
+            return existing;
+        }
+        const bucket = new Map();
+        this.graphSnapshots.set(graphId, bucket);
+        return bucket;
+    }
+    getOrCreateRunHistory(runId) {
+        const existing = this.runHistories.get(runId);
+        if (existing) {
+            return existing;
+        }
+        const history = { events: [], lastSeq: 0, emitter: new EventEmitter() };
+        this.runHistories.set(runId, history);
+        return history;
+    }
+    getOrCreateChildHistory(childId) {
+        const existing = this.childHistories.get(childId);
+        if (existing) {
+            return existing;
+        }
+        const history = { entries: [], lastSeq: 0, emitter: new EventEmitter() };
+        this.childHistories.set(childId, history);
+        return history;
+    }
+    listBlackboardNamespaces() {
+        if (!this.blackboard) {
+            return [];
+        }
+        const namespaces = new Set();
+        for (const entry of this.blackboard.query()) {
+            namespaces.add(extractNamespace(entry.key));
+        }
+        return Array.from(namespaces.values());
+    }
+    parseUri(uri) {
+        if (!uri.startsWith("sc://")) {
+            throw new ResourceNotFoundError(uri);
+        }
+        const body = uri.slice("sc://".length);
+        if (body.startsWith("graphs/")) {
+            const remainder = body.slice("graphs/".length);
+            const [identifier, versionSuffix] = remainder.split("@v");
+            if (!identifier) {
+                throw new ResourceNotFoundError(uri);
+            }
+            if (versionSuffix !== undefined) {
+                const version = Number(versionSuffix);
+                if (!Number.isInteger(version) || version <= 0) {
+                    throw new ResourceNotFoundError(uri);
+                }
+                return { kind: "graph_version", graphId: identifier, version };
+            }
+            return { kind: "graph", graphId: identifier };
+        }
+        if (body.startsWith("snapshots/")) {
+            const remainder = body.slice("snapshots/".length);
+            const [graphId, txId] = remainder.split("/");
+            if (!graphId || !txId) {
+                throw new ResourceNotFoundError(uri);
+            }
+            return { kind: "snapshot", graphId, txId };
+        }
+        if (body.startsWith("runs/") && body.endsWith("/events")) {
+            const runId = body.slice("runs/".length, body.length - "/events".length);
+            if (!runId) {
+                throw new ResourceNotFoundError(uri);
+            }
+            return { kind: "run_events", runId };
+        }
+        if (body.startsWith("children/") && body.endsWith("/logs")) {
+            const childId = body.slice("children/".length, body.length - "/logs".length);
+            if (!childId) {
+                throw new ResourceNotFoundError(uri);
+            }
+            return { kind: "child_logs", childId };
+        }
+        if (body.startsWith("blackboard/")) {
+            const namespace = body.slice("blackboard/".length);
+            if (!namespace) {
+                throw new ResourceNotFoundError(uri);
+            }
+            return { kind: "blackboard_namespace", namespace };
+        }
+        throw new ResourceNotFoundError(uri);
+    }
+}

--- a/dist/serverOptions.js
+++ b/dist/serverOptions.js
@@ -15,6 +15,8 @@ const FLAG_WITH_VALUE = new Set([
     "--bt-tick-ms",
     "--stig-half-life-ms",
     "--supervisor-stall-ticks",
+    "--default-timeout-ms",
+    "--autoscale-cooldown-ms",
     "--dashboard-port",
     "--dashboard-host",
     "--dashboard-interval-ms",
@@ -92,11 +94,26 @@ const DEFAULT_STATE = {
         enableKnowledge: false,
         enableCausalMemory: false,
         enableValueGuard: false,
+        enableMcpIntrospection: false,
+        enableResources: false,
+        enableEventsBus: false,
+        enableCancellation: false,
+        enableTx: false,
+        enableBulk: false,
+        enableIdempotency: false,
+        enableLocks: false,
+        enableDiffPatch: false,
+        enablePlanLifecycle: false,
+        enableChildOpsFine: false,
+        enableValuesExplain: false,
+        enableAssist: false,
     },
     timings: {
         btTickMs: 50,
         stigHalfLifeMs: 30_000,
         supervisorStallTicks: 6,
+        defaultTimeoutMs: 60_000,
+        autoscaleCooldownMs: 10_000,
     },
     safety: {
         maxChildren: 16,
@@ -295,6 +312,84 @@ export function parseOrchestratorRuntimeOptions(argv) {
             case "--disable-value-guard":
                 state.featureToggles.enableValueGuard = false;
                 break;
+            case "--enable-mcp-introspection":
+                state.featureToggles.enableMcpIntrospection = true;
+                break;
+            case "--disable-mcp-introspection":
+                state.featureToggles.enableMcpIntrospection = false;
+                break;
+            case "--enable-resources":
+                state.featureToggles.enableResources = true;
+                break;
+            case "--disable-resources":
+                state.featureToggles.enableResources = false;
+                break;
+            case "--enable-events-bus":
+                state.featureToggles.enableEventsBus = true;
+                break;
+            case "--disable-events-bus":
+                state.featureToggles.enableEventsBus = false;
+                break;
+            case "--enable-cancellation":
+                state.featureToggles.enableCancellation = true;
+                break;
+            case "--disable-cancellation":
+                state.featureToggles.enableCancellation = false;
+                break;
+            case "--enable-tx":
+                state.featureToggles.enableTx = true;
+                break;
+            case "--disable-tx":
+                state.featureToggles.enableTx = false;
+                break;
+            case "--enable-bulk":
+                state.featureToggles.enableBulk = true;
+                break;
+            case "--disable-bulk":
+                state.featureToggles.enableBulk = false;
+                break;
+            case "--enable-idempotency":
+                state.featureToggles.enableIdempotency = true;
+                break;
+            case "--disable-idempotency":
+                state.featureToggles.enableIdempotency = false;
+                break;
+            case "--enable-locks":
+                state.featureToggles.enableLocks = true;
+                break;
+            case "--disable-locks":
+                state.featureToggles.enableLocks = false;
+                break;
+            case "--enable-diff-patch":
+                state.featureToggles.enableDiffPatch = true;
+                break;
+            case "--disable-diff-patch":
+                state.featureToggles.enableDiffPatch = false;
+                break;
+            case "--enable-plan-lifecycle":
+                state.featureToggles.enablePlanLifecycle = true;
+                break;
+            case "--disable-plan-lifecycle":
+                state.featureToggles.enablePlanLifecycle = false;
+                break;
+            case "--enable-child-ops-fine":
+                state.featureToggles.enableChildOpsFine = true;
+                break;
+            case "--disable-child-ops-fine":
+                state.featureToggles.enableChildOpsFine = false;
+                break;
+            case "--enable-values-explain":
+                state.featureToggles.enableValuesExplain = true;
+                break;
+            case "--disable-values-explain":
+                state.featureToggles.enableValuesExplain = false;
+                break;
+            case "--enable-assist":
+                state.featureToggles.enableAssist = true;
+                break;
+            case "--disable-assist":
+                state.featureToggles.enableAssist = false;
+                break;
             case "--bt-tick-ms":
                 state.timings.btTickMs = parsePositiveInteger(value ?? "", flag);
                 break;
@@ -303,6 +398,12 @@ export function parseOrchestratorRuntimeOptions(argv) {
                 break;
             case "--supervisor-stall-ticks":
                 state.timings.supervisorStallTicks = parsePositiveInteger(value ?? "", flag);
+                break;
+            case "--default-timeout-ms":
+                state.timings.defaultTimeoutMs = parsePositiveInteger(value ?? "", flag);
+                break;
+            case "--autoscale-cooldown-ms":
+                state.timings.autoscaleCooldownMs = parsePositiveInteger(value ?? "", flag);
                 break;
             default:
                 // Ignore unknown flags so the orchestrator remains permissive for

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -1,0 +1,201 @@
+# MCP API — Référence rapide
+
+Ce document résume les outils MCP déjà exposés par l'orchestrateur et fournit
+une vue pseudo-schema des structures attendues/retournées. Les définitions
+complètes vivent dans le code (`src/mcp/info.ts`, `src/resources/registry.ts`,
+`src/server.ts`) et sont validées par Zod.
+
+> ℹ️ Tous les outils ci-dessous respectent le contrat MCP JSON-RPC
+> (`tools/list`, `tools/call`). Les exemples utilisent la méthode
+> `tools/call` avec un transport JSON (STDIO ou HTTP).
+
+## Introspection
+
+### Tool `mcp_info`
+
+```ts
+// input
+const McpInfoInput = z.object({}).strict();
+
+// result (interface simplifiée)
+interface McpInfoResult {
+  server: {
+    name: string;
+    version: string;
+    mcpVersion: string;
+  };
+  transports: {
+    stdio: { enabled: boolean };
+    http: {
+      enabled: boolean;
+      host: string | null;
+      port: number | null;
+      path: string | null;
+      enableJson: boolean;
+      stateless: boolean;
+    };
+  };
+  features: FeatureToggles; // cf. serverOptions.ts
+  timings: RuntimeTimingOptions; // cf. serverOptions.ts
+  safety: ChildSafetyOptions; // cf. serverOptions.ts
+  limits: {
+    maxInputBytes: number;
+    defaultTimeoutMs: number;
+    maxEventHistory: number;
+  };
+}
+```
+
+### Tool `mcp_capabilities`
+
+```ts
+// input
+const McpCapabilitiesInput = z.object({}).strict();
+
+// result
+interface McpCapabilitiesResult {
+  namespaces: Array<{
+    name: string;
+    description: string;
+  }>;
+  schemas: Record<string, {
+    namespace: string;
+    summary: string;
+  }>;
+  limits: {
+    maxEventHistory: number;
+  };
+}
+```
+
+Chaque namespace reflète un toggle actif (`enableResources`, `enableBT`,
+`enableBlackboard`, etc.). Les clients peuvent ainsi n'activer que les outils
+supportés lors de la session.
+
+## Registre de ressources
+
+Les URI `sc://` sont exposées via trois outils complémentaires.
+
+### Tool `resources_list`
+
+```ts
+const ResourceListInput = z.object({
+  prefix: z.string().trim().min(1).optional(),
+  limit: z.number().int().positive().max(500).optional(),
+}).strict();
+
+type ResourceKind =
+  | "graph"
+  | "graph_version"
+  | "run_events"
+  | "child_logs"
+  | "snapshot"
+  | "blackboard_namespace";
+
+interface ResourceListResult {
+  items: Array<{
+    uri: string;
+    kind: ResourceKind;
+    metadata?: Record<string, unknown>;
+  }>;
+}
+```
+
+### Tool `resources_read`
+
+```ts
+const ResourceReadInput = z.object({ uri: z.string().min(1) }).strict();
+
+type ResourcePayload =
+  | { graphId: string; version: number; committedAt: number | null; graph: NormalisedGraph }
+  | { graphId: string; txId: string; baseVersion: number; startedAt: number; state: string; committedAt: number | null; finalVersion: number | null; baseGraph: NormalisedGraph; finalGraph: NormalisedGraph | null }
+  | { runId: string; events: ResourceRunEvent[] }
+  | { childId: string; logs: ResourceChildLogEntry[] }
+  | { namespace: string; entries: BlackboardEntrySnapshot[] };
+
+interface ResourceReadResult {
+  uri: string;
+  kind: ResourceKind;
+  payload: ResourcePayload;
+}
+```
+
+`NormalisedGraph`, `ResourceRunEvent`, `ResourceChildLogEntry` et
+`BlackboardEntrySnapshot` sont définis dans `src/graph/types.ts`,
+`src/resources/registry.ts` et `src/coord/blackboard.ts`.
+
+### Tool `resources_watch`
+
+```ts
+const ResourceWatchInput = z.object({
+  uri: z.string().min(1),
+  from_seq: z.number().int().min(0).optional(),
+  limit: z.number().int().positive().max(500).optional(),
+}).strict();
+
+interface ResourceWatchResult {
+  uri: string;
+  kind: ResourceKind;
+  events: Array<ResourceRunEvent | ResourceChildLogEntry>;
+  next_seq: number; // pointeur pour l'appel suivant
+}
+```
+
+Les événements sont ordonnés (seq croissant). Pour un flux complet, bouclez tant
+que `events.length > 0` en rappelant `resources_watch` avec `from_seq = next_seq`.
+
+## Activation des modules MCP
+
+Les flags suivants contrôlent l'exposition des outils facultatifs :
+
+| Flag CLI | Toggle associé | Description |
+| --- | --- | --- |
+| `--enable-resources` | `enableResources` | Active le registre `sc://`. |
+| `--enable-mcp-introspection` | `enableMcpIntrospection` | Force l'exposition des outils `mcp_*` (activé par défaut). |
+| `--enable-events-bus` | `enableEventsBus` | Prépare l'exposition du bus d'événements unifié (outil à venir). |
+| `--enable-cancellation` | `enableCancellation` | Active l'API d'annulation uniforme (en cours d'implémentation). |
+| `--enable-tx` | `enableTx` | Expose la gestion de transactions graphe (à venir). |
+| `--enable-bulk` | `enableBulk` | Active les opérations atomiques en lot (à venir). |
+| `--enable-idempotency` | `enableIdempotency` | Permet la ré-exécution avec `idempotencyKey` (à venir). |
+| `--enable-locks` | `enableLocks` | Active les verrous de graphe (à venir). |
+| `--enable-diff-patch` | `enableDiffPatch` | Expose `graph_diff`/`graph_patch` (à venir). |
+| `--enable-plan-lifecycle` | `enablePlanLifecycle` | Contrôle plan_pause/plan_resume (à venir). |
+| `--enable-child-ops-fine` | `enableChildOpsFine` | Active les outils de réglage fin des enfants (à venir). |
+| `--enable-values-explain` | `enableValuesExplain` | Publie `values_explain` (à venir). |
+| `--enable-assist` | `enableAssist` | Débloque `kg_suggest_plan` et assistance causale (à venir). |
+
+Les modules marqués « à venir » seront ajoutés progressivement : cette référence
+sera enrichie au fur et à mesure (bus d'événements, cancellations uniformes,
+transactions, diff/patch, etc.).
+
+## Exemples JSON-RPC
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 42,
+  "method": "tools/call",
+  "params": {
+    "name": "resources_watch",
+    "arguments": {
+      "uri": "sc://runs/run_123/events",
+      "from_seq": 0,
+      "limit": 100
+    }
+  }
+}
+```
+
+Utilisez la méthode `tools/list` pour vérifier la présence d'un outil avant de
+l'appeler :
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/list"
+}
+```
+
+La réponse contiendra `mcp_info`, `mcp_capabilities` et les `resources_*` si les
+flags correspondants sont actifs.

--- a/src/eventStore.ts
+++ b/src/eventStore.ts
@@ -13,7 +13,8 @@ export type EventKind =
   | "HEARTBEAT"
   | "INFO"
   | "WARN"
-  | "ERROR";
+  | "ERROR"
+  | "BT_RUN";
 
 export type EventLevel = "info" | "warn" | "error";
 export type EventSource = "orchestrator" | "child" | "system";

--- a/src/events/bus.ts
+++ b/src/events/bus.ts
@@ -1,0 +1,272 @@
+import { EventEmitter } from "node:events";
+
+/**
+ * Severity levels supported by the unified event bus. The values align with the
+ * structured logger levels so operators can correlate entries across sinks.
+ */
+export type EventLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * Payload emitted for every event published on the bus. Optional correlation
+ * identifiers remain nullable because older orchestration paths may not yet
+ * forward `runId`/`opId` until the migration is complete.
+ */
+export interface EventEnvelope {
+  /** Monotonic sequence number assigned by the bus. */
+  seq: number;
+  /** Millisecond timestamp recorded at publication time. */
+  ts: number;
+  /** High level category ("plan", "child", ...). */
+  cat: string;
+  /** Severity level attached to the event. */
+  level: EventLevel;
+  /** Optional job identifier retained for backward compatibility with legacy tooling. */
+  jobId?: string | null;
+  /** Optional run identifier correlated to plan lifecycle operations. */
+  runId?: string | null;
+  /** Optional operation identifier when the event belongs to a sub-task. */
+  opId?: string | null;
+  /** Optional graph identifier when a mutation triggered the event. */
+  graphId?: string | null;
+  /** Optional node identifier (Behaviour Tree node, graph node, ...). */
+  nodeId?: string | null;
+  /** Optional child runtime identifier. */
+  childId?: string | null;
+  /** Short human readable message summarising the event. */
+  msg: string;
+  /** Structured payload with additional contextual data. */
+  data?: unknown;
+}
+
+/**
+ * Input accepted by {@link EventBus.publish}. Sequence numbers and timestamps
+ * are populated automatically when missing so tests can stay deterministic by
+ * injecting custom clock functions.
+ */
+export interface EventInput {
+  cat: string;
+  level?: EventLevel;
+  jobId?: string | null;
+  runId?: string | null;
+  opId?: string | null;
+  graphId?: string | null;
+  nodeId?: string | null;
+  childId?: string | null;
+  msg: string;
+  data?: unknown;
+  ts?: number;
+}
+
+/** Filters supported when listing or subscribing to events. */
+export interface EventFilter {
+  cats?: string[];
+  levels?: EventLevel[];
+  jobId?: string;
+  runId?: string;
+  opId?: string;
+  graphId?: string;
+  childId?: string;
+  nodeId?: string;
+  /** Exclusive lower bound applied on the sequence number. */
+  afterSeq?: number;
+  /** Maximum number of events returned (defaults to history limit). */
+  limit?: number;
+}
+
+/** Options accepted when instantiating the event bus. */
+export interface EventBusOptions {
+  /** Maximum number of events kept in memory (defaults to 1000). */
+  historyLimit?: number;
+  /** Optional clock used to stamp events, mainly for deterministic tests. */
+  now?: () => number;
+}
+
+/** Internal event emitted whenever the bus records a new envelope. */
+const BUS_EVENT = "event";
+
+/** Utility ensuring categories remain normalised for lookups. */
+function normaliseCategory(cat: string): string {
+  return cat.trim().toLowerCase();
+}
+
+/** Utility ensuring event messages are compact and predictable. */
+function normaliseMessage(msg: string): string {
+  const trimmed = msg.trim();
+  return trimmed.length > 0 ? trimmed : "event";
+}
+
+/**
+ * Async iterator used to expose live streams. The iterator buffers events until
+ * a consumer reads them, mirroring the behaviour of a JSON Lines stream.
+ */
+class EventStream implements AsyncIterable<EventEnvelope>, AsyncIterator<EventEnvelope> {
+  private readonly buffer: EventEnvelope[] = [];
+  private resolve?: (result: IteratorResult<EventEnvelope>) => void;
+  private closed = false;
+
+  constructor(
+    private readonly emitter: EventEmitter,
+    private readonly matcher: (event: EventEnvelope) => boolean,
+    seed: EventEnvelope[],
+  ) {
+    for (const event of seed) {
+      if (this.matcher(event)) {
+        this.buffer.push(event);
+      }
+    }
+    this.emitter.on(BUS_EVENT, this.handleEvent);
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<EventEnvelope> {
+    return this;
+  }
+
+  async next(): Promise<IteratorResult<EventEnvelope>> {
+    if (this.buffer.length > 0) {
+      return { value: this.buffer.shift()!, done: false };
+    }
+    if (this.closed) {
+      return { value: undefined as unknown as EventEnvelope, done: true };
+    }
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+
+  async return(): Promise<IteratorResult<EventEnvelope>> {
+    this.close();
+    return { value: undefined as unknown as EventEnvelope, done: true };
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.emitter.removeListener(BUS_EVENT, this.handleEvent);
+    if (this.resolve) {
+      this.resolve({ value: undefined as unknown as EventEnvelope, done: true });
+      this.resolve = undefined;
+    }
+  }
+
+  private handleEvent = (event: EventEnvelope) => {
+    if (this.closed || !this.matcher(event)) {
+      return;
+    }
+    if (this.resolve) {
+      this.resolve({ value: event, done: false });
+      this.resolve = undefined;
+      return;
+    }
+    this.buffer.push(event);
+  };
+}
+
+/**
+ * Unified event bus buffering orchestration events in memory. The bus offers
+ * both random access (via {@link list}) and live streaming (via
+ * {@link subscribe}) which keeps downstream MCP tools deterministic and easy
+ * to test.
+ */
+export class EventBus {
+  private readonly emitter = new EventEmitter();
+  private readonly history: EventEnvelope[] = [];
+  private historyLimit: number;
+  private readonly now: () => number;
+  private seq = 0;
+
+  constructor(options: EventBusOptions = {}) {
+    this.historyLimit = Math.max(1, options.historyLimit ?? 1_000);
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Adjust the history limit at runtime and trim existing entries accordingly. */
+  setHistoryLimit(limit: number): void {
+    this.historyLimit = Math.max(1, limit);
+    while (this.history.length > this.historyLimit) {
+      this.history.shift();
+    }
+  }
+
+  /** Determine whether an event matches the provided filters. */
+  private matches(event: EventEnvelope, filter: EventFilter): boolean {
+    const normalisedCats = filter.cats?.map(normaliseCategory);
+    const normalisedLevels = filter.levels?.map((level) => level.toLowerCase() as EventLevel);
+
+    if (normalisedCats && normalisedCats.length > 0 && !normalisedCats.includes(event.cat)) {
+      return false;
+    }
+    if (normalisedLevels && normalisedLevels.length > 0 && !normalisedLevels.includes(event.level)) {
+      return false;
+    }
+    if (filter.jobId && event.jobId !== filter.jobId) {
+      return false;
+    }
+    if (filter.runId && event.runId !== filter.runId) {
+      return false;
+    }
+    if (filter.opId && event.opId !== filter.opId) {
+      return false;
+    }
+    if (filter.graphId && event.graphId !== filter.graphId) {
+      return false;
+    }
+    if (filter.childId && event.childId !== filter.childId) {
+      return false;
+    }
+    if (filter.nodeId && event.nodeId !== filter.nodeId) {
+      return false;
+    }
+    if (typeof filter.afterSeq === "number" && !(event.seq > filter.afterSeq)) {
+      return false;
+    }
+    return true;
+  }
+
+  /** Publish a new event on the bus. */
+  publish(input: EventInput): EventEnvelope {
+    const envelope: EventEnvelope = {
+      seq: ++this.seq,
+      ts: input.ts ?? this.now(),
+      cat: normaliseCategory(input.cat),
+      level: input.level ?? "info",
+      jobId: input.jobId ?? null,
+      runId: input.runId ?? null,
+      opId: input.opId ?? null,
+      graphId: input.graphId ?? null,
+      nodeId: input.nodeId ?? null,
+      childId: input.childId ?? null,
+      msg: normaliseMessage(input.msg),
+      data: input.data,
+    };
+
+    this.history.push(envelope);
+    if (this.history.length > this.historyLimit) {
+      this.history.shift();
+    }
+
+    this.emitter.emit(BUS_EVENT, envelope);
+    return envelope;
+  }
+
+  /**
+   * Returns a snapshot of events matching the provided filters. The snapshot is
+   * sorted chronologically and truncated to `limit` when specified.
+   */
+  list(filter: EventFilter = {}): EventEnvelope[] {
+    const sliced = this.history.filter((event) => this.matches(event, filter));
+    const limit = filter.limit && filter.limit > 0 ? Math.min(filter.limit, this.historyLimit) : this.historyLimit;
+    return sliced.slice(-limit);
+  }
+
+  /**
+   * Creates an async iterator streaming live events. Consumers should call
+   * {@link EventStream.close} once finished to avoid leaking listeners.
+   */
+  subscribe(filter: EventFilter = {}): EventStream {
+    const matcher = (event: EventEnvelope): boolean => this.matches(event, filter);
+    const seed = this.list(filter);
+    return new EventStream(this.emitter, matcher, seed);
+  }
+}

--- a/src/executor/cancel.ts
+++ b/src/executor/cancel.ts
@@ -1,0 +1,249 @@
+import { EventEmitter } from "node:events";
+
+/**
+ * Outcome returned when requesting the cancellation of an operation. The enum
+ * allows callers to differentiate between successful requests and idempotent
+ * retries without resorting to exceptions.
+ */
+export type CancellationRequestOutcome = "requested" | "already_cancelled" | "not_found";
+
+/**
+ * Internal representation for every tracked operation. The entry stores
+ * metadata so diagnostics and tests can assert timelines deterministically.
+ */
+interface CancellationEntry {
+  readonly opId: string;
+  readonly controller: AbortController;
+  runId: string | null;
+  createdAt: number;
+  cancelledAt: number | null;
+  reason: string | null;
+  handle: CancellationHandle;
+}
+
+/** Event emitted whenever a cancellation is requested. */
+const EVENT_CANCELLED = "cancelled";
+
+/** Shared emitter used to fan-out cancellation notifications. */
+const cancellationEmitter = new EventEmitter();
+
+/** Registry storing the lifecycle of every cancellable operation. */
+const operations = new Map<string, CancellationEntry>();
+
+/** Reverse index mapping run identifiers to their active operations. */
+const runIndex = new Map<string, Set<string>>();
+
+/**
+ * Error raised when an operation observes a cancellation signal. The error is
+ * structured so the orchestrator can propagate consistent MCP payloads.
+ */
+export class OperationCancelledError extends Error {
+  public readonly code = "E-CANCEL-OP";
+  public readonly hint = "operation_cancelled";
+  public readonly details: { opId: string; runId: string | null; reason: string | null };
+
+  constructor(opId: string, runId: string | null, reason: string | null) {
+    super(reason ? `operation ${opId} cancelled: ${reason}` : `operation ${opId} cancelled`);
+    this.name = "OperationCancelledError";
+    this.details = { opId, runId, reason };
+  }
+}
+
+/**
+ * Public handle returned to callers when registering an operation. The handle
+ * exposes helpers that keep runtime code agnostic of the underlying registry
+ * implementation.
+ */
+export interface CancellationHandle {
+  /** Operation identifier associated with the handle. */
+  readonly opId: string;
+  /** Optional run identifier correlated to the operation. */
+  readonly runId: string | null;
+  /** Monotonic creation timestamp. */
+  readonly createdAt: number;
+  /** Timestamp recorded when the cancellation was requested, if any. */
+  readonly cancelledAt: number | null;
+  /** Human readable reason supplied by the caller, if any. */
+  readonly reason: string | null;
+  /** Abort signal toggled when a cancellation is requested. */
+  readonly signal: AbortSignal;
+  /** Determine whether the operation has already been cancelled. */
+  isCancelled(): boolean;
+  /** Throw a structured {@link OperationCancelledError} when cancelled. */
+  throwIfCancelled(): void;
+  /** Subscribe to cancellation notifications. */
+  onCancel(listener: (payload: { reason: string | null; at: number }) => void): () => void;
+  /** Build an {@link OperationCancelledError} mirroring the current state. */
+  toError(): OperationCancelledError;
+}
+
+/**
+ * Register a new cancellable operation. Consumers should ensure
+ * {@link unregisterCancellation} is called once the work completes to avoid
+ * leaking book-keeping data.
+ */
+export function registerCancellation(
+  opId: string,
+  options: { runId?: string | null; createdAt?: number } = {},
+): CancellationHandle {
+  if (operations.has(opId)) {
+    throw new Error(`cancellation handle already registered for ${opId}`);
+  }
+
+  const controller = new AbortController();
+  const runId = options.runId ?? null;
+  const createdAt = options.createdAt ?? Date.now();
+
+  const entry: CancellationEntry = {
+    opId,
+    controller,
+    runId,
+    createdAt,
+    cancelledAt: null,
+    reason: null,
+    handle: undefined as unknown as CancellationHandle,
+  };
+
+  const handle: CancellationHandle = {
+    get opId() {
+      return entry.opId;
+    },
+    get runId() {
+      return entry.runId;
+    },
+    get createdAt() {
+      return entry.createdAt;
+    },
+    get cancelledAt() {
+      return entry.cancelledAt;
+    },
+    get reason() {
+      return entry.reason;
+    },
+    get signal() {
+      return entry.controller.signal;
+    },
+    isCancelled(): boolean {
+      return entry.controller.signal.aborted;
+    },
+    throwIfCancelled(): void {
+      if (entry.controller.signal.aborted) {
+        throw handle.toError();
+      }
+    },
+    onCancel(listener: (payload: { reason: string | null; at: number }) => void): () => void {
+      const wrapped = (payload: { opId: string; reason: string | null; at: number }) => {
+        if (payload.opId === entry.opId) {
+          listener({ reason: payload.reason, at: payload.at });
+        }
+      };
+      cancellationEmitter.on(EVENT_CANCELLED, wrapped);
+      return () => {
+        cancellationEmitter.off(EVENT_CANCELLED, wrapped);
+      };
+    },
+    toError(): OperationCancelledError {
+      return new OperationCancelledError(entry.opId, entry.runId, entry.reason);
+    },
+  };
+
+  entry.handle = handle;
+  operations.set(opId, entry);
+  if (runId) {
+    if (!runIndex.has(runId)) {
+      runIndex.set(runId, new Set());
+    }
+    runIndex.get(runId)!.add(opId);
+  }
+
+  return handle;
+}
+
+/** Retrieve a handle previously registered with {@link registerCancellation}. */
+export function getCancellation(opId: string): CancellationHandle | undefined {
+  return operations.get(opId)?.handle;
+}
+
+/** Remove the bookkeeping for an operation once it settles. */
+export function unregisterCancellation(opId: string): void {
+  const entry = operations.get(opId);
+  if (!entry) {
+    return;
+  }
+  operations.delete(opId);
+  if (entry.runId) {
+    const bucket = runIndex.get(entry.runId);
+    if (bucket) {
+      bucket.delete(opId);
+      if (bucket.size === 0) {
+        runIndex.delete(entry.runId);
+      }
+    }
+  }
+}
+
+/** Determine whether an operation has observed a cancellation request. */
+export function isCancelled(opId: string): boolean {
+  return operations.get(opId)?.controller.signal.aborted ?? false;
+}
+
+/**
+ * Request the cancellation of a specific operation.
+ */
+export function requestCancellation(
+  opId: string,
+  options: { reason?: string | null; at?: number } = {},
+): CancellationRequestOutcome {
+  const entry = operations.get(opId);
+  if (!entry) {
+    return "not_found";
+  }
+
+  const alreadyCancelled = entry.controller.signal.aborted;
+  if (!alreadyCancelled) {
+    entry.reason = options.reason ?? entry.reason;
+    entry.cancelledAt = options.at ?? Date.now();
+    entry.controller.abort();
+    cancellationEmitter.emit(EVENT_CANCELLED, {
+      opId: entry.opId,
+      reason: entry.reason,
+      at: entry.cancelledAt ?? Date.now(),
+    });
+    return "requested";
+  }
+
+  if (options.reason && !entry.reason) {
+    entry.reason = options.reason;
+  }
+  return "already_cancelled";
+}
+
+/**
+ * Request the cancellation of every operation associated with the provided run
+ * identifier. The function returns the list of affected operations along with
+ * their individual outcomes so callers can report partial failures.
+ */
+export function cancelRun(
+  runId: string,
+  options: { reason?: string | null; at?: number } = {},
+): Array<{ opId: string; outcome: CancellationRequestOutcome }> {
+  const bucket = runIndex.get(runId);
+  if (!bucket || bucket.size === 0) {
+    return [];
+  }
+  const results: Array<{ opId: string; outcome: CancellationRequestOutcome }> = [];
+  for (const opId of bucket) {
+    const outcome = requestCancellation(opId, options);
+    results.push({ opId, outcome });
+  }
+  return results;
+}
+
+/**
+ * Utility mainly exposed for unit tests so they can isolate registry state
+ * without relying on implicit global ordering.
+ */
+export function resetCancellationRegistry(): void {
+  operations.clear();
+  runIndex.clear();
+}

--- a/src/mcp/info.ts
+++ b/src/mcp/info.ts
@@ -1,0 +1,331 @@
+import type {
+  ChildSafetyOptions,
+  FeatureToggles,
+  RuntimeTimingOptions,
+} from "../serverOptions.js";
+
+/**
+ * Descriptor describing the stdio transport status. Stdio is always available
+ * in-process therefore the snapshot only needs to track the enable flag.
+ */
+export interface StdioTransportSnapshot {
+  /** Whether the stdio transport is currently exposed to clients. */
+  enabled: boolean;
+}
+
+/**
+ * Descriptor mirroring the HTTP transport configuration exposed to MCP
+ * clients. Only the publicly observable attributes are surfaced.
+ */
+export interface HttpTransportSnapshot {
+  /** Whether the HTTP transport is enabled. */
+  enabled: boolean;
+  /** Listening host/interface when the HTTP transport is active. */
+  host: string | null;
+  /** Listening port when the HTTP transport is active. */
+  port: number | null;
+  /** Endpoint path used to expose the MCP handler. */
+  path: string | null;
+  /** Whether JSON streaming mode is enabled for SSE/streaming responses. */
+  enableJson: boolean;
+  /** Whether the HTTP transport operates in a stateless fashion. */
+  stateless: boolean;
+}
+
+/**
+ * High level metadata surfaced to MCP clients when they introspect the server.
+ */
+export interface McpInfo {
+  /** Public identifier of the orchestrator. */
+  server: {
+    /** Human readable name of the orchestrator. */
+    name: string;
+    /** Semantic version of the orchestrator implementation. */
+    version: string;
+    /** Version of the MCP protocol supported by this server. */
+    mcpVersion: string;
+  };
+  /** Snapshot of exposed transports (stdio / HTTP). */
+  transports: {
+    stdio: StdioTransportSnapshot;
+    http: HttpTransportSnapshot;
+  };
+  /** Active feature toggles controlling optional modules. */
+  features: FeatureToggles;
+  /** Runtime pacing information for optional modules. */
+  timings: RuntimeTimingOptions;
+  /** Operational safety guardrails applied to child runtimes. */
+  safety: ChildSafetyOptions;
+  /** Limits applied to payloads and server side buffers. */
+  limits: {
+    /** Maximum payload size (bytes) accepted for a single MCP request. */
+    maxInputBytes: number;
+    /** Default server side timeout (milliseconds) applied to long ops. */
+    defaultTimeoutMs: number;
+    /** Maximum number of events retained in memory for streaming. */
+    maxEventHistory: number;
+  };
+}
+
+/**
+ * Structure describing a namespace entry exposed to MCP clients. Namespaces
+ * are tied to feature toggles so that clients can negotiate optional modules.
+ */
+export interface McpCapabilityNamespace {
+  /** Fully qualified namespace identifier. */
+  name: string;
+  /** Human readable description of the namespace scope. */
+  description: string;
+}
+
+/**
+ * JSON serialisable description of the available schemas. The goal is not to
+ * mirror Zod internals but to expose concise metadata for discovery.
+ */
+export interface McpSchemaSummary {
+  /** Namespace owning the tool/schema. */
+  namespace: string;
+  /** Short summary helping clients understand the payload semantics. */
+  summary: string;
+}
+
+/**
+ * Capabilities structure returned by `getMcpCapabilities`. The payload is kept
+ * intentionally small so that the handshake remains lightweight while still
+ * conveying the necessary discovery hints.
+ */
+export interface McpCapabilities {
+  /** List of enabled namespaces with human readable descriptions. */
+  namespaces: McpCapabilityNamespace[];
+  /** Mapping of namespace identifiers to schema metadata summaries. */
+  schemas: Record<string, McpSchemaSummary>;
+  /** Limits mirrored from the runtime snapshot (useful for pagination). */
+  limits: {
+    maxEventHistory: number;
+  };
+}
+
+/**
+ * Snapshot persisted in memory so that tools can respond without having to
+ * query other modules synchronously. Only plain data is stored in order to keep
+ * the structure serialisable and side-effect free.
+ */
+export interface McpRuntimeSnapshot {
+  server: McpInfo["server"];
+  transports: McpInfo["transports"];
+  features: FeatureToggles;
+  timings: RuntimeTimingOptions;
+  safety: ChildSafetyOptions;
+  limits: McpInfo["limits"];
+}
+
+/**
+ * Partial structure used when updating the runtime snapshot. Nested objects are
+ * merged shallowly so callers can update only the portion that changed.
+ */
+export interface McpRuntimeUpdate {
+  server?: Partial<McpRuntimeSnapshot["server"]>;
+  transports?: {
+    stdio?: Partial<StdioTransportSnapshot>;
+    http?: Partial<HttpTransportSnapshot>;
+  };
+  features?: FeatureToggles;
+  timings?: RuntimeTimingOptions;
+  safety?: ChildSafetyOptions;
+  limits?: Partial<McpRuntimeSnapshot["limits"]>;
+}
+
+/** Default values mirroring the conservative bootstrap configuration. */
+const DEFAULT_RUNTIME_SNAPSHOT: McpRuntimeSnapshot = {
+  server: { name: "self-codex", version: "0.0.0", mcpVersion: "1.0" },
+  transports: {
+    stdio: { enabled: true },
+    http: {
+      enabled: false,
+      host: null,
+      port: null,
+      path: null,
+      enableJson: true,
+      stateless: false,
+    },
+  },
+  features: {
+    enableBT: false,
+    enableReactiveScheduler: false,
+    enableBlackboard: false,
+    enableStigmergy: false,
+    enableCNP: false,
+    enableConsensus: false,
+    enableAutoscaler: false,
+    enableSupervisor: false,
+    enableKnowledge: false,
+    enableCausalMemory: false,
+    enableValueGuard: false,
+    enableMcpIntrospection: false,
+    enableResources: false,
+    enableEventsBus: false,
+    enableCancellation: false,
+    enableTx: false,
+    enableBulk: false,
+    enableIdempotency: false,
+    enableLocks: false,
+    enableDiffPatch: false,
+    enablePlanLifecycle: false,
+    enableChildOpsFine: false,
+    enableValuesExplain: false,
+    enableAssist: false,
+  },
+  timings: {
+    btTickMs: 50,
+    stigHalfLifeMs: 30_000,
+    supervisorStallTicks: 6,
+    defaultTimeoutMs: 60_000,
+    autoscaleCooldownMs: 10_000,
+  },
+  safety: {
+    maxChildren: 16,
+    memoryLimitMb: 512,
+    cpuPercent: 100,
+  },
+  limits: {
+    maxInputBytes: 512 * 1024,
+    defaultTimeoutMs: 60_000,
+    maxEventHistory: 1_000,
+  },
+};
+
+/** Internal mutable reference storing the current snapshot. */
+let runtimeSnapshot: McpRuntimeSnapshot = cloneSnapshot(DEFAULT_RUNTIME_SNAPSHOT);
+
+/**
+ * Creates a deep copy of the provided snapshot to prevent external mutation.
+ */
+function cloneSnapshot<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * Returns the current MCP runtime snapshot. A defensive copy is returned so
+ * callers cannot accidentally mutate the internal state.
+ */
+export function getMcpRuntimeSnapshot(): McpRuntimeSnapshot {
+  return cloneSnapshot(runtimeSnapshot);
+}
+
+/**
+ * Replaces the runtime snapshot with a new value. Primarily used by tests so
+ * they can restore the previous state between assertions.
+ */
+export function setMcpRuntimeSnapshot(next: McpRuntimeSnapshot): void {
+  runtimeSnapshot = cloneSnapshot(next);
+}
+
+/**
+ * Applies a partial update to the runtime snapshot. Only the provided sections
+ * are updated which keeps the function lightweight for frequent calls.
+ */
+export function updateMcpRuntimeSnapshot(update: McpRuntimeUpdate): void {
+  const next = cloneSnapshot(runtimeSnapshot);
+
+  if (update.server) {
+    next.server = { ...next.server, ...update.server };
+  }
+
+  if (update.transports?.stdio) {
+    next.transports.stdio = { ...next.transports.stdio, ...update.transports.stdio };
+  }
+
+  if (update.transports?.http) {
+    next.transports.http = { ...next.transports.http, ...update.transports.http };
+  }
+
+  if (update.features) {
+    next.features = { ...update.features };
+  }
+
+  if (update.timings) {
+    next.timings = { ...update.timings };
+  }
+
+  if (update.safety) {
+    next.safety = { ...update.safety };
+  }
+
+  if (update.limits) {
+    next.limits = { ...next.limits, ...update.limits };
+  }
+
+  runtimeSnapshot = next;
+}
+
+/**
+ * Computes the list of namespaces that should be advertised given the current
+ * feature toggles. The mapping is intentionally explicit so that future
+ * modules can extend the handshake in a single location.
+ */
+function computeCapabilityNamespaces(features: FeatureToggles): McpCapabilityNamespace[] {
+  const definitions: Array<{
+    name: string;
+    description: string;
+    feature?: keyof FeatureToggles;
+  }> = [
+    { name: "core.jobs", description: "Gestion des jobs orchestrateur" },
+    { name: "graph.core", description: "Inspection et mutations de graphes" },
+    { name: "plan.bt", description: "Compilation et exécution Behaviour Tree", feature: "enableBT" },
+    { name: "plan.reactive", description: "Boucle scheduler réactif", feature: "enableReactiveScheduler" },
+    { name: "coord.blackboard", description: "Coordination via blackboard", feature: "enableBlackboard" },
+    { name: "coord.stigmergy", description: "Champ stigmergique", feature: "enableStigmergy" },
+    { name: "coord.contract-net", description: "Protocole Contract-Net", feature: "enableCNP" },
+    { name: "coord.consensus", description: "Vote par consensus", feature: "enableConsensus" },
+    { name: "agents.autoscaler", description: "Autoscaler d'enfants", feature: "enableAutoscaler" },
+    { name: "agents.supervisor", description: "Superviseur orchestrateur", feature: "enableSupervisor" },
+    { name: "memory.knowledge", description: "Graphe de connaissance", feature: "enableKnowledge" },
+    { name: "memory.causal", description: "Mémoire causale", feature: "enableCausalMemory" },
+    { name: "values.guard", description: "Filtre par valeurs", feature: "enableValueGuard" },
+  ];
+
+  return definitions
+    .filter((definition) => {
+      if (!definition.feature) {
+        return true;
+      }
+      return Boolean(features[definition.feature]);
+    })
+    .map(({ name, description }) => ({ name, description }));
+}
+
+/**
+ * Builds a JSON friendly summary for each namespace so clients can display the
+ * available areas without having to understand the full schema definitions.
+ */
+function buildSchemaSummaries(namespaces: McpCapabilityNamespace[]): Record<string, McpSchemaSummary> {
+  const summaries: Record<string, McpSchemaSummary> = {};
+  for (const entry of namespaces) {
+    summaries[entry.name] = {
+      namespace: entry.name,
+      summary: entry.description,
+    };
+  }
+  return summaries;
+}
+
+/**
+ * Returns the current MCP information payload mirrored by the `mcp_info` tool.
+ */
+export function getMcpInfo(): McpInfo {
+  return cloneSnapshot(runtimeSnapshot);
+}
+
+/**
+ * Returns the capability listing derived from the runtime snapshot. The
+ * function recomputes namespaces on the fly to ensure feature toggles are
+ * honoured.
+ */
+export function getMcpCapabilities(): McpCapabilities {
+  const namespaces = computeCapabilityNamespaces(runtimeSnapshot.features);
+  return {
+    namespaces,
+    schemas: buildSchemaSummaries(namespaces),
+    limits: { maxEventHistory: runtimeSnapshot.limits.maxEventHistory },
+  };
+}

--- a/src/resources/registry.ts
+++ b/src/resources/registry.ts
@@ -1,0 +1,654 @@
+import { EventEmitter } from "node:events";
+
+import type { BlackboardStore, BlackboardEntrySnapshot } from "../coord/blackboard.js";
+import type { NormalisedGraph } from "../graph/types.js";
+
+/** Supported resource kinds exposed through the registry. */
+export type ResourceKind =
+  | "graph"
+  | "graph_version"
+  | "run_events"
+  | "child_logs"
+  | "snapshot"
+  | "blackboard_namespace";
+
+/** Options accepted when instantiating the resource registry. */
+export interface ResourceRegistryOptions {
+  /** Maximum number of events preserved per run (default 500). */
+  runHistoryLimit?: number;
+  /** Maximum number of log entries preserved per child (default 500). */
+  childLogHistoryLimit?: number;
+  /** Optional blackboard store used to resolve namespace resources. */
+  blackboard?: BlackboardStore | null;
+}
+
+/** Metadata returned when listing resources. */
+export interface ResourceListEntry {
+  /** Fully qualified MCP URI. */
+  uri: string;
+  /** Kind of resource surfaced at the URI. */
+  kind: ResourceKind;
+  /** Optional metadata providing additional hints. */
+  metadata?: Record<string, unknown>;
+}
+
+/** Payload returned when reading a graph resource. */
+export interface ResourceGraphPayload {
+  graphId: string;
+  version: number;
+  committedAt: number | null;
+  graph: NormalisedGraph;
+}
+
+/** Payload returned when reading a snapshot entry. */
+export interface ResourceSnapshotPayload {
+  graphId: string;
+  txId: string;
+  baseVersion: number;
+  startedAt: number;
+  state: "pending" | "committed" | "rolled_back";
+  committedAt: number | null;
+  finalVersion: number | null;
+  baseGraph: NormalisedGraph;
+  finalGraph: NormalisedGraph | null;
+}
+
+/** Snapshot describing a run event delivered by the registry. */
+export interface ResourceRunEvent {
+  seq: number;
+  ts: number;
+  kind: string;
+  level: string;
+  jobId: string | null;
+  childId: string | null;
+  payload: unknown;
+}
+
+/** Snapshot describing a child log entry. */
+export interface ResourceChildLogEntry {
+  seq: number;
+  ts: number;
+  stream: "stdout" | "stderr" | "meta";
+  message: string;
+}
+
+/** Result returned when reading a resource. */
+export interface ResourceReadResult extends Record<string, unknown> {
+  uri: string;
+  kind: ResourceKind;
+  payload:
+    | ResourceGraphPayload
+    | ResourceSnapshotPayload
+    | { runId: string; events: ResourceRunEvent[] }
+    | { childId: string; logs: ResourceChildLogEntry[] }
+    | { namespace: string; entries: BlackboardEntrySnapshot[] };
+}
+
+/** Options accepted when requesting a watch page. */
+export interface ResourceWatchOptions {
+  /** Sequence after which events must be returned (exclusive). */
+  fromSeq?: number;
+  /** Maximum number of events returned in a single page. */
+  limit?: number;
+}
+
+/** Result returned by {@link ResourceRegistry.watch}. */
+export interface ResourceWatchResult {
+  uri: string;
+  kind: ResourceKind;
+  events: Array<ResourceRunEvent | ResourceChildLogEntry>;
+  nextSeq: number;
+}
+
+/** Base error emitted by the resource registry. */
+export class ResourceRegistryError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly hint?: string,
+    readonly details?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "ResourceRegistryError";
+  }
+}
+
+/** Error raised when attempting to resolve an unknown resource. */
+export class ResourceNotFoundError extends ResourceRegistryError {
+  constructor(uri: string) {
+    super("E-RES-NOT_FOUND", `resource '${uri}' does not exist`);
+    this.name = "ResourceNotFoundError";
+  }
+}
+
+/** Error raised when a watch operation is not supported for the URI. */
+export class ResourceWatchUnsupportedError extends ResourceRegistryError {
+  constructor(uri: string) {
+    super("E-RES-UNSUPPORTED", `resource '${uri}' cannot be watched`, "watch_not_supported");
+    this.name = "ResourceWatchUnsupportedError";
+  }
+}
+
+/**
+ * Internal representation of a committed graph version. Only serialisable data
+ * is retained so the registry remains side-effect free.
+ */
+interface GraphVersionRecord {
+  version: number;
+  committedAt: number;
+  graph: NormalisedGraph;
+}
+
+/** State tracked for a graph identifier. */
+interface GraphHistory {
+  latestVersion: number;
+  versions: Map<number, GraphVersionRecord>;
+}
+
+/** Snapshot registered when opening a transaction. */
+interface GraphSnapshotRecord {
+  txId: string;
+  graphId: string;
+  baseVersion: number;
+  startedAt: number;
+  state: "pending" | "committed" | "rolled_back";
+  committedAt: number | null;
+  finalVersion: number | null;
+  baseGraph: NormalisedGraph;
+  finalGraph: NormalisedGraph | null;
+}
+
+/** History tracked for a single plan/run identifier. */
+interface RunHistory {
+  events: ResourceRunEvent[];
+  lastSeq: number;
+  emitter: EventEmitter;
+}
+
+/** History tracked for a single child identifier. */
+interface ChildLogHistory {
+  entries: ResourceChildLogEntry[];
+  lastSeq: number;
+  emitter: EventEmitter;
+}
+
+/** Utility ensuring limits remain sane. */
+function clampPositive(value: number | undefined, fallback: number): number {
+  if (!value || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+/** Creates a defensive deep clone so callers cannot mutate stored state. */
+function clone<T>(value: T): T {
+  return structuredClone(value) as T;
+}
+
+/** Extract the namespace portion of a blackboard key. */
+function extractNamespace(key: string): string {
+  const separators = [":", "/", "|"]; // keep flexible to accommodate multiple conventions
+  for (const separator of separators) {
+    const index = key.indexOf(separator);
+    if (index > 0) {
+      return key.slice(0, index);
+    }
+  }
+  return key;
+}
+
+/** Maintains deterministic MCP resource metadata and snapshots. */
+export class ResourceRegistry {
+  private readonly graphHistories = new Map<string, GraphHistory>();
+
+  private readonly graphSnapshots = new Map<string, Map<string, GraphSnapshotRecord>>();
+
+  private readonly runHistories = new Map<string, RunHistory>();
+
+  private readonly childHistories = new Map<string, ChildLogHistory>();
+
+  private readonly runHistoryLimit: number;
+
+  private readonly childLogHistoryLimit: number;
+
+  private readonly blackboard: BlackboardStore | null;
+
+  constructor(options: ResourceRegistryOptions = {}) {
+    this.runHistoryLimit = clampPositive(options.runHistoryLimit, 500);
+    this.childLogHistoryLimit = clampPositive(options.childLogHistoryLimit, 500);
+    this.blackboard = options.blackboard ?? null;
+  }
+
+  /**
+   * Records a transaction snapshot so clients can inspect the base version even
+   * if the transaction later aborts.
+   */
+  recordGraphSnapshot(input: {
+    graphId: string;
+    txId: string;
+    baseVersion: number;
+    startedAt: number;
+    graph: NormalisedGraph;
+  }): void {
+    const normalised = this.getOrCreateSnapshotBucket(input.graphId);
+    const snapshot: GraphSnapshotRecord = {
+      txId: input.txId,
+      graphId: input.graphId,
+      baseVersion: input.baseVersion,
+      startedAt: input.startedAt,
+      state: "pending",
+      committedAt: null,
+      finalVersion: null,
+      baseGraph: clone(input.graph),
+      finalGraph: null,
+    };
+    normalised.set(input.txId, snapshot);
+  }
+
+  /** Marks a transaction snapshot as committed and stores the resulting graph. */
+  markGraphSnapshotCommitted(input: {
+    graphId: string;
+    txId: string;
+    committedAt: number;
+    finalVersion: number;
+    finalGraph: NormalisedGraph;
+  }): void {
+    const bucket = this.graphSnapshots.get(input.graphId);
+    if (!bucket) {
+      return;
+    }
+    const snapshot = bucket.get(input.txId);
+    if (!snapshot) {
+      return;
+    }
+    snapshot.state = "committed";
+    snapshot.committedAt = input.committedAt;
+    snapshot.finalVersion = input.finalVersion;
+    snapshot.finalGraph = clone(input.finalGraph);
+    bucket.set(input.txId, snapshot);
+  }
+
+  /** Marks a transaction snapshot as rolled back. */
+  markGraphSnapshotRolledBack(graphId: string, txId: string): void {
+    const bucket = this.graphSnapshots.get(graphId);
+    if (!bucket) {
+      return;
+    }
+    const snapshot = bucket.get(txId);
+    if (!snapshot) {
+      return;
+    }
+    snapshot.state = "rolled_back";
+    snapshot.committedAt = null;
+    snapshot.finalVersion = null;
+    snapshot.finalGraph = null;
+    bucket.set(txId, snapshot);
+  }
+
+  /** Records a committed graph version. */
+  recordGraphVersion(input: {
+    graphId: string;
+    version: number;
+    committedAt: number;
+    graph: NormalisedGraph;
+  }): void {
+    if (!input.graphId) {
+      return;
+    }
+    const history = this.getOrCreateGraphHistory(input.graphId);
+    const record: GraphVersionRecord = {
+      version: input.version,
+      committedAt: input.committedAt,
+      graph: clone(input.graph),
+    };
+    history.versions.set(input.version, record);
+    if (input.version >= history.latestVersion) {
+      history.latestVersion = input.version;
+    }
+    this.graphHistories.set(input.graphId, history);
+  }
+
+  /** Records an orchestrator event correlated with a run identifier. */
+  recordRunEvent(runId: string, event: {
+    seq: number;
+    ts: number;
+    kind: string;
+    level: string;
+    jobId?: string;
+    childId?: string;
+    payload?: unknown;
+  }): void {
+    if (!runId.trim()) {
+      return;
+    }
+    const history = this.getOrCreateRunHistory(runId);
+    const payload: ResourceRunEvent = {
+      seq: event.seq,
+      ts: event.ts,
+      kind: event.kind,
+      level: event.level,
+      jobId: event.jobId ?? null,
+      childId: event.childId ?? null,
+      payload: clone(event.payload ?? null),
+    };
+    history.events.push(payload);
+    history.lastSeq = Math.max(history.lastSeq, payload.seq);
+    if (history.events.length > this.runHistoryLimit) {
+      history.events.splice(0, history.events.length - this.runHistoryLimit);
+    }
+    history.emitter.emit("event", payload);
+  }
+
+  /** Records a log entry produced by a child runtime. */
+  recordChildLogEntry(childId: string, entry: {
+    ts: number;
+    stream: "stdout" | "stderr" | "meta";
+    message: string;
+  }): void {
+    if (!childId.trim()) {
+      return;
+    }
+    const history = this.getOrCreateChildHistory(childId);
+    const seq = history.lastSeq + 1;
+    const record: ResourceChildLogEntry = {
+      seq,
+      ts: entry.ts,
+      stream: entry.stream,
+      message: entry.message,
+    };
+    history.entries.push(record);
+    history.lastSeq = seq;
+    if (history.entries.length > this.childLogHistoryLimit) {
+      history.entries.splice(0, history.entries.length - this.childLogHistoryLimit);
+    }
+    history.emitter.emit("event", record);
+  }
+
+  /**
+   * Returns a deterministic list of URIs. The entries are sorted to guarantee a
+   * stable contract for clients performing prefix scans.
+   */
+  list(prefix?: string): ResourceListEntry[] {
+    const entries: ResourceListEntry[] = [];
+    for (const [graphId, history] of this.graphHistories.entries()) {
+      entries.push({
+        uri: `sc://graphs/${graphId}`,
+        kind: "graph",
+        metadata: { latest_version: history.latestVersion },
+      });
+      for (const version of history.versions.keys()) {
+        entries.push({
+          uri: `sc://graphs/${graphId}@v${version}`,
+          kind: "graph_version",
+        });
+      }
+    }
+    for (const [graphId, bucket] of this.graphSnapshots.entries()) {
+      for (const snapshot of bucket.values()) {
+        entries.push({
+          uri: `sc://snapshots/${graphId}/${snapshot.txId}`,
+          kind: "snapshot",
+          metadata: { state: snapshot.state, base_version: snapshot.baseVersion },
+        });
+      }
+    }
+    for (const runId of this.runHistories.keys()) {
+      entries.push({ uri: `sc://runs/${runId}/events`, kind: "run_events" });
+    }
+    for (const childId of this.childHistories.keys()) {
+      entries.push({ uri: `sc://children/${childId}/logs`, kind: "child_logs" });
+    }
+    for (const namespace of this.listBlackboardNamespaces()) {
+      entries.push({ uri: `sc://blackboard/${namespace}`, kind: "blackboard_namespace" });
+    }
+
+    const filtered = prefix ? entries.filter((entry) => entry.uri.startsWith(prefix)) : entries;
+    return filtered.sort((a, b) => a.uri.localeCompare(b.uri));
+  }
+
+  /** Returns the materialised payload for the requested URI. */
+  read(uri: string): ResourceReadResult {
+    const parsed = this.parseUri(uri);
+    switch (parsed.kind) {
+      case "graph": {
+        const history = this.graphHistories.get(parsed.graphId);
+        if (!history || history.latestVersion === 0) {
+          throw new ResourceNotFoundError(uri);
+        }
+        const record = history.versions.get(history.latestVersion);
+        if (!record) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return {
+          uri,
+          kind: "graph",
+          payload: {
+            graphId: parsed.graphId,
+            version: record.version,
+            committedAt: record.committedAt,
+            graph: clone(record.graph),
+          },
+        };
+      }
+      case "graph_version": {
+        const history = this.graphHistories.get(parsed.graphId);
+        const record = history?.versions.get(parsed.version ?? -1);
+        if (!record) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return {
+          uri,
+          kind: "graph_version",
+          payload: {
+            graphId: parsed.graphId,
+            version: record.version,
+            committedAt: record.committedAt,
+            graph: clone(record.graph),
+          },
+        };
+      }
+      case "snapshot": {
+        const bucket = this.graphSnapshots.get(parsed.graphId);
+        const snapshot = bucket?.get(parsed.txId ?? "");
+        if (!snapshot) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return {
+          uri,
+          kind: "snapshot",
+          payload: clone(snapshot),
+        };
+      }
+      case "run_events": {
+        const history = this.runHistories.get(parsed.runId ?? "");
+        if (!history) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return {
+          uri,
+          kind: "run_events",
+          payload: { runId: parsed.runId!, events: history.events.map((evt) => clone(evt)) },
+        };
+      }
+      case "child_logs": {
+        const history = this.childHistories.get(parsed.childId ?? "");
+        if (!history) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return {
+          uri,
+          kind: "child_logs",
+          payload: { childId: parsed.childId!, logs: history.entries.map((entry) => clone(entry)) },
+        };
+      }
+      case "blackboard_namespace": {
+        if (!this.blackboard) {
+          throw new ResourceNotFoundError(uri);
+        }
+        const entries = this.blackboard
+          .query()
+          .filter((entry) => extractNamespace(entry.key) === parsed.namespace)
+          .map((entry) => clone(entry));
+        if (entries.length === 0) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return {
+          uri,
+          kind: "blackboard_namespace",
+          payload: { namespace: parsed.namespace!, entries },
+        };
+      }
+      default:
+        throw new ResourceNotFoundError(uri);
+    }
+  }
+
+  /**
+   * Returns a monotonic slice of events/logs associated with the resource.
+   * Unsupported resources raise {@link ResourceWatchUnsupportedError}.
+   */
+  watch(uri: string, options: ResourceWatchOptions = {}): ResourceWatchResult {
+    const fromSeq = options.fromSeq ?? 0;
+    const limit = clampPositive(options.limit, 250);
+    const parsed = this.parseUri(uri);
+    switch (parsed.kind) {
+      case "run_events": {
+        const history = this.runHistories.get(parsed.runId ?? "");
+        if (!history) {
+          throw new ResourceNotFoundError(uri);
+        }
+        const events = history.events
+          .filter((event) => event.seq > fromSeq)
+          .sort((a, b) => a.seq - b.seq)
+          .slice(0, limit)
+          .map((event) => clone(event));
+        const nextSeq = events.length > 0 ? events[events.length - 1].seq : Math.max(fromSeq, history.lastSeq);
+        return { uri, kind: "run_events", events, nextSeq };
+      }
+      case "child_logs": {
+        const history = this.childHistories.get(parsed.childId ?? "");
+        if (!history) {
+          throw new ResourceNotFoundError(uri);
+        }
+        const events = history.entries
+          .filter((entry) => entry.seq > fromSeq)
+          .sort((a, b) => a.seq - b.seq)
+          .slice(0, limit)
+          .map((entry) => clone(entry));
+        const nextSeq = events.length > 0 ? events[events.length - 1].seq : Math.max(fromSeq, history.lastSeq);
+        return { uri, kind: "child_logs", events, nextSeq };
+      }
+      default:
+        throw new ResourceWatchUnsupportedError(uri);
+    }
+  }
+
+  private getOrCreateGraphHistory(graphId: string): GraphHistory {
+    const existing = this.graphHistories.get(graphId);
+    if (existing) {
+      return existing;
+    }
+    const history: GraphHistory = { latestVersion: 0, versions: new Map() };
+    this.graphHistories.set(graphId, history);
+    return history;
+  }
+
+  private getOrCreateSnapshotBucket(graphId: string): Map<string, GraphSnapshotRecord> {
+    const existing = this.graphSnapshots.get(graphId);
+    if (existing) {
+      return existing;
+    }
+    const bucket = new Map<string, GraphSnapshotRecord>();
+    this.graphSnapshots.set(graphId, bucket);
+    return bucket;
+  }
+
+  private getOrCreateRunHistory(runId: string): RunHistory {
+    const existing = this.runHistories.get(runId);
+    if (existing) {
+      return existing;
+    }
+    const history: RunHistory = { events: [], lastSeq: 0, emitter: new EventEmitter() };
+    this.runHistories.set(runId, history);
+    return history;
+  }
+
+  private getOrCreateChildHistory(childId: string): ChildLogHistory {
+    const existing = this.childHistories.get(childId);
+    if (existing) {
+      return existing;
+    }
+    const history: ChildLogHistory = { entries: [], lastSeq: 0, emitter: new EventEmitter() };
+    this.childHistories.set(childId, history);
+    return history;
+  }
+
+  private listBlackboardNamespaces(): string[] {
+    if (!this.blackboard) {
+      return [];
+    }
+    const namespaces = new Set<string>();
+    for (const entry of this.blackboard.query()) {
+      namespaces.add(extractNamespace(entry.key));
+    }
+    return Array.from(namespaces.values());
+  }
+
+  private parseUri(uri: string):
+    | { kind: "graph"; graphId: string }
+    | { kind: "graph_version"; graphId: string; version: number }
+    | { kind: "snapshot"; graphId: string; txId: string }
+    | { kind: "run_events"; runId: string }
+    | { kind: "child_logs"; childId: string }
+    | { kind: "blackboard_namespace"; namespace: string } {
+    if (!uri.startsWith("sc://")) {
+      throw new ResourceNotFoundError(uri);
+    }
+    const body = uri.slice("sc://".length);
+    if (body.startsWith("graphs/")) {
+      const remainder = body.slice("graphs/".length);
+      const [identifier, versionSuffix] = remainder.split("@v");
+      if (!identifier) {
+        throw new ResourceNotFoundError(uri);
+      }
+      if (versionSuffix !== undefined) {
+        const version = Number(versionSuffix);
+        if (!Number.isInteger(version) || version <= 0) {
+          throw new ResourceNotFoundError(uri);
+        }
+        return { kind: "graph_version", graphId: identifier, version };
+      }
+      return { kind: "graph", graphId: identifier };
+    }
+    if (body.startsWith("snapshots/")) {
+      const remainder = body.slice("snapshots/".length);
+      const [graphId, txId] = remainder.split("/");
+      if (!graphId || !txId) {
+        throw new ResourceNotFoundError(uri);
+      }
+      return { kind: "snapshot", graphId, txId };
+    }
+    if (body.startsWith("runs/") && body.endsWith("/events")) {
+      const runId = body.slice("runs/".length, body.length - "/events".length);
+      if (!runId) {
+        throw new ResourceNotFoundError(uri);
+      }
+      return { kind: "run_events", runId };
+    }
+    if (body.startsWith("children/") && body.endsWith("/logs")) {
+      const childId = body.slice("children/".length, body.length - "/logs".length);
+      if (!childId) {
+        throw new ResourceNotFoundError(uri);
+      }
+      return { kind: "child_logs", childId };
+    }
+    if (body.startsWith("blackboard/")) {
+      const namespace = body.slice("blackboard/".length);
+      if (!namespace) {
+        throw new ResourceNotFoundError(uri);
+      }
+      return { kind: "blackboard_namespace", namespace };
+    }
+    throw new ResourceNotFoundError(uri);
+  }
+}

--- a/src/serverOptions.ts
+++ b/src/serverOptions.ts
@@ -61,6 +61,32 @@ export interface FeatureToggles {
   enableCausalMemory: boolean;
   /** Enable value guard checks filtering unsafe plans. */
   enableValueGuard: boolean;
+  /** Expose MCP handshake metadata and negotiated namespaces. */
+  enableMcpIntrospection: boolean;
+  /** Allow listing and reading stable `sc://` resources. */
+  enableResources: boolean;
+  /** Publish correlated runtime events over the unified bus. */
+  enableEventsBus: boolean;
+  /** Honour cancellation tokens across long-running operations. */
+  enableCancellation: boolean;
+  /** Surface graph transactions over the MCP API. */
+  enableTx: boolean;
+  /** Accept atomic bulk operations across orchestration primitives. */
+  enableBulk: boolean;
+  /** Record and replay idempotent operations when keys match. */
+  enableIdempotency: boolean;
+  /** Guard concurrent graph mutation through cooperative locks. */
+  enableLocks: boolean;
+  /** Expose diff/patch helpers for graph evolution. */
+  enableDiffPatch: boolean;
+  /** Provide lifecycle plan inspection, pause and resume. */
+  enablePlanLifecycle: boolean;
+  /** Offer granular child runtime controls (spawn/attach/limits). */
+  enableChildOpsFine: boolean;
+  /** Run value graph explanations alongside dry-runs. */
+  enableValuesExplain: boolean;
+  /** Suggest alternative fragments leveraging the knowledge graph. */
+  enableAssist: boolean;
 }
 
 /** Tunable delays exposed so operators can adjust runtime pacing. */
@@ -71,6 +97,10 @@ export interface RuntimeTimingOptions {
   stigHalfLifeMs: number;
   /** Number of scheduler ticks tolerated without progress before stalling. */
   supervisorStallTicks: number;
+  /** Default timeout applied to operations lacking an explicit budget. */
+  defaultTimeoutMs: number;
+  /** Cooldown applied between autoscaler resize actions. */
+  autoscaleCooldownMs: number;
 }
 
 export interface OrchestratorRuntimeOptions {
@@ -168,6 +198,8 @@ const FLAG_WITH_VALUE = new Set([
   "--bt-tick-ms",
   "--stig-half-life-ms",
   "--supervisor-stall-ticks",
+  "--default-timeout-ms",
+  "--autoscale-cooldown-ms",
   "--dashboard-port",
   "--dashboard-host",
   "--dashboard-interval-ms",
@@ -250,11 +282,26 @@ const DEFAULT_STATE: ParseState = {
     enableKnowledge: false,
     enableCausalMemory: false,
     enableValueGuard: false,
+    enableMcpIntrospection: false,
+    enableResources: false,
+    enableEventsBus: false,
+    enableCancellation: false,
+    enableTx: false,
+    enableBulk: false,
+    enableIdempotency: false,
+    enableLocks: false,
+    enableDiffPatch: false,
+    enablePlanLifecycle: false,
+    enableChildOpsFine: false,
+    enableValuesExplain: false,
+    enableAssist: false,
   },
   timings: {
     btTickMs: 50,
     stigHalfLifeMs: 30_000,
     supervisorStallTicks: 6,
+    defaultTimeoutMs: 60_000,
+    autoscaleCooldownMs: 10_000,
   },
   safety: {
     maxChildren: 16,
@@ -458,6 +505,84 @@ export function parseOrchestratorRuntimeOptions(argv: string[]): OrchestratorRun
       case "--disable-value-guard":
         state.featureToggles.enableValueGuard = false;
         break;
+      case "--enable-mcp-introspection":
+        state.featureToggles.enableMcpIntrospection = true;
+        break;
+      case "--disable-mcp-introspection":
+        state.featureToggles.enableMcpIntrospection = false;
+        break;
+      case "--enable-resources":
+        state.featureToggles.enableResources = true;
+        break;
+      case "--disable-resources":
+        state.featureToggles.enableResources = false;
+        break;
+      case "--enable-events-bus":
+        state.featureToggles.enableEventsBus = true;
+        break;
+      case "--disable-events-bus":
+        state.featureToggles.enableEventsBus = false;
+        break;
+      case "--enable-cancellation":
+        state.featureToggles.enableCancellation = true;
+        break;
+      case "--disable-cancellation":
+        state.featureToggles.enableCancellation = false;
+        break;
+      case "--enable-tx":
+        state.featureToggles.enableTx = true;
+        break;
+      case "--disable-tx":
+        state.featureToggles.enableTx = false;
+        break;
+      case "--enable-bulk":
+        state.featureToggles.enableBulk = true;
+        break;
+      case "--disable-bulk":
+        state.featureToggles.enableBulk = false;
+        break;
+      case "--enable-idempotency":
+        state.featureToggles.enableIdempotency = true;
+        break;
+      case "--disable-idempotency":
+        state.featureToggles.enableIdempotency = false;
+        break;
+      case "--enable-locks":
+        state.featureToggles.enableLocks = true;
+        break;
+      case "--disable-locks":
+        state.featureToggles.enableLocks = false;
+        break;
+      case "--enable-diff-patch":
+        state.featureToggles.enableDiffPatch = true;
+        break;
+      case "--disable-diff-patch":
+        state.featureToggles.enableDiffPatch = false;
+        break;
+      case "--enable-plan-lifecycle":
+        state.featureToggles.enablePlanLifecycle = true;
+        break;
+      case "--disable-plan-lifecycle":
+        state.featureToggles.enablePlanLifecycle = false;
+        break;
+      case "--enable-child-ops-fine":
+        state.featureToggles.enableChildOpsFine = true;
+        break;
+      case "--disable-child-ops-fine":
+        state.featureToggles.enableChildOpsFine = false;
+        break;
+      case "--enable-values-explain":
+        state.featureToggles.enableValuesExplain = true;
+        break;
+      case "--disable-values-explain":
+        state.featureToggles.enableValuesExplain = false;
+        break;
+      case "--enable-assist":
+        state.featureToggles.enableAssist = true;
+        break;
+      case "--disable-assist":
+        state.featureToggles.enableAssist = false;
+        break;
       case "--bt-tick-ms":
         state.timings.btTickMs = parsePositiveInteger(value ?? "", flag);
         break;
@@ -466,6 +591,12 @@ export function parseOrchestratorRuntimeOptions(argv: string[]): OrchestratorRun
         break;
       case "--supervisor-stall-ticks":
         state.timings.supervisorStallTicks = parsePositiveInteger(value ?? "", flag);
+        break;
+      case "--default-timeout-ms":
+        state.timings.defaultTimeoutMs = parsePositiveInteger(value ?? "", flag);
+        break;
+      case "--autoscale-cooldown-ms":
+        state.timings.autoscaleCooldownMs = parsePositiveInteger(value ?? "", flag);
         break;
       default:
         // Ignore unknown flags so the orchestrator remains permissive for

--- a/tests/cancel.bt.decorator.test.ts
+++ b/tests/cancel.bt.decorator.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import {
+  registerCancellation,
+  requestCancellation,
+  resetCancellationRegistry,
+  OperationCancelledError,
+} from "../src/executor/cancel.js";
+import { CancellableNode, type BehaviorNode, type BehaviorTickResult } from "../src/executor/bt/nodes.js";
+import type { TickRuntime } from "../src/executor/bt/types.js";
+
+describe("cancellation decorator", () => {
+  beforeEach(() => {
+    resetCancellationRegistry();
+  });
+
+  it("prevents the wrapped node from executing when cancelled", async () => {
+    const handle = registerCancellation("op-test", { runId: "run-1", createdAt: 0 });
+    const child: BehaviorNode = {
+      id: "child",
+      async tick(): Promise<BehaviorTickResult> {
+        throw new Error("child should not execute when cancelled");
+      },
+      reset() {
+        // no-op
+      },
+    };
+    const node = new CancellableNode("decorator", child);
+    const runtime: TickRuntime = {
+      invokeTool: async () => null,
+      now: () => 0,
+      wait: async () => undefined,
+      variables: {},
+      throwIfCancelled: () => handle.throwIfCancelled(),
+    };
+
+    requestCancellation(handle.opId, { reason: "test" });
+
+    let caught: unknown;
+    try {
+      await node.tick(runtime);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(OperationCancelledError);
+  });
+
+  it("reports idempotent outcomes when requesting cancellation twice", () => {
+    const handle = registerCancellation("op-second", { runId: "run-2", createdAt: 0 });
+    const first = requestCancellation(handle.opId, { reason: "first" });
+    const second = requestCancellation(handle.opId, { reason: "second" });
+
+    expect(first).to.equal("requested");
+    expect(second).to.equal("already_cancelled");
+  });
+});

--- a/tests/cancel.plan.run.test.ts
+++ b/tests/cancel.plan.run.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import {
+  registerCancellation,
+  cancelRun,
+  getCancellation,
+  isCancelled,
+  resetCancellationRegistry,
+} from "../src/executor/cancel.js";
+
+describe("plan cancellation registry", () => {
+  beforeEach(() => {
+    resetCancellationRegistry();
+  });
+
+  it("cancels every operation associated with a run identifier", () => {
+    registerCancellation("op-1", { runId: "run-cascade" });
+    registerCancellation("op-2", { runId: "run-cascade" });
+    registerCancellation("op-ignored", { runId: "other" });
+
+    const outcomes = cancelRun("run-cascade", { reason: "manual" });
+
+    expect(outcomes).to.deep.equal([
+      { opId: "op-1", outcome: "requested" },
+      { opId: "op-2", outcome: "requested" },
+    ]);
+
+    expect(isCancelled("op-1")).to.equal(true);
+    expect(isCancelled("op-2")).to.equal(true);
+    expect(isCancelled("op-ignored")).to.equal(false);
+
+    const first = getCancellation("op-1");
+    const second = getCancellation("op-2");
+    expect(first?.reason).to.equal("manual");
+    expect(second?.reason).to.equal("manual");
+  });
+
+  it("returns an empty array when no operations are registered for the run", () => {
+    const outcomes = cancelRun("unknown-run", { reason: "noop" });
+    expect(outcomes).to.deep.equal([]);
+  });
+});

--- a/tests/events.subscribe.progress.test.ts
+++ b/tests/events.subscribe.progress.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Exercises the unified event bus by validating filtering semantics, streaming
+ * behaviour and correlation friendly pagination. The tests use a deterministic
+ * clock so sequence ordering and timestamps remain predictable.
+ */
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { EventBus } from "../src/events/bus.js";
+
+describe("event bus", () => {
+  it("normalises categories and filters by run/op identifiers", () => {
+    const bus = new EventBus({ historyLimit: 10, now: (() => {
+      let tick = 0;
+      return () => ++tick;
+    })() });
+
+    bus.publish({ cat: "PLAN", jobId: "job-1", runId: "run-1", opId: "op-alpha", msg: "start" });
+    bus.publish({ cat: "PLAN", jobId: "job-2", runId: "run-2", opId: "op-beta", msg: "progress" });
+    bus.publish({ cat: "CHILD", jobId: "job-1", childId: "child-9", msg: "ready" });
+
+    const filtered = bus.list({ cats: ["plan"], runId: "run-1" });
+    expect(filtered).to.have.lengthOf(1);
+    expect(filtered[0].runId).to.equal("run-1");
+    expect(filtered[0].opId).to.equal("op-alpha");
+    expect(filtered[0].cat).to.equal("plan");
+
+    const byChild = bus.list({ cats: ["child"], childId: "child-9" });
+    expect(byChild).to.have.lengthOf(1);
+    expect(byChild[0].childId).to.equal("child-9");
+
+    const ordered = bus.list({});
+    expect(ordered.map((event) => event.seq)).to.deep.equal([1, 2, 3]);
+  });
+
+  it("streams events sequentially when subscribing after a checkpoint", async () => {
+    const bus = new EventBus({ historyLimit: 5 });
+
+    const first = bus.publish({ cat: "plan", runId: "run-42", msg: "queued" });
+    const second = bus.publish({ cat: "plan", runId: "run-42", msg: "executing" });
+    const third = bus.publish({ cat: "plan", runId: "run-42", msg: "done" });
+
+    const stream = bus.subscribe({ runId: "run-42", afterSeq: first.seq });
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const next = await iterator.next();
+    expect(next.done).to.equal(false);
+    expect(next.value.seq).to.equal(second.seq);
+    expect(next.value.msg).to.equal("executing");
+
+    const final = await iterator.next();
+    expect(final.done).to.equal(false);
+    expect(final.value.seq).to.equal(third.seq);
+    expect(final.value.msg).to.equal("done");
+
+    const pending = iterator.next();
+    stream.close();
+    const closing = await pending;
+    expect(closing.done).to.equal(true);
+  });
+
+  it("paginates idempotently by leveraging the afterSeq cursor", () => {
+    const bus = new EventBus({ historyLimit: 5 });
+
+    bus.publish({ cat: "plan", runId: "run-9", msg: "start" });
+    const latest = bus.publish({ cat: "plan", runId: "run-9", msg: "finish" });
+
+    const firstPage = bus.list({ cats: ["plan"], runId: "run-9" });
+    expect(firstPage).to.have.lengthOf(2);
+
+    const secondPage = bus.list({ cats: ["plan"], runId: "run-9", afterSeq: latest.seq });
+    expect(secondPage).to.have.lengthOf(0);
+
+    bus.publish({ cat: "plan", runId: "run-9", msg: "cleanup" });
+    const thirdPage = bus.list({ cats: ["plan"], runId: "run-9", afterSeq: latest.seq });
+    expect(thirdPage).to.have.lengthOf(1);
+    expect(thirdPage[0].msg).to.equal("cleanup");
+  });
+});

--- a/tests/mcp.info-capabilities.test.ts
+++ b/tests/mcp.info-capabilities.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests ensuring the MCP introspection helpers surface consistent metadata with
+ * the server runtime configuration. By exercising both info and capabilities we
+ * guarantee future agents receive coherent handshake data before triggering
+ * long running operations.
+ */
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+
+import {
+  configureChildSafetyLimits,
+  configureRuntimeFeatures,
+  configureRuntimeTimings,
+  getChildSafetyLimits,
+  getRuntimeFeatures,
+  getRuntimeTimings,
+} from "../src/server.js";
+import {
+  getMcpCapabilities,
+  getMcpInfo,
+  getMcpRuntimeSnapshot,
+  setMcpRuntimeSnapshot,
+  updateMcpRuntimeSnapshot,
+} from "../src/mcp/info.js";
+import type {
+  ChildSafetyOptions,
+  FeatureToggles,
+  RuntimeTimingOptions,
+} from "../src/serverOptions.js";
+
+describe("mcp introspection helpers", () => {
+  let originalFeatures: FeatureToggles;
+  let originalTimings: RuntimeTimingOptions;
+  let originalSafety: ChildSafetyOptions;
+  let originalSnapshot = getMcpRuntimeSnapshot();
+
+  beforeEach(() => {
+    originalFeatures = getRuntimeFeatures();
+    originalTimings = getRuntimeTimings();
+    originalSafety = getChildSafetyLimits();
+    originalSnapshot = getMcpRuntimeSnapshot();
+  });
+
+  afterEach(() => {
+    configureRuntimeFeatures(originalFeatures);
+    configureRuntimeTimings(originalTimings);
+    configureChildSafetyLimits(originalSafety);
+    setMcpRuntimeSnapshot(originalSnapshot);
+  });
+
+  it("expose des transports et limites cohérents avec la configuration runtime", () => {
+    const toggles: FeatureToggles = {
+      ...originalFeatures,
+      enableBT: true,
+      enableBlackboard: true,
+      enableKnowledge: true,
+      enableValueGuard: true,
+    };
+    configureRuntimeFeatures(toggles);
+
+    const timings: RuntimeTimingOptions = {
+      btTickMs: originalTimings.btTickMs + 5,
+      stigHalfLifeMs: originalTimings.stigHalfLifeMs + 10_000,
+      supervisorStallTicks: originalTimings.supervisorStallTicks + 1,
+    };
+    configureRuntimeTimings(timings);
+
+    const safety: ChildSafetyOptions = {
+      maxChildren: originalSafety.maxChildren - 2,
+      memoryLimitMb: originalSafety.memoryLimitMb - 64,
+      cpuPercent: Math.max(10, originalSafety.cpuPercent - 20),
+    };
+    configureChildSafetyLimits(safety);
+
+    updateMcpRuntimeSnapshot({
+      server: { name: "introspection-test", version: "9.9.9", mcpVersion: "1.1" },
+      transports: {
+        stdio: { enabled: false },
+        http: {
+          enabled: true,
+          host: "127.0.0.1",
+          port: 8081,
+          path: "/mcp-test",
+          enableJson: true,
+          stateless: true,
+        },
+      },
+      limits: {
+        maxInputBytes: 64 * 1024,
+        defaultTimeoutMs: 12_000,
+        maxEventHistory: 42,
+      },
+    });
+
+    const info = getMcpInfo();
+
+    expect(info.server).to.deep.equal({ name: "introspection-test", version: "9.9.9", mcpVersion: "1.1" });
+    expect(info.transports.stdio.enabled).to.equal(false);
+    expect(info.transports.http).to.deep.equal({
+      enabled: true,
+      host: "127.0.0.1",
+      port: 8081,
+      path: "/mcp-test",
+      enableJson: true,
+      stateless: true,
+    });
+    expect(info.features).to.deep.equal(toggles);
+    expect(info.timings).to.deep.equal(timings);
+    expect(info.safety).to.deep.equal(safety);
+    expect(info.limits).to.deep.equal({
+      maxInputBytes: 64 * 1024,
+      defaultTimeoutMs: 12_000,
+      maxEventHistory: 42,
+    });
+  });
+
+  it("filtre les namespaces exposés selon les toggles actifs", () => {
+    const toggles: FeatureToggles = {
+      ...originalFeatures,
+      enableBT: true,
+      enableReactiveScheduler: false,
+      enableBlackboard: true,
+      enableStigmergy: false,
+      enableCNP: true,
+      enableConsensus: false,
+      enableAutoscaler: true,
+      enableSupervisor: false,
+      enableKnowledge: true,
+      enableCausalMemory: false,
+      enableValueGuard: true,
+    };
+    configureRuntimeFeatures(toggles);
+    updateMcpRuntimeSnapshot({ limits: { maxEventHistory: 128 } });
+
+    const capabilities = getMcpCapabilities();
+    const namespaces = capabilities.namespaces.map((entry) => entry.name);
+
+    expect(namespaces).to.include("core.jobs");
+    expect(namespaces).to.include("graph.core");
+    expect(namespaces).to.include("plan.bt");
+    expect(namespaces).to.include("coord.blackboard");
+    expect(namespaces).to.include("coord.contract-net");
+    expect(namespaces).to.include("agents.autoscaler");
+    expect(namespaces).to.include("memory.knowledge");
+    expect(namespaces).to.include("values.guard");
+
+    expect(namespaces).to.not.include("plan.reactive");
+    expect(namespaces).to.not.include("coord.stigmergy");
+    expect(namespaces).to.not.include("coord.consensus");
+    expect(namespaces).to.not.include("agents.supervisor");
+    expect(namespaces).to.not.include("memory.causal");
+
+    for (const entry of capabilities.namespaces) {
+      expect(entry.description).to.be.a("string").and.to.have.length.greaterThan(0);
+      expect(capabilities.schemas[entry.name]).to.deep.equal({
+        namespace: entry.name,
+        summary: entry.description,
+      });
+    }
+
+    expect(capabilities.limits).to.deep.equal({ maxEventHistory: 128 });
+  });
+});

--- a/tests/plan.bt.events.test.ts
+++ b/tests/plan.bt.events.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+  PlanRunBTInputSchema,
+  PlanRunReactiveInputSchema,
+  handlePlanRunBT,
+  handlePlanRunReactive,
+  type PlanToolContext,
+} from "../src/tools/planTools.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+
+interface RecordedEvent {
+  kind: string;
+  payload?: unknown;
+}
+
+describe("plan behaviour tree events", () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  function buildContext(): { context: PlanToolContext; events: RecordedEvent[] } {
+    const logger = {
+      info: sinon.spy(),
+      warn: sinon.spy(),
+      error: sinon.spy(),
+      debug: sinon.spy(),
+    } as unknown as PlanToolContext["logger"];
+    const events: RecordedEvent[] = [];
+    const context: PlanToolContext = {
+      supervisor: {} as PlanToolContext["supervisor"],
+      graphState: {} as PlanToolContext["graphState"],
+      logger,
+      childrenRoot: "/tmp",
+      defaultChildRuntime: "codex",
+      emitEvent: (event) => {
+        events.push({ kind: event.kind, payload: event.payload });
+      },
+      stigmergy: new StigmergyField(),
+    };
+    return { context, events };
+  }
+
+  it("emits correlated lifecycle events for plan_run_bt", async () => {
+    const { context, events } = buildContext();
+    const input = PlanRunBTInputSchema.parse({
+      tree: {
+        id: "demo",
+        root: {
+          type: "task",
+          id: "root",
+          node_id: "root",
+          tool: "noop",
+          input_key: "payload",
+        },
+      },
+      variables: { payload: { message: "ping" } },
+    });
+
+    const result = await handlePlanRunBT(context, input);
+
+    expect(result.run_id).to.be.a("string").and.to.have.length.greaterThan(0);
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+
+    const startEvent = events.find((evt) => (evt.payload as { phase?: string })?.phase === "start");
+    expect(startEvent, "start event present").to.exist;
+    expect((startEvent!.payload as { mode?: string }).mode).to.equal("bt");
+    expect((startEvent!.payload as { run_id?: string }).run_id).to.equal(result.run_id);
+
+    const nodeEvents = events.filter((evt) => (evt.payload as { phase?: string })?.phase === "node");
+    expect(nodeEvents.length).to.be.greaterThan(0);
+    for (const evt of nodeEvents) {
+      const payload = evt.payload as { run_id?: string; op_id?: string };
+      expect(payload.run_id).to.equal(result.run_id);
+      expect(payload.op_id).to.equal(result.op_id);
+    }
+
+    const completeEvent = events.find((evt) => (evt.payload as { phase?: string })?.phase === "complete");
+    expect(completeEvent, "complete event present").to.exist;
+    expect((completeEvent!.payload as { status?: string }).status).to.equal(result.status);
+  });
+
+  it("tracks reactive scheduler phases with consistent identifiers", async () => {
+    const { context, events } = buildContext();
+    const input = PlanRunReactiveInputSchema.parse({
+      tree: {
+        id: "demo",
+        root: {
+          type: "task",
+          id: "root",
+          node_id: "root",
+          tool: "noop",
+          input_key: "payload",
+        },
+      },
+      variables: { payload: { message: "pong" } },
+      tick_ms: 25,
+    });
+
+    const execution = handlePlanRunReactive(context, input);
+    await clock.tickAsync(25);
+    const result = await execution;
+
+    expect(result.run_id).to.be.a("string").and.to.have.length.greaterThan(0);
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+
+    const phases = events
+      .map((evt) => (evt.payload as { phase?: string })?.phase)
+      .filter((value): value is string => Boolean(value));
+    expect(phases).to.include("start");
+    expect(phases).to.include("tick");
+    expect(phases).to.include("complete");
+
+    const distinctRunIds = new Set(
+      events
+        .map((evt) => (evt.payload as { run_id?: string })?.run_id)
+        .filter((value): value is string => typeof value === "string"),
+    );
+    expect(distinctRunIds.size).to.equal(1);
+    expect([...distinctRunIds][0]).to.equal(result.run_id);
+  });
+});

--- a/tests/resources.list-read-watch.test.ts
+++ b/tests/resources.list-read-watch.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Validates the MCP resource registry by exercising listing, reading and
+ * watching capabilities. The tests seed graphs, run events, child logs and
+ * blackboard entries to ensure URIs resolve deterministically and sequences are
+ * strictly monotonic for watch pagination.
+ */
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+import {
+  ResourceNotFoundError,
+  ResourceRegistry,
+  ResourceWatchUnsupportedError,
+} from "../src/resources/registry.js";
+
+function createGraph(graphId: string, version: number): NormalisedGraph {
+  return {
+    name: "workflow",
+    graphId,
+    graphVersion: version,
+    nodes: [
+      {
+        id: "root",
+        label: "root",
+        attributes: { order: version },
+      },
+    ],
+    edges: [],
+    metadata: { revision: version },
+  };
+}
+
+describe("resources registry", () => {
+  it("lists and reads committed graphs, snapshots, runs, children and blackboard namespaces", () => {
+    const blackboard = new BlackboardStore();
+    blackboard.set("core:pending", { task: "triage" });
+    blackboard.set("core:active", { task: "review" });
+
+    const registry = new ResourceRegistry({ blackboard, runHistoryLimit: 20, childLogHistoryLimit: 20 });
+
+    registry.recordGraphSnapshot({
+      graphId: "demo",
+      txId: "tx-1",
+      baseVersion: 1,
+      startedAt: 1_000,
+      graph: createGraph("demo", 1),
+    });
+    registry.markGraphSnapshotCommitted({
+      graphId: "demo",
+      txId: "tx-1",
+      committedAt: 1_500,
+      finalVersion: 2,
+      finalGraph: createGraph("demo", 2),
+    });
+
+    registry.recordGraphVersion({ graphId: "demo", version: 1, committedAt: 900, graph: createGraph("demo", 1) });
+    registry.recordGraphVersion({ graphId: "demo", version: 2, committedAt: 1_500, graph: createGraph("demo", 2) });
+
+    registry.recordRunEvent("run-77", {
+      seq: 1,
+      ts: 2_000,
+      kind: "PLAN",
+      level: "info",
+      jobId: "job-1",
+      childId: null,
+      payload: { run_id: "run-77", note: "start" },
+    });
+    registry.recordRunEvent("run-77", {
+      seq: 2,
+      ts: 2_100,
+      kind: "STATUS",
+      level: "info",
+      jobId: "job-1",
+      childId: "child-9",
+      payload: { run_id: "run-77", step: "fanout" },
+    });
+
+    registry.recordChildLogEntry("child-9", { ts: 2_050, stream: "stdout", message: "ready" });
+    registry.recordChildLogEntry("child-9", { ts: 2_120, stream: "stderr", message: "warning" });
+
+    const uris = registry.list().map((entry) => entry.uri);
+    expect(uris).to.deep.equal([
+      "sc://blackboard/core",
+      "sc://children/child-9/logs",
+      "sc://graphs/demo",
+      "sc://graphs/demo@v1",
+      "sc://graphs/demo@v2",
+      "sc://runs/run-77/events",
+      "sc://snapshots/demo/tx-1",
+    ]);
+
+    const graphsOnly = registry.list("sc://graphs/").map((entry) => entry.uri);
+    expect(graphsOnly).to.deep.equal(["sc://graphs/demo", "sc://graphs/demo@v1", "sc://graphs/demo@v2"]);
+
+    const latest = registry.read("sc://graphs/demo");
+    expect(latest.kind).to.equal("graph");
+    expect(latest.payload).to.deep.include({ graphId: "demo", version: 2, committedAt: 1_500 });
+
+    const v1 = registry.read("sc://graphs/demo@v1");
+    expect(v1.kind).to.equal("graph_version");
+    expect(v1.payload).to.deep.include({ graphId: "demo", version: 1, committedAt: 900 });
+
+    const snapshot = registry.read("sc://snapshots/demo/tx-1");
+    expect(snapshot.kind).to.equal("snapshot");
+    expect(snapshot.payload).to.deep.include({ state: "committed", baseVersion: 1, finalVersion: 2 });
+
+    const run = registry.read("sc://runs/run-77/events");
+    expect(run.kind).to.equal("run_events");
+    expect(run.payload).to.deep.equal({
+      runId: "run-77",
+      events: [
+        {
+          seq: 1,
+          ts: 2_000,
+          kind: "PLAN",
+          level: "info",
+          jobId: "job-1",
+          childId: null,
+          payload: { run_id: "run-77", note: "start" },
+        },
+        {
+          seq: 2,
+          ts: 2_100,
+          kind: "STATUS",
+          level: "info",
+          jobId: "job-1",
+          childId: "child-9",
+          payload: { run_id: "run-77", step: "fanout" },
+        },
+      ],
+    });
+
+    const childLogs = registry.read("sc://children/child-9/logs");
+    expect(childLogs.kind).to.equal("child_logs");
+    expect(childLogs.payload).to.deep.equal({
+      childId: "child-9",
+      logs: [
+        { seq: 1, ts: 2_050, stream: "stdout", message: "ready" },
+        { seq: 2, ts: 2_120, stream: "stderr", message: "warning" },
+      ],
+    });
+
+    const namespace = registry.read("sc://blackboard/core");
+    expect(namespace.kind).to.equal("blackboard_namespace");
+    expect(namespace.payload.namespace).to.equal("core");
+    expect(namespace.payload.entries).to.have.length(2);
+  });
+
+  it("paginates watches with monotonic sequence numbers", () => {
+    const registry = new ResourceRegistry();
+    registry.recordRunEvent("run-123", {
+      seq: 10,
+      ts: 5_000,
+      kind: "PLAN",
+      level: "info",
+      jobId: "job-xyz",
+      payload: { run_id: "run-123" },
+    });
+    registry.recordRunEvent("run-123", {
+      seq: 11,
+      ts: 5_100,
+      kind: "STATUS",
+      level: "info",
+      childId: "child-a",
+      payload: { run_id: "run-123", state: "running" },
+    });
+    registry.recordRunEvent("run-123", {
+      seq: 12,
+      ts: 5_200,
+      kind: "REPLY",
+      level: "info",
+      childId: "child-a",
+      payload: { run_id: "run-123", reply: "ok" },
+    });
+
+    const firstPage = registry.watch("sc://runs/run-123/events", { fromSeq: 0, limit: 2 });
+    expect(firstPage.events.map((event) => event.seq)).to.deep.equal([10, 11]);
+    expect(firstPage.nextSeq).to.equal(11);
+
+    const secondPage = registry.watch("sc://runs/run-123/events", { fromSeq: firstPage.nextSeq, limit: 2 });
+    expect(secondPage.events.map((event) => event.seq)).to.deep.equal([12]);
+    expect(secondPage.nextSeq).to.equal(12);
+
+    registry.recordChildLogEntry("child-a", { ts: 5_050, stream: "stdout", message: "tick" });
+    registry.recordChildLogEntry("child-a", { ts: 5_060, stream: "stdout", message: "tock" });
+
+    const logPage = registry.watch("sc://children/child-a/logs", { fromSeq: 0 });
+    expect(logPage.events.map((entry) => (entry as typeof logPage.events[number]).seq)).to.deep.equal([1, 2]);
+    expect(logPage.nextSeq).to.equal(2);
+  });
+
+  it("raises domain errors for unsupported operations", () => {
+    const registry = new ResourceRegistry();
+    expect(() => registry.read("sc://graphs/unknown")).to.throw(ResourceNotFoundError);
+    expect(() => registry.watch("sc://graphs/demo", { fromSeq: 0 })).to.throw(ResourceWatchUnsupportedError);
+  });
+});

--- a/tests/serverOptions.parse.test.ts
+++ b/tests/serverOptions.parse.test.ts
@@ -36,11 +36,26 @@ describe("parseOrchestratorRuntimeOptions", () => {
       enableKnowledge: false,
       enableCausalMemory: false,
       enableValueGuard: false,
+      enableMcpIntrospection: false,
+      enableResources: false,
+      enableEventsBus: false,
+      enableCancellation: false,
+      enableTx: false,
+      enableBulk: false,
+      enableIdempotency: false,
+      enableLocks: false,
+      enableDiffPatch: false,
+      enablePlanLifecycle: false,
+      enableChildOpsFine: false,
+      enableValuesExplain: false,
+      enableAssist: false,
     });
     expect(result.timings).to.deep.equal({
       btTickMs: 50,
       stigHalfLifeMs: 30_000,
       supervisorStallTicks: 6,
+      defaultTimeoutMs: 60_000,
+      autoscaleCooldownMs: 10_000,
     });
     expect(result.dashboard).to.deep.equal({
       enabled: false,
@@ -159,6 +174,19 @@ describe("parseOrchestratorRuntimeOptions", () => {
       "--enable-knowledge",
       "--enable-causal-memory",
       "--enable-value-guard",
+      "--enable-mcp-introspection",
+      "--enable-resources",
+      "--enable-events-bus",
+      "--enable-cancellation",
+      "--enable-tx",
+      "--enable-bulk",
+      "--enable-idempotency",
+      "--enable-locks",
+      "--enable-diff-patch",
+      "--enable-plan-lifecycle",
+      "--enable-child-ops-fine",
+      "--enable-values-explain",
+      "--enable-assist",
     ]);
 
     expect(result.features).to.deep.equal({
@@ -173,6 +201,19 @@ describe("parseOrchestratorRuntimeOptions", () => {
       enableKnowledge: true,
       enableCausalMemory: true,
       enableValueGuard: true,
+      enableMcpIntrospection: true,
+      enableResources: true,
+      enableEventsBus: true,
+      enableCancellation: true,
+      enableTx: true,
+      enableBulk: true,
+      enableIdempotency: true,
+      enableLocks: true,
+      enableDiffPatch: true,
+      enablePlanLifecycle: true,
+      enableChildOpsFine: true,
+      enableValuesExplain: true,
+      enableAssist: true,
     });
   });
 
@@ -184,6 +225,10 @@ describe("parseOrchestratorRuntimeOptions", () => {
       "45000",
       "--supervisor-stall-ticks",
       "9",
+      "--default-timeout-ms",
+      "45000",
+      "--autoscale-cooldown-ms",
+      "3000",
       "--dashboard",
       "--dashboard-interval-ms",
       "100",
@@ -193,6 +238,8 @@ describe("parseOrchestratorRuntimeOptions", () => {
       btTickMs: 75,
       stigHalfLifeMs: 45_000,
       supervisorStallTicks: 9,
+      defaultTimeoutMs: 45_000,
+      autoscaleCooldownMs: 3_000,
     });
     expect(result.dashboard.streamIntervalMs).to.equal(250);
   });


### PR DESCRIPTION
## Summary
- introduce src/executor/cancel.ts to manage per-operation AbortControllers and expose OperationCancelledError helpers
- wire cooperative cancellation into Behaviour Tree nodes/interpreter, add op_cancel/plan_cancel MCP tools, and update docs checklist
- add unit tests covering the cancellable decorator and run-level cancellation cascades while refreshing dist outputs

## Testing
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68debd89ae28832f9dfb6a89c1cf621e