### PR TITLE
Implement graph, child, and stig bulk tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,14 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 * [x] **Créer** `src/events/bus.ts`
 
   * [x] Type `Event {ts, cat, level, runId?, opId?, graphId?, nodeId?, childId?, msg, data?, seq}`
-  * [ ] Wrapper sur émetteurs existants (BT, scheduler, bb, stig, cnp, consensus, values, children)
+  * [x] Wrapper sur émetteurs existants (BT, scheduler, bb, stig, cnp, consensus, values, children)
     * [x] BT + scheduler : `plan_run_bt` / `plan_run_reactive` publient `BT_RUN` corrélé (`run_id`, `op_id`, `mode`)
+    * [x] Value guard : instrumentation `ValueGraph` + bridge MCP (corrélations run/op à compléter côté outils)
+  * [x] Blackboard + stigmergy : ponts vers `EventBus` (mutations + évaporation)
+  * [x] Annulation : registre `cancel` → `EventBus` (run/op/outcome, sévérité idempotente)
+  * [x] Children : runtime lifecycle & flux stdout/stderr relayés avec corrélation run/op/child
+  * [x] Contract-Net : annonces, enchères et attributions relayées sur le bus avec corrélation run/op
+  * [x] Consensus : décisions agrégées → `EventBus` (run/op/job + métadonnées)
 * [ ] **Modifier** `src/executor/*`, `src/coord/*`, `src/agents/*`
 
   * [ ] Publier évènements standardisés avec `opId/runId`
@@ -89,6 +95,8 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
   * [x] tool `events_subscribe({cats?, runId?})` (stream SSE/jsonlines)
 * [x] **Tests** : `tests/events.subscribe.progress.test.ts`
+
+  * [x] `tests/events.bridges.test.ts`
 
   * [x] Filtrage par catégorie ; ordre ; corrélation idempotente
 
@@ -115,40 +123,40 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 ### 2.1 Transactions exposées
 
-* [ ] **Modifier** `src/graph/tx.ts` (compléter métadonnées, horodatage, owner)
-* [ ] **Modifier** `src/server.ts`
+* [x] **Modifier** `src/graph/tx.ts` (compléter métadonnées, horodatage, owner)
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] tools `tx_begin({graphId})`, `tx_apply({txId, ops:GraphOp[]})`, `tx_commit({txId})`, `tx_rollback({txId})`
-  * [ ] Validation Zod des `GraphOp` (add/remove node/edge, metadata patch, rewrite nommée)
-* [ ] **Tests** : `tests/tx.begin-apply-commit.test.ts`
+  * [x] tools `tx_begin({graphId})`, `tx_apply({txId, ops:GraphOp[]})`, `tx_commit({txId})`, `tx_rollback({txId})`
+  * [x] Validation Zod des `GraphOp` (add/remove node/edge, metadata patch, rewrite nommée)
+* [x] **Tests** : `tests/tx.begin-apply-commit.test.ts`
 
-  * [ ] Conflit de version ; rollback idempotent ; aperçu version `previewVersion`
+  * [x] Conflit de version ; rollback idempotent ; aperçu version `previewVersion`
 
 ### 2.2 Diff/Patch & invariants
 
-* [ ] **Créer** `src/graph/diff.ts` (JSON Patch RFC 6902)
-* [ ] **Créer** `src/graph/patch.ts` (appliquer patch avec vérification)
-* [ ] **Créer** `src/graph/invariants.ts`
+* [x] **Créer** `src/graph/diff.ts` (JSON Patch RFC 6902)
+* [x] **Créer** `src/graph/patch.ts` (appliquer patch avec vérification)
+* [x] **Créer** `src/graph/invariants.ts`
 
-  * [ ] Acyclicité (si DAG), ports/labels requis, contraintes edge cardinality
-* [ ] **Modifier** `src/server.ts`
+  * [x] Acyclicité (si DAG), ports/labels requis, contraintes edge cardinality
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] tools `graph_diff({graphId, from, to})`, `graph_patch({graphId, patch})`
-* [ ] **Tests** :
+  * [x] tools `graph_diff({graphId, from, to})`, `graph_patch({graphId, patch})`
+* [x] **Tests** :
 
-  * [ ] `tests/graph.diff-patch.test.ts` (roundtrip)
-  * [ ] `tests/graph.invariants.enforced.test.ts` (rejet patch invalide)
+  * [x] `tests/graph.diff-patch.test.ts` (roundtrip)
+  * [x] `tests/graph.invariants.enforced.test.ts` (rejet patch invalide)
 
 ### 2.3 Locks de graphe
 
-* [ ] **Créer** `src/graph/locks.ts`
+* [x] **Créer** `src/graph/locks.ts`
 
-  * [ ] `graph_lock({graphId, holder, ttlMs}) -> {lockId}` ; `graph_unlock({lockId})`
-  * [ ] Rafraîchissement ; expiration ; re-entrance par holder
-* [ ] **Modifier** mutations/tx pour **refuser** si lock détenu par autre holder
-* [ ] **Tests** : `tests/graph.locks.concurrent.test.ts`
+  * [x] `graph_lock({graphId, holder, ttlMs}) -> {lockId}` ; `graph_unlock({lockId})`
+  * [x] Rafraîchissement ; expiration ; re-entrance par holder
+* [x] **Modifier** mutations/tx pour **refuser** si lock détenu par autre holder
+* [x] **Tests** : `tests/graph.locks.concurrent.test.ts`
 
-  * [ ] Pas de deadlock ; re-entrance ; expiration propre
+  * [x] Pas de deadlock ; re-entrance ; expiration propre
 
 ### 2.4 Idempotency keys
 
@@ -162,13 +170,13 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 * [ ] **Modifier** `src/server.ts`
 
-  * [ ] tools `bb_batch_set([{ns,key,value,ttlMs?}])`
-  * [ ] `graph_batch_mutate({graphId, ops:GraphOp[]})`
-  * [ ] `child_batch_create([{idempotencyKey?, role?, prompt, limits?}])`
-  * [ ] `stig_batch([{nodeId,type,intensity}])`
-* [ ] **Tests** : `tests/bulk.bb-graph-child-stig.test.ts`
+  * [x] tools `bb_batch_set([{ns,key,value,ttlMs?}])`
+  * [x] `graph_batch_mutate({graphId, ops:GraphOp[]})`
+  * [x] `child_batch_create([{idempotencyKey?, role?, prompt, limits?}])`
+  * [x] `stig_batch([{nodeId,type,intensity}])`
+* [x] **Tests** : `tests/bulk.bb-graph-child-stig.test.ts` (couverture `bb_batch_set` ajoutée, graph/child/stig restant)
 
-  * [ ] Atomicité : rollback si erreur partielle
+  * [x] Atomicité : rollback si erreur partielle
 
 ---
 
@@ -187,14 +195,14 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 ### 3.2 Child operations
 
-* [ ] **Modifier** `src/childRuntime.ts`, `src/state/childrenIndex.ts`
+* [x] **Modifier** `src/childRuntime.ts`, `src/state/childrenIndex.ts`
 
-  * [ ] Exposer `setRole`, `setLimits`, `attach` si déjà en vie
-* [ ] **Modifier** `src/server.ts`
+  * [x] Exposer `setRole`, `setLimits`, `attach` si déjà en vie
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] tools `child_spawn_codex({role?, prompt, modelHint?, limits?, idempotencyKey?})`
-  * [ ] `child_attach({childId})`, `child_set_role({childId, role})`, `child_set_limits(...)`
-* [ ] **Tests** : `tests/child.spawn-attach-limits.test.ts`
+  * [x] tools `child_spawn_codex({role?, prompt, modelHint?, limits?, idempotencyKey?})`
+  * [x] `child_attach({childId})`, `child_set_role({childId, role})`, `child_set_limits(...)`
+* [x] **Tests** : `tests/child.spawn-attach-limits.test.ts`
 
 ---
 
@@ -290,11 +298,12 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 * [ ] **Modifier** `src/values/valueGraph.ts`
 
-  * [ ] `values_explain({plan}) -> {violations:[{nodeId, value, severity, hint}]}`
+* [x] `values_explain({plan}) -> {violations:[{nodeId, value, severity, hint}]}`
 * [ ] **Modifier** `src/server.ts`
 
-  * [ ] tool `values_explain` et intégration dans `plan_dry_run`
-* [ ] **Tests** : `tests/values.explain.integration.test.ts`
+  * [x] tool `values_explain`
+  * [x] Intégration dans `plan_dry_run`
+* [x] **Tests** : `tests/values.explain.integration.test.ts`
 
 ---
 
@@ -416,7 +425,7 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 5. **Agrégation** : terminer avec `plan_reduce` (`reducer: "vote"`) pour sortir la recommandation majoritaire. Consigner le vote dans
    la mémoire partagée pour audit (`bb_set`).
 
-> En attente : instrumentation bus d'événements (`events_subscribe`) pour tracer `runId/opId` lors des offres CNP.
+> Mise à jour : instrumentation bus d'événements (`events_subscribe`) disponible via `bridgeContractNetEvents` (corrélation runId/opId incluse pour les annonces/bids/awards CNP).
 
 ### Dry-run explicable (values_explain + KG/causal + rewrite)
 
@@ -498,3 +507,140 @@ Si tu veux, je peux te générer à la demande les **squelettes TypeScript** exa
 - ✅ Adapté `handlePlanRunReactive` pour enregistrer le handle, propager `throwIfCancelled` (runtime/loop), publier les événements `cancel` et rejeter avec `OperationCancelledError`.
 - ✅ Ajouté un scénario déterministe dans `tests/plan.run-reactive.test.ts` couvrant l’annulation via `cancelRun` (fake timers) + exécuté `npm run lint`, `npm test` (post `npm ci`).
 - ⚠️ À poursuivre : étendre la cascade d’annulation aux runtimes enfants et enrichir le bus MCP avec des événements dédiés au cancel.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 87)
+- ✅ Ponté le blackboard et la stigmergie vers le bus MCP via `bridgeBlackboardEvents` / `bridgeStigmergyEvents` et raccord dans `server.ts`.
+- ✅ Ajouté `tests/events.bridges.test.ts` (horloge déterministe) + exécuté `npm run lint`, `npm test`.
+- 🔜 Étendre la passerelle aux modules CNP / consensus / values / children et propager les identifiants run/op.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 88)
+- ✅ Étendu `src/executor/cancel.ts` pour exposer `subscribeCancellationEvents` (run/op/outcome) et alimenter le bus MCP via `bridgeCancellationEvents` + sorties `dist/`.
+- ✅ Relié `src/server.ts` / `dist/server.js` à cette passerelle et complété `tests/events.bridges.test.ts` (annulation idempotente) après `npm run lint` & `npm test`.
+- 🔜 Propager la corrélation cancellation → job/children et couvrir consensus/children/events additionnels.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 89)
+- ✅ Étendu `ChildRuntime` pour émettre des événements `lifecycle` structurés (spawn/error/exit) et ajouté la documentation associée.
+- ✅ Ajouté `bridgeChildRuntimeEvents` + heuristiques run/op/job + branché le superviseur pour publier automatiquement les flux IO/enfants sur le bus MCP.
+- ✅ Couvert `tests/events.bridges.test.ts` avec un scénario child complet + exécuté `npm run lint` puis `npm test` (succès intégral, 325 tests).
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 90)
+- ✅ Équipé `ContractNetCoordinator` d'un émetteur d'événements (`observe`) pour suivre en temps réel inscriptions agents, annonces, bids, attributions et complétions avec horodatage déterministe.
+- ✅ Ajouté `bridgeContractNetEvents` dans `src/events/bridges.ts` + raccord dans `src/server.ts` afin de publier les flux Contract-Net sur le bus MCP (catégorie `contract_net`, corrélations run/op).
+- ✅ Étendu `tests/events.bridges.test.ts` avec un scénario Contract-Net couvrant auto-bids, overrides manuels, award/complete et désinscription ; exécuté `npm run lint` puis `npm test` (326 tests OK) pour rafraîchir `dist/`.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 91)
+- ✅ Ajouté `publishConsensusEvent` et horloge injectable dans `src/coord/consensus.ts`, instrumenté `plan_join` et `consensus_vote` pour publier des décisions structurées.
+- ✅ Créé `bridgeConsensusEvents`, branché le serveur et couvert un scénario dédié dans `tests/events.bridges.test.ts` (horloge déterministe, corrélations run/op/job).
+- ✅ Exécuté `npm run lint` puis `npm test` (327 tests OK) afin de régénérer `dist/` et valider la passerelle consensus.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 92)
+- ✅ Implémenté `ValueGraph.explain` avec agrégation des contributions, hints narratifs et corrélation `nodeId`/`primaryContributor`.
+- ✅ Ajouté le tool MCP `values_explain` dans `src/server.ts` + gestion du logger, avec schéma Zod dédié et tests `tests/values.explain.integration.test.ts`.
+- ⚠️ À faire ensuite : brancher `plan_dry_run` sur `values_explain` et propager les `nodeId` issus des plans compilés.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 93)
+- ✅ Branché `plan_dry_run` sur le value guard : normalisation des impacts (avec `nodeId`), compilation optionnelle des graphes et journalisation détaillée.
+- ✅ Ajouté l'outil MCP `plan_dry_run` côté serveur + schéma Zod dédié et deux scénarios déterministes `tests/plan.dry-run.test.ts`.
+- ✅ Installé les dépendances (`npm ci`) puis exécuté `npm run lint` & `npm test` (331 tests) pour rafraîchir `dist/`.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 94)
+- ✅ Instrumenté `ValueGraph` avec un émetteur d'événements (config/score/filter/explain) + horloge injectable et snapshots d'impacts.
+- ✅ Ajouté `bridgeValueEvents` pour refléter les décisions du value guard sur le bus MCP et branché le serveur.
+- ✅ Étendu `tests/events.bridges.test.ts` avec un scénario value guard déterministe et exécuté `npm run lint`, `npm test` (332 tests OK).
+- ✅ Propager `runId`/`opId` depuis les outils value guard afin d'alimenter le resolver de corrélation côté bridge (couvert itération 95).
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 95)
+- ✅ Étendu les schémas `values_score`/`values_filter`/`values_explain` avec les champs facultatifs `run_id`/`op_id`/`job_id`/`graph_id`/`node_id` et propagé ces métadonnées jusque dans `ValueGraph`.
+- ✅ Ajouté la prise en charge des hints de corrélation dans `ValueGraph` (options d'évaluation) et `bridgeValueEvents` afin que le bus MCP publie directement `runId`/`opId` sans resolver externe.
+- ✅ Mis à jour `tests/events.bridges.test.ts` pour couvrir la corrélation native du value guard et enrichi les logs tools avec les identifiants.
+- ✅ Propagé les hints de corrélation value guard côté `plan_dry_run` et fan-out initial pour relier les aperçus aux mêmes `runId`/`opId`.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 96)
+- ✅ Étendu le schéma `plan_dry_run` avec les hints de corrélation (`run_id`/`op_id`/`job_id`/`graph_id`/`node_id`/`child_id`) et extrait ces métadonnées pour alimenter le value guard.
+- ✅ Propagé les hints vers `ValueGraph.explain` afin que les événements `plan_explained` exposent directement les identifiants ; journalisation `plan_dry_run` mise à jour pour inclure `run_id`/`op_id`.
+- ✅ Ajouté un scénario déterministe dans `tests/plan.dry-run.test.ts` vérifiant la présence des hints dans la télémétrie du value guard.
+- 🔜 Étendre la fan-out corrélée côté planification réelle (ex. `plan_run_bt`/`plan_run_reactive`) afin d'associer les dry-runs aux exécutions et cascader les identifiants jusqu'aux runtimes enfants.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 97)
+- ✅ Étendu `plan_run_bt` et `plan_run_reactive` pour accepter/propager les hints `run_id`/`op_id`/`job_id`/`graph_id`/`node_id`/`child_id`, réutiliser les identifiants fournis et enrichir logs + bus MCP avec ces métadonnées.
+- ✅ Mis à jour `PlanRun*Result` pour renvoyer la corrélation, injecté les hints dans les événements `BT_RUN` et aligné `tests/plan.bt.events.test.ts` avec de nouveaux scénarios corrélés.
+- ✅ Propager ces hints vers `plan_fanout`, les outils enfants et `server.ts` pour cascader la corrélation jusqu'aux runtimes et à la cancellation (couvert itération 98).
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 98)
+- ✅ Étendu `PlanFanoutInputSchema`/`PlanFanoutResult` avec les hints `run_id`/`op_id`/`job_id`/`graph_id`/`node_id`/`child_id`, mis à jour le mapping JSON et normalisé les métadonnées injectées dans les manifestes enfants.
+- ✅ Enregistré `plan_fanout` auprès du registre d’annulation, enrichi les logs/événements (PLAN, spawn, cancel) et propagé les hints vers le `ChildSupervisor` pour corréler IO et manifests.
+- ✅ Ajouté un scénario déterministe `plan.fanout-join.test.ts` couvrant les hints fournis, actualisé les attentes existantes et vérifié la persistance côté manifest/mapping.
+- 🔜 Finaliser la cascade des hints côté outils enfants (plan_cancel/op_cancel) et vérifier la remontée des corrélations dans les ressources MCP (runs/enfants) pour aligner cancellation et observabilité.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 99)
+- ✅ Étendu le registre d’annulation pour mémoriser `jobId`/`graphId`/`nodeId`/`childId`, enrichi `OperationCancelledError` et les événements émis afin que le bus MCP relaie directement ces corrélations.
+- ✅ Mis à jour `op_cancel`/`plan_cancel` pour renvoyer des résultats snake_case incluant les métadonnées et consigner des logs détaillés, puis couvert ces comportements dans `tests/cancel.plan.run.test.ts`.
+- ✅ Ajusté `bridgeCancellationEvents` et les tests d’événements pour vérifier la présence des hints (job/graph/node/child) sans resolver auxiliaire ; exécuté `npm run build`, `npm run lint`, `npm test`.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 100)
+- ✅ Enrichi `ResourceRegistry` pour stocker les identifiants `runId`/`opId`/`graphId`/`nodeId` sur chaque événement de run et ajouté la documentation correspondante.
+- ✅ Propagé ces métadonnées depuis `pushEvent` dans `src/server.ts` afin que le registre MCP capture les corrélations natives du bus.
+- ✅ Étendu `tests/resources.list-read-watch.test.ts` avec des scénarios validant la persistance des hints et la pagination corrélée.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 101)
+- ✅ Propagé les flux stdout/stderr des enfants vers `ResourceRegistry` avec les hints `jobId`/`runId`/`opId`/`graphId`/`nodeId` en étendant `ChildSupervisor` et le callback `recordChildLogEntry` du serveur.
+- ✅ Aligné les schémas de logs enfants (`ResourceChildLogEntry`) pour conserver `raw`/`parsed` et ajouté une couverture déterministe (`tests/child.supervisor.test.ts`, `tests/resources.list-read-watch.test.ts`).
+- 🔜 Vérifier que les outils MCP (`resources_watch`) exposent correctement les nouveaux champs côté clients et propager la même corrélation vers un éventuel `logs_tail` une fois implémenté.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 102)
+- ✅ Étendu `ChildRuntime` avec `setRole`/`setLimits`/`attach`, persisté le rôle dans le manifeste et mémorisé les limites pour les mises à jour à chaud.
+- ✅ Enrichi `ChildrenIndex` avec `role`/`limits`/`attachedAt` + API dédiées, ajouté les outils MCP `child_spawn_codex`/`child_attach`/`child_set_role`/`child_set_limits` et synchronisé le serveur.
+- ✅ Couverture dédiée `tests/child.spawn-attach-limits.test.ts` validant rôle/limites/attach + restauration sérialisée du nouvel état, MAJ AGENTS checklist.
+- ✅ Propager le champ `role` côté `GraphState`/dashboard et exposer les nouvelles opérations dans la documentation MCP (couvert itération 103 pour la partie GraphState/dashboard ; la documentation reste à compléter).
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 103)
+- ✅ Propagé `role`/`limits`/`attachedAt` depuis `ChildrenIndex` vers `GraphState`, incluant sérialisation déterministe des limites et normalisation des snapshots enfants.
+- ✅ Mis à jour le dashboard SSE pour exposer les nouveaux attributs (rôle, limites, attachements) et documenté les champs ajoutés.
+- ✅ Étendu `tests/graphState.test.ts` et les doubles de supervision/autoscaler afin de couvrir les nouvelles métadonnées.
+- ✅ Documenté les nouveaux outils enfants (`child_*`), reflété le champ `role` côté documentation/CLI et vérifié que `resources_watch` expose les métadonnées enrichies.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 104)
+- ✅ Actualisé `README.md` pour détailler `child_spawn_codex`, `child_attach`, `child_set_role`, `child_set_limits` et noter la propagation des hints de corrélation.
+- ✅ Complété `docs/mcp-api.md` avec les structures `ResourceRunEvent`/`ResourceChildLogEntry` enrichies et la section dédiée aux contrôles fins du runtime enfant.
+- ✅ Vérifié que la checklist reflète l'avancement (entrée déplacée en ✅) et noté le contexte pour le prochain agent.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 105)
+- ✅ Implémenté `GraphTransactionManager` avec gestion TTL/owner/note, snapshot committedAt et détection des commits no-op (`src/graph/tx.ts`).
+- ✅ Exposé les outils MCP `tx_begin`/`tx_apply`/`tx_commit`/`tx_rollback` avec logs corrélés, validation Zod des opérations et enregistrement des snapshots/versions (`src/server.ts`, `src/tools/txTools.ts`).
+- ✅ Étendu le registry ressources pour stocker snapshots/versions et écrit `tests/tx.begin-apply-commit.test.ts` couvrant conflit, rollback, aperçu `preview_version`; exécuté `npm run build`, `npm run lint`, `npm test`.
+- 🔜 Enchaîner sur diff/patch + invariants (section 2.2), puis verrous/idempotency afin de fiabiliser les transactions concurrentes avant d'ouvrir les opérations bulk.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 106)
+- ✅ Ajouté la paire diff/patch (`src/graph/diff.ts`, `src/graph/patch.ts`) et le module d'invariants (`src/graph/invariants.ts`) pour couvrir DAG, labels, ports et cardinalités.
+- ✅ Enregistré les outils MCP `graph_diff`/`graph_patch` dans `src/server.ts`, avec schémas dédiés (`src/tools/graphDiffTools.ts`) et intégration au registre `sc://`.
+- ✅ Rédigé des tests déterministes (`tests/graph.diff-patch.test.ts`, `tests/graph.invariants.enforced.test.ts`) et mis à jour la documentation (`README.md`, `docs/mcp-api.md`).
+- 🔜 Préparer les verrous/idempotency (sections 2.3/2.4) puis couvrir le bulk pour sécuriser les mutations concurrentes.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 107)
+- ✅ Implémenté `GraphLockManager` (`src/graph/locks.ts`) avec TTL rafraîchissable, ré-entrance par holder et erreurs structurées (`E-GRAPH-LOCK-HELD`, `E-GRAPH-MUTATION-LOCKED`).
+- ✅ Ajouté les outils MCP `graph_lock`/`graph_unlock` (`src/tools/graphLockTools.ts`, `src/server.ts`), branché `graph_patch`, `graph_mutate` et `tx_*` sur le gestionnaire de verrous, et documenté l'usage (`README.md`, `docs/mcp-api.md`).
+- ✅ Couverture déterministe `tests/graph.locks.concurrent.test.ts` + enrichissement des suites existantes (`tests/graph.diff-patch.test.ts`, `tests/tx.begin-apply-commit.test.ts`) pour vérifier le rejet concurrent.
+- 🔜 Enchaîner sur les clés d'idempotence (section 2.4) avant d'aborder les opérations bulk atomiques.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 108)
+- ✅ Créé un registre `IdempotencyRegistry` avec TTL injectables et intégration serveur (`src/infra/idempotency.ts`, `src/server.ts`).
+- ✅ Ajouté la prise en charge de `idempotency_key` + `idempotent` pour `child_create`, `child_spawn_codex`, `plan_run_bt`, `cnp_announce` et `tx_begin` avec journalisation dédiée.
+- ✅ Documenté le comportement dans `README.md`/`docs/mcp-api.md` et ajouté `tests/idempotency.replay.test.ts` couvrant les replays, plus adaptations des suites existantes.
+- 🔜 Étendre l'idempotence aux futures opérations bulk (`graph_batch_mutate`, batch enfants/stigmergie) et aligner les clients sur les nouveaux champs.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 109)
+- ✅ Ajouté l'idempotence à `plan_run_reactive` (schéma, cache et journalisation `plan_run_reactive_replayed`) en factorisant `executePlanRunReactive`.
+- ✅ Étendu la documentation (`README.md`, `docs/mcp-api.md`) et les suites (`tests/idempotency.replay.test.ts`, `tests/plan.run-reactive.test.ts`, `tests/plan.bt.events.test.ts`) pour refléter les drapeaux `idempotent`/`idempotency_key`.
+- ✅ Nettoyé `node_modules/` après exécution de `npm run build`, `npm run lint`, `npm test` et suppression des artefacts `children/` temporaires.
+- 🔜 Couvrir les opérations bulk (`graph_batch_mutate`, fan-out multi-enfants) avec le cache idempotent et vérifier la compatibilité côté clients MCP.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 110)
+- ✅ Introduit `BlackboardStore.batchSet` pour appliquer plusieurs mutations atomiquement et restaurer l'état en cas d'échec.
+- ✅ Exposé le tool MCP `bb_batch_set` (`src/tools/coordTools.ts`, `src/server.ts`) et documenté son usage (`README.md`, `docs/mcp-api.md`).
+- ✅ Créé `tests/bulk.bb-graph-child-stig.test.ts` avec une couverture dédiée `bb_batch_set` (succès + rollback). Les opérations bulk graph/enfant/stig restent à implémenter.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 111)
+- ✅ Finalisé les tools bulk `graph_batch_mutate`, `child_batch_create` et `stig_batch` côté serveur avec journalisation et support idempotent.
+- ✅ Mis à jour `README.md` et `docs/mcp-api.md` pour détailler les nouveaux schémas (`StigBatchInput`, `GraphBatchMutateInput`, `ChildBatchCreateInput`) et clarifier les champs `created`/`changed`.
+- ✅ Étendu `tests/bulk.bb-graph-child-stig.test.ts` avec les scénarios de version attendue, no-op, comptage `created` et rollback enfants ; exécuté la suite complète (`npm run build`, `npm run lint`, `npm test`).
+- 🔜 Couvrir l'émission des événements bus/corrélations pour les outils bulk côté serveur et ajouter un test d'intégration MCP end-to-end.

--- a/dist/coord/stigmergy.js
+++ b/dist/coord/stigmergy.js
@@ -58,6 +58,71 @@ export class StigmergyField {
         return snapshot;
     }
     /**
+     * Applies multiple markings atomically. Either every entry is committed or
+     * the field is restored to its previous state. Events are only emitted once
+     * the batch succeeds so downstream observers never observe partial updates.
+     */
+    batchMark(entries) {
+        if (entries.length === 0) {
+            return [];
+        }
+        const originalEntries = new Map();
+        for (const [key, entry] of this.entries.entries()) {
+            originalEntries.set(key, { ...entry });
+        }
+        const originalTotals = new Map();
+        for (const [nodeId, total] of this.totals.entries()) {
+            originalTotals.set(nodeId, { ...total });
+        }
+        const results = [];
+        const events = [];
+        try {
+            for (const payload of entries) {
+                if (!Number.isFinite(payload.intensity) || payload.intensity <= 0) {
+                    throw new Error("intensity must be a positive finite number");
+                }
+                const normalisedType = normaliseType(payload.type);
+                const timestamp = this.now();
+                const key = this.makeKey(payload.nodeId, normalisedType);
+                const existing = this.entries.get(key);
+                const previousIntensity = existing?.intensity ?? 0;
+                const nextIntensity = previousIntensity + payload.intensity;
+                const entry = {
+                    nodeId: payload.nodeId,
+                    type: normalisedType,
+                    intensity: nextIntensity,
+                    updatedAt: timestamp,
+                };
+                this.entries.set(key, entry);
+                const total = this.adjustTotal(payload.nodeId, nextIntensity - previousIntensity, timestamp);
+                const snapshot = this.cloneEntry(entry);
+                results.push({ point: snapshot, nodeTotal: { nodeId: payload.nodeId, intensity: total.intensity, updatedAt: total.updatedAt } });
+                events.push({
+                    nodeId: payload.nodeId,
+                    type: normalisedType,
+                    intensity: snapshot.intensity,
+                    totalIntensity: total.intensity,
+                    updatedAt: snapshot.updatedAt,
+                });
+            }
+        }
+        catch (error) {
+            this.entries.clear();
+            for (const [key, entry] of originalEntries.entries()) {
+                this.entries.set(key, entry);
+            }
+            this.totals.clear();
+            for (const [nodeId, total] of originalTotals.entries()) {
+                this.totals.set(nodeId, total);
+            }
+            throw error;
+        }
+        for (const event of events) {
+            this.emitChange(event);
+        }
+        return results;
+    }
+    /**
      * Applies exponential decay to all pheromones using the provided half-life.
      * Entries whose intensity drops below {@link EPSILON} are evicted from the
      * field. The method returns the list of points that changed so callers can

--- a/dist/events/bridges.js
+++ b/dist/events/bridges.js
@@ -1,0 +1,415 @@
+import { subscribeConsensusEvents, } from "../coord/consensus.js";
+import { subscribeCancellationEvents } from "../executor/cancel.js";
+/**
+ * Subscribes to the blackboard change stream and publishes structured events on
+ * the unified bus. The function returns a disposer so callers can detach the
+ * bridge when shutting the orchestrator down.
+ */
+export function bridgeBlackboardEvents(options) {
+    const { blackboard, bus, resolveCorrelation } = options;
+    let lastVersion = blackboard.getCurrentVersion();
+    const listener = (event) => {
+        lastVersion = Math.max(lastVersion, event.version);
+        const correlation = resolveCorrelation?.(event) ?? {};
+        const level = event.kind === "expire" ? "warn" : "info";
+        const payload = {
+            kind: event.kind,
+            key: event.key,
+            version: event.version,
+            timestamp: event.timestamp,
+            reason: event.reason ?? null,
+            entry: event.entry ?? null,
+            previous: event.previous ?? null,
+        };
+        bus.publish({
+            cat: "blackboard",
+            level,
+            jobId: correlation.jobId ?? null,
+            runId: correlation.runId ?? null,
+            opId: correlation.opId ?? null,
+            graphId: correlation.graphId ?? null,
+            nodeId: correlation.nodeId ?? null,
+            childId: correlation.childId ?? null,
+            msg: `bb_${event.kind}`,
+            data: payload,
+        });
+    };
+    const detach = blackboard.watch({ fromVersion: lastVersion, listener });
+    return () => {
+        detach();
+    };
+}
+/**
+ * Observes stigmergic field mutations and mirrors them on the unified bus so
+ * downstream MCP clients can reason about pheromone dynamics in real time.
+ */
+export function bridgeStigmergyEvents(options) {
+    const { field, bus, resolveCorrelation } = options;
+    const detach = field.onChange((event) => {
+        const correlation = resolveCorrelation?.(event) ?? {};
+        bus.publish({
+            cat: "stigmergy",
+            level: "info",
+            jobId: correlation.jobId ?? null,
+            runId: correlation.runId ?? null,
+            opId: correlation.opId ?? null,
+            graphId: correlation.graphId ?? null,
+            nodeId: event.nodeId,
+            childId: correlation.childId ?? null,
+            msg: "stigmergy_change",
+            data: {
+                nodeId: event.nodeId,
+                type: event.type,
+                intensity: event.intensity,
+                totalIntensity: event.totalIntensity,
+                updatedAt: event.updatedAt,
+            },
+        });
+    });
+    return () => {
+        detach();
+    };
+}
+/**
+ * Observes cancellation registry notifications and forwards them to the unified
+ * bus. The bridge differentiates between brand new requests and idempotent
+ * retries so MCP clients can surface the correct severity.
+ */
+export function bridgeCancellationEvents(options) {
+    const { bus, subscribe = subscribeCancellationEvents, resolveCorrelation } = options;
+    const unsubscribe = subscribe((event) => {
+        const correlation = resolveCorrelation?.(event) ?? {};
+        const level = event.outcome === "requested" ? "info" : "warn";
+        const message = event.outcome === "requested" ? "cancel_requested" : "cancel_repeat";
+        bus.publish({
+            cat: "cancel",
+            level,
+            jobId: correlation.jobId ?? event.jobId ?? null,
+            runId: correlation.runId ?? event.runId ?? null,
+            opId: correlation.opId ?? event.opId,
+            graphId: correlation.graphId ?? event.graphId ?? null,
+            nodeId: correlation.nodeId ?? event.nodeId ?? null,
+            childId: correlation.childId ?? event.childId ?? null,
+            msg: message,
+            data: {
+                opId: event.opId,
+                runId: event.runId ?? null,
+                jobId: event.jobId ?? null,
+                graphId: event.graphId ?? null,
+                nodeId: event.nodeId ?? null,
+                childId: event.childId ?? null,
+                reason: event.reason,
+                at: event.at,
+                outcome: event.outcome,
+            },
+        });
+    });
+    return () => {
+        unsubscribe();
+    };
+}
+/**
+ * Observes child runtime events and forwards them to the unified bus. Messages
+ * are categorised by stream while lifecycle notifications surface spawn/exit
+ * transitions so MCP clients can correlate orchestrator decisions.
+ */
+export function bridgeChildRuntimeEvents(options) {
+    const { runtime, bus, resolveCorrelation } = options;
+    const handleCorrelation = (context) => {
+        return resolveCorrelation?.(context) ?? {};
+    };
+    const messageListener = (message) => {
+        const correlation = handleCorrelation({ kind: "message", runtime, message });
+        const level = message.stream === "stderr" ? "warn" : "info";
+        // Promote correlation identifiers surfaced directly by the child payload
+        // so tooling receives run/op hints even when the resolver stays silent.
+        const parsed = message.parsed;
+        const jobId = correlation.jobId ?? (parsed && typeof parsed.jobId === "string" ? parsed.jobId : null);
+        const runId = correlation.runId ?? (parsed && typeof parsed.runId === "string" ? parsed.runId : null);
+        const opId = correlation.opId ?? (parsed && typeof parsed.opId === "string" ? parsed.opId : null);
+        const childId = correlation.childId ??
+            (parsed && typeof parsed.childId === "string" ? parsed.childId : runtime.childId);
+        bus.publish({
+            cat: "child",
+            level,
+            childId,
+            jobId,
+            runId,
+            opId,
+            graphId: correlation.graphId ?? null,
+            nodeId: correlation.nodeId ?? null,
+            msg: message.stream === "stderr" ? "child_stderr" : "child_stdout",
+            data: {
+                childId: runtime.childId,
+                stream: message.stream,
+                raw: message.raw,
+                parsed: message.parsed,
+                receivedAt: message.receivedAt,
+                sequence: message.sequence,
+            },
+        });
+    };
+    const lifecycleListener = (event) => {
+        const correlation = handleCorrelation({ kind: "lifecycle", runtime, lifecycle: event });
+        let level = "info";
+        let msg = "child_lifecycle";
+        const data = {
+            childId: runtime.childId,
+            phase: event.phase,
+            at: event.at,
+            pid: event.pid,
+            forced: event.forced,
+            reason: event.reason,
+        };
+        if (event.phase === "spawned") {
+            msg = "child_spawned";
+        }
+        else if (event.phase === "exit") {
+            msg = "child_exit";
+            data.code = event.code;
+            data.signal = event.signal;
+            if (event.forced || (typeof event.code === "number" && event.code !== 0) || event.signal) {
+                level = "warn";
+            }
+        }
+        else if (event.phase === "error") {
+            msg = "child_error";
+            level = "error";
+        }
+        bus.publish({
+            cat: "child",
+            level,
+            childId: correlation.childId ?? runtime.childId,
+            jobId: correlation.jobId ?? null,
+            runId: correlation.runId ?? null,
+            opId: correlation.opId ?? null,
+            graphId: correlation.graphId ?? null,
+            nodeId: correlation.nodeId ?? null,
+            msg,
+            data,
+        });
+    };
+    runtime.on("message", messageListener);
+    runtime.on("lifecycle", lifecycleListener);
+    return () => {
+        runtime.off("message", messageListener);
+        runtime.off("lifecycle", lifecycleListener);
+    };
+}
+/**
+ * Observes Contract-Net lifecycle events and forwards them to the unified bus
+ * so MCP tooling can audit announcements, bids and awards alongside other
+ * orchestration streams.
+ */
+export function bridgeContractNetEvents(options) {
+    const { coordinator, bus, subscribe = (listener) => coordinator.observe(listener), resolveCorrelation } = options;
+    const listener = (event) => {
+        const correlation = resolveCorrelation?.(event) ?? {};
+        let level = "info";
+        let msg = "cnp_event";
+        let data = {};
+        switch (event.kind) {
+            case "agent_registered":
+                msg = event.updated ? "cnp_agent_updated" : "cnp_agent_registered";
+                data = { agent: event.agent, updated: event.updated };
+                break;
+            case "agent_unregistered":
+                msg = "cnp_agent_unregistered";
+                data = { agentId: event.agentId, remainingAssignments: event.remainingAssignments };
+                break;
+            case "call_announced":
+                msg = "cnp_call_announced";
+                data = { call: event.call };
+                break;
+            case "bid_recorded":
+                msg = event.previousKind ? "cnp_bid_updated" : "cnp_bid_recorded";
+                data = {
+                    callId: event.callId,
+                    agentId: event.agentId,
+                    bid: event.bid,
+                    previousKind: event.previousKind,
+                };
+                break;
+            case "call_awarded":
+                msg = "cnp_call_awarded";
+                data = { call: event.call, decision: event.decision };
+                break;
+            case "call_completed":
+                msg = "cnp_call_completed";
+                data = { call: event.call };
+                break;
+            default:
+                data = event;
+                break;
+        }
+        bus.publish({
+            cat: "contract_net",
+            level,
+            jobId: correlation.jobId ?? null,
+            runId: correlation.runId ?? null,
+            opId: correlation.opId ?? null,
+            graphId: correlation.graphId ?? null,
+            nodeId: correlation.nodeId ?? null,
+            childId: correlation.childId ?? null,
+            msg,
+            data,
+        });
+    };
+    const dispose = subscribe(listener);
+    return () => {
+        dispose();
+    };
+}
+/**
+ * Observes consensus computation events and forwards them to the unified bus so
+ * operators can audit quorum evaluations without adding bespoke hooks.
+ */
+export function bridgeConsensusEvents(options) {
+    const { bus, subscribe = subscribeConsensusEvents, resolveCorrelation } = options;
+    const dispose = subscribe((event) => {
+        const correlation = resolveCorrelation?.(event) ?? {};
+        let level = event.satisfied ? "info" : "warn";
+        let msg = "consensus_decision";
+        if (event.tie && !event.outcome) {
+            msg = "consensus_tie_unresolved";
+            level = "warn";
+        }
+        else if (!event.satisfied) {
+            msg = "consensus_decision_unsatisfied";
+        }
+        bus.publish({
+            cat: "consensus",
+            level,
+            jobId: correlation.jobId ?? event.jobId ?? null,
+            runId: correlation.runId ?? event.runId ?? null,
+            opId: correlation.opId ?? event.opId ?? null,
+            graphId: correlation.graphId ?? null,
+            nodeId: correlation.nodeId ?? null,
+            childId: correlation.childId ?? null,
+            msg,
+            data: {
+                source: event.source,
+                at: event.at,
+                mode: event.mode,
+                outcome: event.outcome,
+                satisfied: event.satisfied,
+                tie: event.tie,
+                threshold: event.threshold,
+                total_weight: event.totalWeight,
+                votes: event.votes,
+                tally: event.tally,
+                metadata: event.metadata ?? null,
+            },
+        });
+    });
+    return () => {
+        dispose();
+    };
+}
+/**
+ * Observes value guard events and forwards them to the unified bus. The bridge
+ * surfaces configuration updates alongside plan evaluations so MCP clients can
+ * audit guard outcomes without directly coupling to the `ValueGraph`.
+ */
+export function bridgeValueEvents(options) {
+    const { graph, bus, subscribe = (listener) => graph.subscribe(listener), resolveCorrelation, } = options;
+    const listener = (event) => {
+        const hints = {};
+        if (event.correlation) {
+            const { runId, opId, jobId, graphId, nodeId, childId } = event.correlation;
+            if (runId !== undefined)
+                hints.runId = runId ?? null;
+            if (opId !== undefined)
+                hints.opId = opId ?? null;
+            if (jobId !== undefined)
+                hints.jobId = jobId ?? null;
+            if (graphId !== undefined)
+                hints.graphId = graphId ?? null;
+            if (nodeId !== undefined)
+                hints.nodeId = nodeId ?? null;
+            if (childId !== undefined)
+                hints.childId = childId ?? null;
+        }
+        const resolved = resolveCorrelation?.(event);
+        if (resolved) {
+            for (const [key, value] of Object.entries(resolved)) {
+                if (value !== undefined) {
+                    hints[key] = value;
+                }
+            }
+        }
+        let level = "info";
+        let msg = "values_event";
+        let data = {};
+        switch (event.kind) {
+            case "config_updated":
+                msg = "values_config_updated";
+                data = {
+                    summary: event.summary,
+                };
+                break;
+            case "plan_scored": {
+                msg = "values_scored";
+                const violations = event.result.violations.length;
+                if (violations > 0) {
+                    level = "warn";
+                }
+                data = {
+                    plan_id: event.planId,
+                    plan_label: event.planLabel,
+                    impacts_count: event.impacts.length,
+                    impacts: event.impacts,
+                    result: event.result,
+                    violations_count: violations,
+                };
+                break;
+            }
+            case "plan_filtered": {
+                const allowed = event.decision.allowed;
+                msg = allowed ? "values_filter_allowed" : "values_filter_blocked";
+                level = allowed ? "info" : "warn";
+                data = {
+                    plan_id: event.planId,
+                    plan_label: event.planLabel,
+                    impacts_count: event.impacts.length,
+                    impacts: event.impacts,
+                    decision: event.decision,
+                };
+                break;
+            }
+            case "plan_explained": {
+                const allowed = event.result.decision.allowed;
+                msg = allowed ? "values_explain_allowed" : "values_explain_blocked";
+                level = allowed ? "info" : "warn";
+                data = {
+                    plan_id: event.planId,
+                    plan_label: event.planLabel,
+                    impacts_count: event.impacts.length,
+                    impacts: event.impacts,
+                    result: event.result,
+                };
+                break;
+            }
+            default:
+                data = event;
+                break;
+        }
+        bus.publish({
+            cat: "values",
+            level,
+            jobId: hints.jobId ?? null,
+            runId: hints.runId ?? null,
+            opId: hints.opId ?? null,
+            graphId: hints.graphId ?? null,
+            nodeId: hints.nodeId ?? null,
+            childId: hints.childId ?? null,
+            msg,
+            data,
+            ts: event.at,
+        });
+    };
+    const dispose = subscribe(listener);
+    return () => {
+        dispose();
+    };
+}

--- a/dist/graph/diff.js
+++ b/dist/graph/diff.js
@@ -1,0 +1,127 @@
+/**
+ * Compute a RFC 6902 JSON Patch transforming {@link base} into {@link target}.
+ *
+ * The implementation intentionally focuses on top-level mutations (name,
+ * metadata, nodes, edges) to guarantee deterministic output without requiring
+ * a heavy structural diff dependency. Arrays are fully replaced whenever they
+ * diverge which keeps the patch readable and easy to apply.
+ */
+export function diffGraphs(base, target) {
+    const baseDoc = toDiffDocument(base);
+    const targetDoc = toDiffDocument(target);
+    const operations = [];
+    if (baseDoc.name !== targetDoc.name) {
+        operations.push({ op: "replace", path: "/name", value: targetDoc.name });
+    }
+    if (!recordsEqual(baseDoc.metadata, targetDoc.metadata)) {
+        emitRecordDiff("/metadata", baseDoc.metadata, targetDoc.metadata, operations);
+    }
+    const nodesChanged = !arraysEqual(baseDoc.nodes, targetDoc.nodes);
+    if (nodesChanged) {
+        operations.push({ op: "replace", path: "/nodes", value: targetDoc.nodes });
+    }
+    const edgesChanged = !arraysEqual(baseDoc.edges, targetDoc.edges);
+    if (edgesChanged) {
+        operations.push({ op: "replace", path: "/edges", value: targetDoc.edges });
+    }
+    const changed = operations.length > 0;
+    return {
+        operations,
+        changed,
+        summary: {
+            nameChanged: baseDoc.name !== targetDoc.name,
+            metadataChanged: !recordsEqual(baseDoc.metadata, targetDoc.metadata),
+            nodesChanged,
+            edgesChanged,
+        },
+    };
+}
+/** Convert a normalised graph into the canonical representation used for diffs. */
+function toDiffDocument(graph) {
+    return {
+        name: graph.name ?? "",
+        metadata: sortRecord(graph.metadata ?? {}),
+        nodes: graph.nodes
+            .map((node) => ({
+            id: node.id,
+            label: node.label ?? null,
+            attributes: sortRecord(node.attributes ?? {}),
+        }))
+            .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
+        edges: graph.edges
+            .map((edge) => ({
+            from: edge.from,
+            to: edge.to,
+            label: edge.label ?? null,
+            weight: typeof edge.weight === "number" ? Number(edge.weight) : null,
+            attributes: sortRecord(edge.attributes ?? {}),
+        }))
+            .sort((a, b) => {
+            if (a.from === b.from) {
+                return a.to < b.to ? -1 : a.to > b.to ? 1 : 0;
+            }
+            return a.from < b.from ? -1 : 1;
+        }),
+    };
+}
+/** Compare two records for equality (assuming both were sorted). */
+function recordsEqual(left, right) {
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length) {
+        return false;
+    }
+    for (const key of leftKeys) {
+        if (!(key in right)) {
+            return false;
+        }
+        if (left[key] !== right[key]) {
+            return false;
+        }
+    }
+    return true;
+}
+/** Compare two arrays via JSON serialization (values are already canonical). */
+function arraysEqual(left, right) {
+    if (left.length !== right.length) {
+        return false;
+    }
+    for (let index = 0; index < left.length; index += 1) {
+        if (JSON.stringify(left[index]) !== JSON.stringify(right[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+/** Emit per-key JSON Patch operations for record mutations. */
+function emitRecordDiff(basePath, base, target, operations) {
+    const baseKeys = new Set(Object.keys(base));
+    const targetKeys = new Set(Object.keys(target));
+    for (const key of baseKeys) {
+        if (!targetKeys.has(key)) {
+            operations.push({ op: "remove", path: `${basePath}/${escapePointer(key)}` });
+        }
+    }
+    for (const key of targetKeys) {
+        const pointer = `${basePath}/${escapePointer(key)}`;
+        if (!baseKeys.has(key)) {
+            operations.push({ op: "add", path: pointer, value: target[key] });
+        }
+        else if (base[key] !== target[key]) {
+            operations.push({ op: "replace", path: pointer, value: target[key] });
+        }
+    }
+}
+/** Sort record entries lexicographically for deterministic comparisons. */
+function sortRecord(values) {
+    const sortedEntries = Object.entries(values).sort(([a], [b]) => a.localeCompare(b));
+    const result = {};
+    for (const [key, value] of sortedEntries) {
+        result[key] = value;
+    }
+    return result;
+}
+/** Escape a JSON pointer segment following RFC 6901. */
+function escapePointer(segment) {
+    return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}

--- a/dist/graph/invariants.js
+++ b/dist/graph/invariants.js
@@ -1,0 +1,190 @@
+/** Error thrown when invariants are violated. */
+export class GraphInvariantError extends Error {
+    violations;
+    constructor(violations) {
+        super(violations
+            .map((violation) => `${violation.code}: ${violation.message}`)
+            .join("; "));
+        this.violations = violations;
+        this.name = "GraphInvariantError";
+    }
+}
+/**
+ * Evaluate the invariants declared in the graph metadata and node attributes.
+ * Callers can override the derived options via {@link overrides}.
+ */
+export function evaluateGraphInvariants(graph, overrides = {}) {
+    const options = deriveOptions(graph, overrides);
+    const violations = [];
+    if (options.enforceDag) {
+        const cycles = detectCycles(graph);
+        if (cycles.length > 0) {
+            violations.push({
+                code: "E-GRAPH-CYCLE",
+                message: `cycles detected (${cycles.length}) in graph '${graph.graphId}'`,
+                details: { cycles },
+            });
+        }
+    }
+    if (options.requireNodeLabels) {
+        const missing = graph.nodes.filter((node) => !node.label || node.label.trim().length === 0).map((node) => node.id);
+        if (missing.length > 0) {
+            violations.push({
+                code: "E-NODE-LABEL",
+                message: "node labels are required when 'require_labels' metadata is true",
+                nodes: missing,
+            });
+        }
+    }
+    if (options.requireEdgeLabels) {
+        const missing = graph.edges
+            .filter((edge) => !edge.label || edge.label.trim().length === 0)
+            .map((edge) => ({ from: edge.from, to: edge.to }));
+        if (missing.length > 0) {
+            for (const entry of missing) {
+                violations.push({
+                    code: "E-EDGE-LABEL",
+                    message: `edge '${entry.from}' -> '${entry.to}' is missing a label`,
+                    edge: entry,
+                });
+            }
+        }
+    }
+    if (options.requirePortAttributes) {
+        for (const edge of graph.edges) {
+            const fromPort = normalisePort(edge.attributes.from_port);
+            const toPort = normalisePort(edge.attributes.to_port);
+            if (!fromPort || !toPort) {
+                violations.push({
+                    code: "E-EDGE-PORT",
+                    message: `edge '${edge.from}' -> '${edge.to}' must declare 'from_port' and 'to_port' attributes`,
+                    edge: { from: edge.from, to: edge.to },
+                });
+            }
+        }
+    }
+    const cardinalityViolations = enforceCardinality(graph, options);
+    violations.push(...cardinalityViolations);
+    return { ok: violations.length === 0, violations };
+}
+/** Assert that the invariants hold, throwing a {@link GraphInvariantError} when they do not. */
+export function assertGraphInvariants(graph, overrides = {}) {
+    const report = evaluateGraphInvariants(graph, overrides);
+    if (!report.ok) {
+        throw new GraphInvariantError(report.violations);
+    }
+}
+/** Infer invariant options from metadata and node attributes. */
+function deriveOptions(graph, overrides) {
+    const metadata = normaliseRecord(graph.metadata ?? {});
+    return {
+        enforceDag: overrides.enforceDag ?? (metadata.graph_kind === "dag" || metadata.dag === true || metadata.enforce_dag === true),
+        requireNodeLabels: overrides.requireNodeLabels ?? metadata.require_labels === true,
+        requireEdgeLabels: overrides.requireEdgeLabels ?? metadata.require_edge_labels === true,
+        requirePortAttributes: overrides.requirePortAttributes ?? metadata.require_ports === true,
+        defaultMaxInDegree: overrides.defaultMaxInDegree ?? parseDegree(metadata.max_in_degree),
+        defaultMaxOutDegree: overrides.defaultMaxOutDegree ?? parseDegree(metadata.max_out_degree),
+    };
+}
+/** Parse a degree hint from metadata. */
+function parseDegree(value) {
+    if (typeof value !== "number") {
+        return undefined;
+    }
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+/**
+ * Enforce per-node cardinality limits using metadata defaults and attribute-level overrides.
+ */
+function enforceCardinality(graph, options) {
+    const violations = [];
+    const incoming = new Map();
+    const outgoing = new Map();
+    for (const node of graph.nodes) {
+        incoming.set(node.id, 0);
+        outgoing.set(node.id, 0);
+    }
+    for (const edge of graph.edges) {
+        incoming.set(edge.to, (incoming.get(edge.to) ?? 0) + 1);
+        outgoing.set(edge.from, (outgoing.get(edge.from) ?? 0) + 1);
+    }
+    for (const node of graph.nodes) {
+        const maxIn = parseDegree(node.attributes.max_in_degree) ?? options.defaultMaxInDegree;
+        const maxOut = parseDegree(node.attributes.max_out_degree) ?? options.defaultMaxOutDegree;
+        if (typeof maxIn === "number" && (incoming.get(node.id) ?? 0) > maxIn) {
+            violations.push({
+                code: "E-IN-DEGREE",
+                message: `node '${node.id}' exceeds max_in_degree (${incoming.get(node.id)} > ${maxIn})`,
+                nodes: [node.id],
+                details: { max: maxIn, actual: incoming.get(node.id) ?? 0 },
+            });
+        }
+        if (typeof maxOut === "number" && (outgoing.get(node.id) ?? 0) > maxOut) {
+            violations.push({
+                code: "E-OUT-DEGREE",
+                message: `node '${node.id}' exceeds max_out_degree (${outgoing.get(node.id)} > ${maxOut})`,
+                nodes: [node.id],
+                details: { max: maxOut, actual: outgoing.get(node.id) ?? 0 },
+            });
+        }
+    }
+    return violations;
+}
+/** Detect directed cycles using depth-first search. */
+function detectCycles(graph) {
+    const adjacency = new Map();
+    for (const node of graph.nodes) {
+        adjacency.set(node.id, []);
+    }
+    for (const edge of graph.edges) {
+        if (!adjacency.has(edge.from)) {
+            adjacency.set(edge.from, []);
+        }
+        adjacency.get(edge.from).push(edge.to);
+    }
+    const visiting = new Set();
+    const visited = new Set();
+    const stack = [];
+    const cycles = [];
+    const visit = (nodeId) => {
+        visiting.add(nodeId);
+        stack.push(nodeId);
+        for (const neighbour of adjacency.get(nodeId) ?? []) {
+            if (visiting.has(neighbour)) {
+                const startIndex = stack.indexOf(neighbour);
+                if (startIndex >= 0) {
+                    cycles.push(stack.slice(startIndex).concat(neighbour));
+                }
+                continue;
+            }
+            if (!visited.has(neighbour)) {
+                visit(neighbour);
+            }
+        }
+        visiting.delete(nodeId);
+        visited.add(nodeId);
+        stack.pop();
+    };
+    for (const nodeId of adjacency.keys()) {
+        if (!visited.has(nodeId)) {
+            visit(nodeId);
+        }
+    }
+    return cycles;
+}
+/** Normalise metadata/attribute records. */
+function normaliseRecord(record) {
+    const output = {};
+    for (const [key, value] of Object.entries(record)) {
+        output[key] = value;
+    }
+    return output;
+}
+/** Normalise a port attribute value into a non-empty string. */
+function normalisePort(value) {
+    if (typeof value !== "string") {
+        return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}

--- a/dist/graph/locks.js
+++ b/dist/graph/locks.js
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+/** Default TTL upper bound (24h) mirroring transaction guard rails. */
+const MAX_TTL_MS = 86_400_000;
+/** Base error used by the locking subsystem. */
+export class GraphLockError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "GraphLockError";
+    }
+}
+/** Error thrown when another holder already protects the requested graph. */
+export class GraphLockHeldError extends GraphLockError {
+    code = "E-GRAPH-LOCK-HELD";
+    details;
+    constructor(graphId, holder, lockId, expiresAt) {
+        super(`graph '${graphId}' is locked by '${holder}'`);
+        this.name = "GraphLockHeldError";
+        this.details = { graphId, holder, lockId, expiresAt };
+    }
+}
+/** Error thrown when an operation references an unknown lock identifier. */
+export class GraphLockUnknownError extends GraphLockError {
+    code = "E-GRAPH-LOCK-NOT-FOUND";
+    details;
+    constructor(lockId) {
+        super(`graph lock '${lockId}' is not active`);
+        this.name = "GraphLockUnknownError";
+        this.details = { lockId };
+    }
+}
+/** Error thrown when a mutation is attempted while a conflicting lock exists. */
+export class GraphMutationLockedError extends GraphLockError {
+    code = "E-GRAPH-MUTATION-LOCKED";
+    details;
+    constructor(graphId, holder, lockId, expiresAt) {
+        super(`graph '${graphId}' is locked by '${holder}'`);
+        this.name = "GraphMutationLockedError";
+        this.details = { graphId, holder, lockId, expiresAt };
+    }
+}
+/**
+ * Cooperative lock manager protecting graph mutations. The manager exposes
+ * optimistic APIs: callers either receive the lock immediately or a
+ * deterministic error that can be retried after the TTL expires.
+ */
+export class GraphLockManager {
+    clock;
+    locksByGraphId = new Map();
+    locksById = new Map();
+    constructor(clock = () => Date.now()) {
+        this.clock = clock;
+    }
+    /** Acquire a lock for the provided graph identifier. */
+    acquire(graphId, holder, options = {}) {
+        const normalisedGraphId = normaliseGraphId(graphId);
+        const normalisedHolder = normaliseHolder(holder);
+        const now = this.clock();
+        this.pruneExpired(normalisedGraphId, now);
+        const existing = this.locksByGraphId.get(normalisedGraphId);
+        const ttlMs = normaliseTtl(options.ttlMs);
+        if (existing) {
+            if (existing.holder !== normalisedHolder) {
+                throw new GraphLockHeldError(normalisedGraphId, existing.holder, existing.lockId, existing.expiresAt);
+            }
+            const refreshed = {
+                ...existing,
+                refreshedAt: now,
+                ttlMs: ttlMs ?? existing.ttlMs,
+                expiresAt: computeExpiry(now, ttlMs ?? existing.ttlMs),
+            };
+            this.store(refreshed);
+            return { ...refreshed };
+        }
+        const snapshot = {
+            lockId: randomUUID(),
+            graphId: normalisedGraphId,
+            holder: normalisedHolder,
+            acquiredAt: now,
+            refreshedAt: now,
+            ttlMs,
+            expiresAt: computeExpiry(now, ttlMs),
+        };
+        this.store(snapshot);
+        return { ...snapshot };
+    }
+    /** Release the lock identified by {@link lockId}. */
+    release(lockId) {
+        const record = this.locksById.get(lockId);
+        if (!record) {
+            throw new GraphLockUnknownError(lockId);
+        }
+        const now = this.clock();
+        this.locksById.delete(lockId);
+        const existing = this.locksByGraphId.get(record.graphId);
+        if (existing && existing.lockId === lockId) {
+            this.locksByGraphId.delete(record.graphId);
+        }
+        const expired = record.expiresAt !== null && record.expiresAt <= now;
+        return {
+            lockId: record.lockId,
+            graphId: record.graphId,
+            holder: record.holder,
+            releasedAt: now,
+            expired,
+            expiresAt: record.expiresAt,
+        };
+    }
+    /**
+     * Ensure the caller can mutate the target graph. Throws when a conflicting
+     * lock is active.
+     */
+    assertCanMutate(graphId, holder) {
+        const normalisedGraphId = normaliseGraphId(graphId);
+        const now = this.clock();
+        this.pruneExpired(normalisedGraphId, now);
+        const active = this.locksByGraphId.get(normalisedGraphId);
+        if (!active) {
+            return;
+        }
+        const normalisedHolder = holder === undefined || holder === null ? null : normaliseHolder(holder);
+        if (normalisedHolder !== active.holder) {
+            throw new GraphMutationLockedError(active.graphId, active.holder, active.lockId, active.expiresAt);
+        }
+    }
+    /** Describe the current lock protecting the graph, if any. */
+    describe(graphId) {
+        const normalisedGraphId = normaliseGraphId(graphId);
+        const now = this.clock();
+        this.pruneExpired(normalisedGraphId, now);
+        const snapshot = this.locksByGraphId.get(normalisedGraphId);
+        return snapshot ? { ...snapshot } : null;
+    }
+    /** Describe the lock associated with the identifier, if it exists. */
+    describeById(lockId) {
+        const snapshot = this.locksById.get(lockId);
+        if (!snapshot) {
+            return null;
+        }
+        return { ...snapshot };
+    }
+    store(snapshot) {
+        this.locksByGraphId.set(snapshot.graphId, snapshot);
+        this.locksById.set(snapshot.lockId, snapshot);
+    }
+    pruneExpired(graphId, now) {
+        const existing = this.locksByGraphId.get(graphId);
+        if (!existing) {
+            return;
+        }
+        if (existing.expiresAt !== null && existing.expiresAt <= now) {
+            this.locksByGraphId.delete(graphId);
+            this.locksById.delete(existing.lockId);
+        }
+    }
+}
+function normaliseGraphId(graphId) {
+    if (!graphId || graphId.trim().length === 0) {
+        throw new GraphLockError("graph id must not be empty");
+    }
+    return graphId.trim();
+}
+function normaliseHolder(holder) {
+    const trimmed = holder.trim();
+    if (trimmed.length === 0) {
+        throw new GraphLockError("holder must not be empty");
+    }
+    return trimmed;
+}
+function normaliseTtl(ttlMs) {
+    if (ttlMs === null || ttlMs === undefined) {
+        return null;
+    }
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+        return null;
+    }
+    return Math.min(Math.floor(ttlMs), MAX_TTL_MS);
+}
+function computeExpiry(now, ttlMs) {
+    if (ttlMs === null) {
+        return null;
+    }
+    return now + ttlMs;
+}

--- a/dist/graph/patch.js
+++ b/dist/graph/patch.js
@@ -1,0 +1,187 @@
+/** Error thrown when a JSON Patch cannot be applied to the graph document. */
+export class GraphPatchApplyError extends Error {
+    path;
+    constructor(message, path) {
+        super(message);
+        this.path = path;
+        this.name = "GraphPatchApplyError";
+    }
+}
+/**
+ * Apply JSON Patch operations on top of a normalised graph. The helper keeps the
+ * graph identifier and version untouched so {@link GraphTransactionManager}
+ * remains the single authority deciding when versions get incremented.
+ */
+export function applyGraphPatch(base, patch) {
+    const document = toDocument(base);
+    for (const operation of patch) {
+        applyOperation(document, operation);
+    }
+    return fromDocument(document, base);
+}
+/** Convert a {@link NormalisedGraph} into a mutable document representation. */
+function toDocument(graph) {
+    return {
+        name: graph.name ?? "",
+        metadata: cloneRecord(graph.metadata ?? {}),
+        nodes: graph.nodes.map((node) => ({
+            id: node.id,
+            label: node.label ?? null,
+            attributes: cloneRecord(node.attributes ?? {}),
+        })),
+        edges: graph.edges.map((edge) => ({
+            from: edge.from,
+            to: edge.to,
+            label: edge.label ?? null,
+            weight: typeof edge.weight === "number" ? Number(edge.weight) : null,
+            attributes: cloneRecord(edge.attributes ?? {}),
+        })),
+    };
+}
+/** Convert the mutable document back into a normalised graph descriptor. */
+function fromDocument(document, base) {
+    return {
+        name: document.name,
+        graphId: base.graphId,
+        graphVersion: base.graphVersion,
+        metadata: cloneRecord(document.metadata),
+        nodes: document.nodes.map((node) => ({
+            id: node.id,
+            label: node.label ?? undefined,
+            attributes: cloneRecord(node.attributes),
+        })),
+        edges: document.edges.map((edge) => ({
+            from: edge.from,
+            to: edge.to,
+            label: edge.label ?? undefined,
+            weight: edge.weight ?? undefined,
+            attributes: cloneRecord(edge.attributes),
+        })),
+    };
+}
+/** Apply a single JSON Patch operation to the provided document. */
+function applyOperation(document, operation) {
+    const segments = parsePointer(operation.path);
+    if (segments.length === 0) {
+        throw new GraphPatchApplyError("root operations are not supported", operation.path);
+    }
+    switch (operation.op) {
+        case "replace":
+            replaceAtPointer(document, segments, operation.path, operation.value);
+            break;
+        case "add":
+            addAtPointer(document, segments, operation.path, operation.value);
+            break;
+        case "remove":
+            removeAtPointer(document, segments, operation.path);
+            break;
+        default:
+            throw new GraphPatchApplyError(`unsupported operation '${operation.op}'`, operation.path);
+    }
+}
+/** Replace a value located at the JSON pointer. */
+function replaceAtPointer(document, segments, path, value) {
+    const parent = resolveContainer(document, segments.slice(0, -1), path);
+    const key = segments.at(-1);
+    if (Array.isArray(parent)) {
+        const index = parseIndex(key, path, parent.length - 1);
+        parent[index] = cloneValue(value);
+    }
+    else {
+        parent[key] = cloneValue(value);
+    }
+}
+/** Add a value at the pointer location (for objects only). */
+function addAtPointer(document, segments, path, value) {
+    const parent = resolveContainer(document, segments.slice(0, -1), path);
+    const key = segments.at(-1);
+    if (Array.isArray(parent)) {
+        if (key === "-") {
+            parent.push(cloneValue(value));
+        }
+        else {
+            const index = parseIndex(key, path, parent.length);
+            parent.splice(index, 0, cloneValue(value));
+        }
+    }
+    else {
+        if (Object.prototype.hasOwnProperty.call(parent, key)) {
+            throw new GraphPatchApplyError(`key '${key}' already exists`, path);
+        }
+        parent[key] = cloneValue(value);
+    }
+}
+/** Remove the value stored at the pointer location. */
+function removeAtPointer(document, segments, path) {
+    const parent = resolveContainer(document, segments.slice(0, -1), path);
+    const key = segments.at(-1);
+    if (Array.isArray(parent)) {
+        const index = parseIndex(key, path, parent.length - 1);
+        parent.splice(index, 1);
+    }
+    else {
+        if (!Object.prototype.hasOwnProperty.call(parent, key)) {
+            throw new GraphPatchApplyError(`key '${key}' does not exist`, path);
+        }
+        delete parent[key];
+    }
+}
+/** Resolve the container referenced by the pointer segments. */
+function resolveContainer(document, segments, path) {
+    let current = document;
+    for (const segment of segments) {
+        if (Array.isArray(current)) {
+            const index = parseIndex(segment, path, current.length - 1);
+            current = current[index];
+        }
+        else if (typeof current === "object" && current !== null) {
+            if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+                throw new GraphPatchApplyError(`path '${path}' is invalid`, path);
+            }
+            current = current[segment];
+        }
+        else {
+            throw new GraphPatchApplyError(`path '${path}' cannot be resolved`, path);
+        }
+    }
+    if (!Array.isArray(current) && typeof current !== "object") {
+        throw new GraphPatchApplyError(`path '${path}' does not reference a container`, path);
+    }
+    return current;
+}
+/** Parse a JSON pointer into individual segments. */
+function parsePointer(pointer) {
+    if (!pointer.startsWith("/")) {
+        throw new GraphPatchApplyError("JSON pointer must start with '/'", pointer);
+    }
+    if (pointer === "/") {
+        return [];
+    }
+    return pointer
+        .slice(1)
+        .split("/")
+        .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+/** Parse and validate an array index. */
+function parseIndex(segment, path, max) {
+    if (!/^\d+$/.test(segment)) {
+        throw new GraphPatchApplyError(`segment '${segment}' is not a valid index`, path);
+    }
+    const index = Number(segment);
+    if (index < 0 || index > max) {
+        throw new GraphPatchApplyError(`index '${index}' is out of bounds`, path);
+    }
+    return index;
+}
+/** Deep clone a graph attribute record. */
+function cloneRecord(values) {
+    const result = {};
+    for (const [key, value] of Object.entries(values)) {
+        result[key] = value;
+    }
+    return result;
+}
+/** Clone arbitrary JSON-compatible values. */
+function cloneValue(value) {
+    return structuredClone(value);
+}

--- a/dist/graph/tx.js
+++ b/dist/graph/tx.js
@@ -28,6 +28,16 @@ export class UnknownTransactionError extends GraphTransactionError {
         this.name = "UnknownTransactionError";
     }
 }
+/** Error thrown when attempting to interact with an expired transaction. */
+export class GraphTransactionExpiredError extends GraphTransactionError {
+    code = "E-TX-EXPIRED";
+    details;
+    constructor(txId, expiredAt, now) {
+        super(`transaction '${txId}' expired at ${new Date(expiredAt).toISOString()}`);
+        this.name = "GraphTransactionExpiredError";
+        this.details = { txId, expiredAt, now };
+    }
+}
 /**
  * Manage transactional snapshots for normalised graphs. The manager enforces a
  * strict single-writer policy: concurrent transactions must observe the latest
@@ -43,7 +53,7 @@ export class GraphTransactionManager {
      * working copy which can be mutated freely before invoking {@link commit} or
      * {@link rollback}.
      */
-    begin(graph) {
+    begin(graph, options = {}) {
         if (!graph.graphId || graph.graphId.trim().length === 0) {
             throw new GraphTransactionError("graph id must be provided before opening a transaction");
         }
@@ -65,12 +75,21 @@ export class GraphTransactionManager {
         const txId = randomUUID();
         const startedAt = Date.now();
         const snapshot = this.cloneGraph(graph);
+        const workingCopy = this.cloneGraph(graph);
+        const owner = normaliseOwner(options.owner);
+        const note = normaliseNote(options.note);
+        const expiresAt = normaliseExpiry(startedAt, options.ttlMs);
         const record = {
             txId,
             graphId: graph.graphId,
             baseVersion: graph.graphVersion,
             snapshot,
+            workingCopy,
             startedAt,
+            owner,
+            note,
+            expiresAt,
+            lastTouchedAt: startedAt,
         };
         this.transactions.set(txId, record);
         return {
@@ -78,6 +97,9 @@ export class GraphTransactionManager {
             graphId: graph.graphId,
             baseVersion: graph.graphVersion,
             startedAt,
+            owner,
+            note,
+            expiresAt,
             workingCopy: this.cloneGraph(graph),
         };
     }
@@ -88,10 +110,8 @@ export class GraphTransactionManager {
      * latest committed snapshot.
      */
     commit(txId, updatedGraph) {
-        const record = this.transactions.get(txId);
-        if (!record) {
-            throw new UnknownTransactionError(txId);
-        }
+        const now = Date.now();
+        const record = this.getActiveTransaction(txId, now);
         if (updatedGraph.graphId !== record.graphId) {
             throw new GraphTransactionError(`graph id mismatch: expected '${record.graphId}' but received '${updatedGraph.graphId}'`);
         }
@@ -108,7 +128,7 @@ export class GraphTransactionManager {
             throw new GraphVersionConflictError(record.graphId, expectedVersion, providedVersion);
         }
         const mutated = !this.graphsEqual(record.snapshot, updatedGraph);
-        const committedAt = mutated ? Date.now() : state.committedAt;
+        const committedAt = mutated ? now : state.committedAt;
         const nextVersion = mutated ? expectedVersion + 1 : state.version;
         let finalGraph;
         if (mutated) {
@@ -143,12 +163,10 @@ export class GraphTransactionManager {
      * be re-used or inspected safely.
      */
     rollback(txId) {
-        const record = this.transactions.get(txId);
-        if (!record) {
-            throw new UnknownTransactionError(txId);
-        }
+        const now = Date.now();
+        const record = this.getActiveTransaction(txId, now);
         this.transactions.delete(txId);
-        const rolledBackAt = Date.now();
+        const rolledBackAt = now;
         return {
             txId,
             graphId: record.graphId,
@@ -160,6 +178,62 @@ export class GraphTransactionManager {
     /** Retrieve the number of active transactions, useful for diagnostics. */
     countActiveTransactions() {
         return this.transactions.size;
+    }
+    /** Returns a clone of the in-memory working copy for the transaction. */
+    getWorkingCopy(txId) {
+        const now = Date.now();
+        const record = this.getActiveTransaction(txId, now, true);
+        return this.cloneGraph(record.workingCopy);
+    }
+    /** Replaces the working copy for a transaction after applying mutations. */
+    setWorkingCopy(txId, graph) {
+        const now = Date.now();
+        const record = this.getActiveTransaction(txId, now, true);
+        record.workingCopy = this.cloneGraph(graph);
+        this.transactions.set(txId, record);
+    }
+    /** Returns metadata about an active transaction. */
+    describe(txId) {
+        const now = Date.now();
+        const record = this.getActiveTransaction(txId, now);
+        return {
+            txId: record.txId,
+            graphId: record.graphId,
+            baseVersion: record.baseVersion,
+            startedAt: record.startedAt,
+            owner: record.owner,
+            note: record.note,
+            expiresAt: record.expiresAt,
+            lastTouchedAt: record.lastTouchedAt,
+        };
+    }
+    /** Returns the latest committed snapshot stored for the graph. */
+    getCommittedState(graphId) {
+        const state = this.states.get(graphId);
+        if (!state) {
+            return null;
+        }
+        return {
+            graphId,
+            version: state.version,
+            committedAt: state.committedAt,
+            graph: this.cloneGraph(state.graph),
+        };
+    }
+    getActiveTransaction(txId, now = Date.now(), touch = false) {
+        const record = this.transactions.get(txId);
+        if (!record) {
+            throw new UnknownTransactionError(txId);
+        }
+        if (record.expiresAt !== null && record.expiresAt <= now) {
+            this.transactions.delete(txId);
+            throw new GraphTransactionExpiredError(txId, record.expiresAt, now);
+        }
+        if (touch) {
+            record.lastTouchedAt = now;
+            this.transactions.set(txId, record);
+        }
+        return record;
     }
     /** Shallow helper to deep-clone a normalised graph without sharing references. */
     cloneGraph(graph) {
@@ -173,4 +247,27 @@ export class GraphTransactionManager {
     graphsEqual(first, second) {
         return JSON.stringify(first) === JSON.stringify(second);
     }
+}
+function normaliseOwner(owner) {
+    if (!owner) {
+        return null;
+    }
+    const trimmed = owner.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+function normaliseNote(note) {
+    if (!note) {
+        return null;
+    }
+    const trimmed = note.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+function normaliseExpiry(startedAt, ttlMs) {
+    if (ttlMs === null || ttlMs === undefined) {
+        return null;
+    }
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+        return null;
+    }
+    return startedAt + Math.floor(ttlMs);
 }

--- a/dist/infra/idempotency.js
+++ b/dist/infra/idempotency.js
@@ -1,0 +1,151 @@
+/** Clamp used to avoid storing negative TTLs when callers provide invalid data. */
+const MIN_TTL_MS = 1;
+/** Default TTL (~10 minutes) offering a generous window for retries. */
+const DEFAULT_TTL_MS = 600_000;
+/**
+ * In-memory registry storing idempotent outcomes. The implementation favours a
+ * predictable behaviour over absolute performance as the orchestrator only
+ * keeps a few dozen entries at a time (tools and server enforce timeouts).
+ */
+export class IdempotencyRegistry {
+    entries = new Map();
+    pending = new Map();
+    clock;
+    defaultTtlMs;
+    constructor(options = {}) {
+        this.clock = options.clock ?? (() => Date.now());
+        const ttl = options.defaultTtlMs ?? DEFAULT_TTL_MS;
+        this.defaultTtlMs = ttl > 0 ? ttl : DEFAULT_TTL_MS;
+    }
+    /** Number of live entries currently tracked. */
+    size() {
+        return this.entries.size;
+    }
+    /** Remove every entry from the registry. Mainly used by tests. */
+    clear() {
+        this.entries.clear();
+        this.pending.clear();
+    }
+    /** Retrieve an entry without updating the hit counter (used for diagnostics). */
+    peek(key) {
+        const entry = this.entries.get(key);
+        if (!entry) {
+            return null;
+        }
+        if (this.isExpired(entry, this.clock())) {
+            this.entries.delete(key);
+            return null;
+        }
+        return { ...entry, value: this.clone(entry.value) };
+    }
+    /**
+     * Remember the outcome of an asynchronous operation. The factory is invoked
+     * at most once per key; concurrent callers await the same promise and replay
+     * the stored value once resolved.
+     */
+    async remember(key, factory, options = {}) {
+        const now = this.clock();
+        const existing = this.entries.get(key);
+        if (existing && !this.isExpired(existing, now)) {
+            existing.hits += 1;
+            existing.lastHitAt = now;
+            return {
+                value: this.clone(existing.value),
+                idempotent: true,
+                entry: { ...existing, value: this.clone(existing.value) },
+            };
+        }
+        let pending = this.pending.get(key);
+        if (!pending) {
+            pending = this.executeFactory(key, factory, options.ttlMs);
+            this.pending.set(key, pending);
+        }
+        try {
+            const stored = await pending;
+            const value = this.clone(stored.value);
+            return {
+                value,
+                idempotent: existing !== undefined && !this.isExpired(existing, now),
+                entry: { ...stored, value: this.clone(stored.value) },
+            };
+        }
+        finally {
+            this.pending.delete(key);
+        }
+    }
+    /**
+     * Synchronous variant used by helpers that must remain synchronous (e.g.
+     * `tx_begin`). The factory is executed immediately when the key is unknown.
+     */
+    rememberSync(key, factory, options = {}) {
+        const now = this.clock();
+        const existing = this.entries.get(key);
+        if (existing && !this.isExpired(existing, now)) {
+            existing.hits += 1;
+            existing.lastHitAt = now;
+            return {
+                value: this.clone(existing.value),
+                idempotent: true,
+                entry: { ...existing, value: this.clone(existing.value) },
+            };
+        }
+        const produced = factory();
+        const stored = this.storeInternal(key, produced, options.ttlMs);
+        return {
+            value: this.clone(stored.value),
+            idempotent: false,
+            entry: { ...stored, value: this.clone(stored.value) },
+        };
+    }
+    /** Manually remove expired entries. Called periodically by the server. */
+    pruneExpired(now = this.clock()) {
+        for (const [key, entry] of this.entries) {
+            if (this.isExpired(entry, now)) {
+                this.entries.delete(key);
+            }
+        }
+    }
+    /** Persist a value without running a factory (used for fixtures/tests). */
+    store(key, value, options = {}) {
+        const stored = this.storeInternal(key, value, options.ttlMs);
+        return { ...stored, value: this.clone(stored.value) };
+    }
+    async executeFactory(key, factory, ttlOverride) {
+        const value = await factory();
+        return this.storeInternal(key, value, ttlOverride);
+    }
+    storeInternal(key, value, ttlOverride) {
+        const now = this.clock();
+        const ttlMs = this.normaliseTtl(ttlOverride);
+        const entry = {
+            key,
+            value: this.clone(value),
+            storedAt: now,
+            expiresAt: now + ttlMs,
+            hits: 1,
+            lastHitAt: now,
+        };
+        this.entries.set(key, entry);
+        return entry;
+    }
+    normaliseTtl(ttlMs) {
+        if (ttlMs === undefined || ttlMs === null || Number.isNaN(ttlMs)) {
+            return this.defaultTtlMs;
+        }
+        if (!Number.isFinite(ttlMs)) {
+            return this.defaultTtlMs;
+        }
+        return Math.max(MIN_TTL_MS, ttlMs);
+    }
+    isExpired(entry, now) {
+        return now >= entry.expiresAt;
+    }
+    clone(value) {
+        try {
+            return structuredClone(value);
+        }
+        catch {
+            return value;
+        }
+    }
+}

--- a/dist/monitor/dashboard.js
+++ b/dist/monitor/dashboard.js
@@ -290,6 +290,9 @@ function buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supe
             lastHeartbeatAt: child.lastHeartbeatAt,
             lastActivityAt,
             waitingFor: child.waitingFor,
+            role: child.role,
+            attachedAt: child.attachedAt,
+            limits: child.limits,
         };
     });
     return {

--- a/dist/tools/graphBatchTools.js
+++ b/dist/tools/graphBatchTools.js
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import { GraphTransactionError, GraphVersionConflictError, } from "../graph/tx.js";
+import { GraphMutateInputSchema, handleGraphMutate, normaliseGraphPayload, serialiseNormalisedGraph, } from "./graphTools.js";
+const GraphBatchOperationSchema = GraphMutateInputSchema.shape.operations.element;
+/** Schema accepted by the `graph_batch_mutate` tool. */
+export const GraphBatchMutateInputSchema = z
+    .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    operations: z
+        .array(GraphBatchOperationSchema)
+        .min(1, "at least one operation must be provided")
+        .max(200, "cannot apply more than 200 operations at once"),
+    expected_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    idempotency_key: z.string().min(1).optional(),
+})
+    .strict();
+export const GraphBatchMutateInputShape = GraphBatchMutateInputSchema.shape;
+/**
+ * Applies a batch of idempotent graph operations on the latest committed
+ * descriptor. The helper opens an ephemeral transaction, ensuring callers
+ * observe the mutation atomically while replaying cached results when an
+ * idempotency key is provided.
+ */
+export async function handleGraphBatchMutate(context, input) {
+    const execute = async () => {
+        const committed = context.transactions.getCommittedState(input.graph_id);
+        if (!committed) {
+            throw new GraphTransactionError(`graph '${input.graph_id}' has no committed state`);
+        }
+        if (input.expected_version !== undefined && committed.version !== input.expected_version) {
+            throw new GraphVersionConflictError(input.graph_id, committed.version, input.expected_version);
+        }
+        context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+        const tx = context.transactions.begin(committed.graph, {
+            owner: input.owner ?? null,
+            note: input.note ?? null,
+        });
+        context.resources.recordGraphSnapshot({
+            graphId: tx.graphId,
+            txId: tx.txId,
+            baseVersion: tx.baseVersion,
+            startedAt: tx.startedAt,
+            graph: tx.workingCopy,
+            owner: tx.owner,
+            note: tx.note,
+            expiresAt: tx.expiresAt,
+        });
+        let committedResult = null;
+        try {
+            const mutateInput = {
+                graph: serialiseNormalisedGraph(tx.workingCopy),
+                operations: input.operations,
+            };
+            const mutation = handleGraphMutate(mutateInput);
+            const normalised = normaliseGraphPayload(mutation.graph);
+            context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+            committedResult = context.transactions.commit(tx.txId, normalised);
+            context.resources.markGraphSnapshotCommitted({
+                graphId: committedResult.graphId,
+                txId: committedResult.txId,
+                committedAt: committedResult.committedAt,
+                finalVersion: committedResult.version,
+                finalGraph: committedResult.graph,
+            });
+            context.resources.recordGraphVersion({
+                graphId: committedResult.graphId,
+                version: committedResult.version,
+                committedAt: committedResult.committedAt,
+                graph: committedResult.graph,
+            });
+            const changed = mutation.applied.some((entry) => entry.changed);
+            return {
+                graph_id: committedResult.graphId,
+                base_version: tx.baseVersion,
+                committed_version: committedResult.version,
+                committed_at: committedResult.committedAt,
+                changed,
+                operations_applied: mutation.applied.length,
+                applied: mutation.applied,
+                graph: serialiseNormalisedGraph(committedResult.graph),
+                owner: tx.owner,
+                note: tx.note,
+            };
+        }
+        catch (error) {
+            try {
+                context.transactions.rollback(tx.txId);
+                context.resources.markGraphSnapshotRolledBack(tx.graphId, tx.txId);
+            }
+            catch {
+                // Ignored: the initial error is more relevant for callers.
+            }
+            throw error;
+        }
+    };
+    const key = input.idempotency_key ?? null;
+    if (context.idempotency && key) {
+        const hit = await context.idempotency.remember(`graph_batch_mutate:${key}`, execute);
+        const snapshot = hit.value;
+        return { ...snapshot, idempotent: hit.idempotent, idempotency_key: key };
+    }
+    const snapshot = await execute();
+    return { ...snapshot, idempotent: false, idempotency_key: key };
+}

--- a/dist/tools/graphDiffTools.js
+++ b/dist/tools/graphDiffTools.js
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import { diffGraphs } from "../graph/diff.js";
+import { applyGraphPatch } from "../graph/patch.js";
+import { evaluateGraphInvariants, GraphInvariantError } from "../graph/invariants.js";
+import { GraphTransactionError, GraphVersionConflictError, } from "../graph/tx.js";
+import { GraphDescriptorSchema, normaliseGraphPayload, serialiseNormalisedGraph, } from "./graphTools.js";
+/** Schema describing a graph selector used by the diff tool. */
+const GraphSelectorSchema = z.union([
+    z.object({ latest: z.literal(true) }).strict(),
+    z.object({ version: z.number().int().nonnegative() }).strict(),
+    z.object({ graph: GraphDescriptorSchema }).strict(),
+]);
+/** Schema describing a RFC 6902 operation accepted by graph_patch. */
+export const GraphPatchOperationSchema = z
+    .object({
+    op: z.enum(["add", "remove", "replace"]),
+    path: z.string().min(1, "path must not be empty"),
+    value: z.unknown().optional(),
+})
+    .strict();
+/** Schema accepted by the graph_diff tool. */
+export const GraphDiffInputSchema = z
+    .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    from: GraphSelectorSchema,
+    to: GraphSelectorSchema,
+})
+    .strict();
+/** Schema accepted by the graph_patch tool. */
+export const GraphPatchInputSchema = z
+    .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    base_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    enforce_invariants: z.boolean().default(true),
+    patch: z.array(GraphPatchOperationSchema).min(1, "at least one patch operation is required"),
+})
+    .strict();
+export const GraphDiffInputShape = GraphDiffInputSchema.shape;
+export const GraphPatchInputShape = GraphPatchInputSchema.shape;
+/** Compute a diff between two graph selectors. */
+export function handleGraphDiff(context, input) {
+    const resolvedFrom = resolveGraphSelector(context, input.graph_id, input.from);
+    const resolvedTo = resolveGraphSelector(context, input.graph_id, input.to);
+    const diff = diffGraphs(resolvedFrom.graph, resolvedTo.graph);
+    return {
+        graph_id: input.graph_id,
+        from: resolvedFrom.summary,
+        to: resolvedTo.summary,
+        changed: diff.changed,
+        operations: diff.operations,
+        summary: diff.summary,
+    };
+}
+/** Apply a JSON Patch on top of the latest committed graph. */
+export function handleGraphPatch(context, input) {
+    const committed = ensureCommittedState(context, input.graph_id);
+    if (input.base_version !== undefined && input.base_version !== committed.version) {
+        throw new GraphVersionConflictError(input.graph_id, committed.version, input.base_version);
+    }
+    context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+    const tx = context.transactions.begin(committed.graph, {
+        owner: input.owner ?? null,
+        note: input.note ?? null,
+    });
+    context.resources.recordGraphSnapshot({
+        graphId: tx.graphId,
+        txId: tx.txId,
+        baseVersion: tx.baseVersion,
+        startedAt: tx.startedAt,
+        graph: tx.workingCopy,
+        owner: tx.owner,
+        note: tx.note,
+        expiresAt: tx.expiresAt,
+    });
+    let invariants = null;
+    let committedResult = null;
+    try {
+        const patched = applyGraphPatch(committed.graph, input.patch);
+        const normalised = normaliseGraphPayload(serialiseNormalisedGraph(patched));
+        if (input.enforce_invariants) {
+            invariants = evaluateGraphInvariants(normalised);
+            if (!invariants.ok) {
+                throw new GraphInvariantError(invariants.violations);
+            }
+        }
+        const diff = diffGraphs(committed.graph, normalised);
+        const changed = diff.changed;
+        context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+        context.transactions.setWorkingCopy(tx.txId, normalised);
+        committedResult = context.transactions.commit(tx.txId, normalised);
+        context.resources.markGraphSnapshotCommitted({
+            graphId: committedResult.graphId,
+            txId: committedResult.txId,
+            committedAt: committedResult.committedAt,
+            finalVersion: committedResult.version,
+            finalGraph: committedResult.graph,
+        });
+        context.resources.recordGraphVersion({
+            graphId: committedResult.graphId,
+            version: committedResult.version,
+            committedAt: committedResult.committedAt,
+            graph: committedResult.graph,
+        });
+        return {
+            graph_id: committedResult.graphId,
+            base_version: tx.baseVersion,
+            committed_version: committedResult.version,
+            changed,
+            operations_applied: input.patch.length,
+            invariants,
+            graph: serialiseNormalisedGraph(committedResult.graph),
+        };
+    }
+    catch (error) {
+        try {
+            context.transactions.rollback(tx.txId);
+        }
+        catch (rollbackError) {
+            // Ignored: the transaction has already failed, the caller is primarily interested in the original error.
+            void rollbackError;
+        }
+        context.resources.markGraphSnapshotRolledBack(tx.graphId, tx.txId);
+        throw error;
+    }
+}
+/** Resolve a selector into a normalised graph and a descriptive summary. */
+function resolveGraphSelector(context, graphId, selector) {
+    if ("graph" in selector) {
+        const normalised = normaliseGraphPayload(selector.graph);
+        return {
+            graph: normalised,
+            summary: { source: "descriptor", version: normalised.graphVersion ?? null },
+        };
+    }
+    if ("version" in selector) {
+        const resource = context.resources.read(`sc://graphs/${graphId}@v${selector.version}`);
+        const payload = resource.payload;
+        return {
+            graph: structuredClone(payload.graph),
+            summary: { source: "version", version: payload.version },
+        };
+    }
+    const resource = context.resources.read(`sc://graphs/${graphId}`);
+    const payload = resource.payload;
+    return {
+        graph: structuredClone(payload.graph),
+        summary: { source: "latest", version: payload.version },
+    };
+}
+/** Ensure the transaction manager knows about the latest committed graph state. */
+function ensureCommittedState(context, graphId) {
+    const committed = context.transactions.getCommittedState(graphId);
+    if (committed) {
+        return { graph: committed.graph, version: committed.version };
+    }
+    const resource = context.resources.read(`sc://graphs/${graphId}`);
+    const payload = resource.payload;
+    bootstrapCommittedState(context.transactions, payload.graph);
+    const refreshed = context.transactions.getCommittedState(graphId);
+    if (!refreshed) {
+        throw new GraphTransactionError(`unable to register committed state for graph '${graphId}'`);
+    }
+    return { graph: refreshed.graph, version: refreshed.version };
+}
+/** Register a committed graph in the transaction manager without mutating it. */
+function bootstrapCommittedState(transactions, graph) {
+    let tx = null;
+    try {
+        tx = transactions.begin(graph);
+    }
+    finally {
+        if (tx) {
+            try {
+                transactions.rollback(tx.txId);
+            }
+            catch (error) {
+                void error;
+            }
+        }
+    }
+}

--- a/dist/tools/graphLockTools.js
+++ b/dist/tools/graphLockTools.js
@@ -1,0 +1,47 @@
+import { z } from "zod";
+/** Schema accepted by the graph_lock tool. */
+export const GraphLockInputSchema = z
+    .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    holder: z.string().trim().min(1, "holder is required").max(120, "holder is too long"),
+    ttl_ms: z.number().int().positive().max(86_400_000).optional(),
+})
+    .strict();
+/** Schema accepted by the graph_unlock tool. */
+export const GraphUnlockInputSchema = z
+    .object({
+    lock_id: z.string().uuid(),
+})
+    .strict();
+export const GraphLockInputShape = GraphLockInputSchema.shape;
+export const GraphUnlockInputShape = GraphUnlockInputSchema.shape;
+/** Acquire or refresh the lock guarding a graph. */
+export function handleGraphLock(context, input) {
+    const snapshot = context.locks.acquire(input.graph_id, input.holder, { ttlMs: input.ttl_ms ?? null });
+    return formatLockSnapshot(snapshot);
+}
+/** Release the lock guarding a graph. */
+export function handleGraphUnlock(context, input) {
+    const result = context.locks.release(input.lock_id);
+    return formatLockRelease(result);
+}
+function formatLockSnapshot(snapshot) {
+    return {
+        lock_id: snapshot.lockId,
+        graph_id: snapshot.graphId,
+        holder: snapshot.holder,
+        acquired_at: snapshot.acquiredAt,
+        refreshed_at: snapshot.refreshedAt,
+        expires_at: snapshot.expiresAt,
+    };
+}
+function formatLockRelease(result) {
+    return {
+        lock_id: result.lockId,
+        graph_id: result.graphId,
+        holder: result.holder,
+        released_at: result.releasedAt,
+        expired: result.expired,
+        expires_at: result.expiresAt,
+    };
+}

--- a/dist/tools/txTools.js
+++ b/dist/tools/txTools.js
@@ -1,0 +1,183 @@
+import { z } from "zod";
+import { GraphTransactionError, GraphVersionConflictError, } from "../graph/tx.js";
+import { normaliseGraphPayload, serialiseNormalisedGraph, GraphDescriptorSchema, GraphMutateInputSchema, handleGraphMutate } from "./graphTools.js";
+/** Schema accepted by the `tx_begin` tool. */
+export const TxBeginInputSchema = z
+    .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    expected_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    ttl_ms: z.number().int().positive().max(86_400_000).optional(),
+    graph: GraphDescriptorSchema.optional(),
+    idempotency_key: z.string().min(1).optional(),
+})
+    .strict();
+/** Schema accepted by the `tx_apply` tool. */
+export const TxApplyInputSchema = z
+    .object({
+    tx_id: z.string().uuid(),
+    operations: z
+        .array(GraphMutateInputSchema.shape.operations.element)
+        .min(1, "at least one operation must be provided"),
+})
+    .strict();
+/** Schema accepted by the `tx_commit` tool. */
+export const TxCommitInputSchema = z
+    .object({
+    tx_id: z.string().uuid(),
+})
+    .strict();
+/** Schema accepted by the `tx_rollback` tool. */
+export const TxRollbackInputSchema = z
+    .object({
+    tx_id: z.string().uuid(),
+})
+    .strict();
+export const TxBeginInputShape = TxBeginInputSchema.shape;
+export const TxApplyInputShape = TxApplyInputSchema.shape;
+export const TxCommitInputShape = TxCommitInputSchema.shape;
+export const TxRollbackInputShape = TxRollbackInputSchema.shape;
+/** Opens a new transaction, returning a working copy that can be mutated server-side. */
+export function handleTxBegin(context, input) {
+    const execute = () => {
+        const baseGraph = resolveBaseGraph(context, input);
+        if (input.expected_version !== undefined && baseGraph.graphVersion !== input.expected_version) {
+            throw new GraphVersionConflictError(input.graph_id, baseGraph.graphVersion, input.expected_version);
+        }
+        context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+        const opened = context.transactions.begin(baseGraph, {
+            owner: input.owner ?? null,
+            note: input.note ?? null,
+            ttlMs: input.ttl_ms ?? null,
+        });
+        context.resources.recordGraphSnapshot({
+            graphId: opened.graphId,
+            txId: opened.txId,
+            baseVersion: opened.baseVersion,
+            startedAt: opened.startedAt,
+            graph: opened.workingCopy,
+            owner: opened.owner,
+            note: opened.note,
+            expiresAt: opened.expiresAt,
+        });
+        return formatBeginResult(opened);
+    };
+    const key = input.idempotency_key ?? null;
+    if (context.idempotency && key) {
+        const hit = context.idempotency.rememberSync(`tx_begin:${key}`, execute);
+        const snapshot = hit.value;
+        return { ...snapshot, idempotent: hit.idempotent, idempotency_key: key };
+    }
+    const snapshot = execute();
+    return { ...snapshot, idempotent: false, idempotency_key: key };
+}
+/** Applies graph operations to the transaction working copy. */
+export function handleTxApply(context, input) {
+    // Retrieve a defensive copy so mutations occur on a fresh descriptor.
+    const workingCopy = context.transactions.getWorkingCopy(input.tx_id);
+    const metadata = context.transactions.describe(input.tx_id);
+    context.locks.assertCanMutate(metadata.graphId, metadata.owner);
+    const mutateInput = {
+        graph: serialiseNormalisedGraph(workingCopy),
+        operations: input.operations,
+    };
+    const result = handleGraphMutate(mutateInput);
+    context.transactions.setWorkingCopy(input.tx_id, normaliseGraphPayload(result.graph));
+    const changed = result.applied.some((entry) => entry.changed);
+    const previewVersion = changed ? metadata.baseVersion + 1 : metadata.baseVersion;
+    return {
+        tx_id: input.tx_id,
+        graph_id: metadata.graphId,
+        base_version: metadata.baseVersion,
+        preview_version: previewVersion,
+        owner: metadata.owner,
+        note: metadata.note,
+        expires_at: metadata.expiresAt,
+        changed,
+        applied: result.applied,
+        graph: result.graph,
+    };
+}
+/** Commits the transaction, returning the updated graph descriptor. */
+export function handleTxCommit(context, input) {
+    const metadata = context.transactions.describe(input.tx_id);
+    context.locks.assertCanMutate(metadata.graphId, metadata.owner);
+    const workingCopy = context.transactions.getWorkingCopy(input.tx_id);
+    const committed = context.transactions.commit(input.tx_id, workingCopy);
+    context.resources.markGraphSnapshotCommitted({
+        graphId: committed.graphId,
+        txId: committed.txId,
+        committedAt: committed.committedAt,
+        finalVersion: committed.version,
+        finalGraph: committed.graph,
+    });
+    context.resources.recordGraphVersion({
+        graphId: committed.graphId,
+        version: committed.version,
+        committedAt: committed.committedAt,
+        graph: committed.graph,
+    });
+    return {
+        tx_id: committed.txId,
+        graph_id: committed.graphId,
+        version: committed.version,
+        committed_at: committed.committedAt,
+        graph: serialiseNormalisedGraph(committed.graph),
+    };
+}
+/** Rolls back the transaction, returning the original snapshot. */
+export function handleTxRollback(context, input) {
+    const rolled = context.transactions.rollback(input.tx_id);
+    context.resources.markGraphSnapshotRolledBack(rolled.graphId, rolled.txId);
+    return {
+        tx_id: rolled.txId,
+        graph_id: rolled.graphId,
+        version: rolled.version,
+        rolled_back_at: rolled.rolledBackAt,
+        snapshot: serialiseNormalisedGraph(rolled.snapshot),
+    };
+}
+function formatBeginResult(opened) {
+    return {
+        tx_id: opened.txId,
+        graph_id: opened.graphId,
+        base_version: opened.baseVersion,
+        started_at: opened.startedAt,
+        owner: opened.owner,
+        note: opened.note,
+        expires_at: opened.expiresAt,
+        graph: serialiseNormalisedGraph(opened.workingCopy),
+    };
+}
+/**
+ * Retrieves the base graph used to open a transaction, either from the request
+ * payload or from the committed state tracked by the manager/registry.
+ */
+function resolveBaseGraph(context, input) {
+    if (input.graph) {
+        const normalised = normaliseGraphPayload(input.graph);
+        if (normalised.graphId !== input.graph_id) {
+            throw new GraphTransactionError(`graph payload id '${normalised.graphId}' does not match requested graph_id '${input.graph_id}'`);
+        }
+        return normalised;
+    }
+    const state = context.transactions.getCommittedState(input.graph_id);
+    if (state) {
+        return state.graph;
+    }
+    try {
+        const resource = context.resources.read(`sc://graphs/${input.graph_id}`);
+        if (resource.kind !== "graph") {
+            throw new GraphTransactionError(`graph '${input.graph_id}' is not available for transactions`);
+        }
+        const payload = resource.payload;
+        return structuredClone(payload.graph);
+    }
+    catch (error) {
+        if (error instanceof GraphTransactionError) {
+            throw error;
+        }
+        throw new GraphTransactionError(error instanceof Error ? error.message : `graph '${input.graph_id}' is not available for transactions`);
+    }
+}

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -124,6 +124,37 @@ interface ResourceReadResult {
 `BlackboardEntrySnapshot` sont définis dans `src/graph/types.ts`,
 `src/resources/registry.ts` et `src/coord/blackboard.ts`.
 
+```ts
+interface ResourceRunEvent {
+  seq: number;
+  ts: number;
+  kind: string;
+  level: string;
+  jobId: string | null;
+  runId: string;        // toujours renseigné (identique au seau MCP)
+  opId: string | null;  // identifiant d'opération (plan, valeur, fanout...)
+  graphId: string | null;
+  nodeId: string | null;
+  childId: string | null;
+  payload: unknown;
+}
+
+interface ResourceChildLogEntry {
+  seq: number;
+  ts: number;
+  stream: "stdout" | "stderr" | "meta";
+  message: string;
+  jobId: string | null;
+  runId: string | null;
+  opId: string | null;
+  graphId: string | null;
+  nodeId: string | null;
+  childId: string;
+  raw: string | null;
+  parsed: unknown;
+}
+```
+
 ### Tool `resources_watch`
 
 ```ts
@@ -141,8 +172,52 @@ interface ResourceWatchResult {
 }
 ```
 
-Les événements sont ordonnés (seq croissant). Pour un flux complet, bouclez tant
-que `events.length > 0` en rappelant `resources_watch` avec `from_seq = next_seq`.
+Les événements sont ordonnés (seq croissant) et incluent les hints de
+corrélation (`jobId`, `runId`, `opId`, `graphId`, `nodeId`, `childId`). Pour un
+flux complet, bouclez tant que `events.length > 0` en rappelant
+`resources_watch` avec `from_seq = next_seq`.
+
+## Contrôles fins du runtime enfant
+
+Lorsque `enableChildOpsFine` est actif, quatre outils MCP complètent `child_create`
+pour gérer la vie d'un runtime existant. Ils partagent les mêmes hints de
+correlation (`run_id`, `op_id`, `job_id`, `graph_id`, `node_id`, `child_id`) que
+les autres outils plan/valeur et mettent à jour immédiatement le registre
+(`sc://children/<id>/logs`) ainsi que le bus d'événements.
+
+```ts
+const ChildSpawnCodexInput = z
+  .object({
+    child_id: z.string().min(1),
+    manifest_path: z.string().min(1).default("codex.json"),
+    role: z.string().min(1).optional(),
+    limits: ChildLimitsInput.optional(),
+    run_id: z.string().min(1).optional(),
+    op_id: z.string().min(1).optional(),
+    job_id: z.string().min(1).optional(),
+    graph_id: z.string().min(1).optional(),
+    node_id: z.string().min(1).optional(),
+    child_id_hint: z.string().min(1).optional(),
+  })
+  .strict();
+
+const ChildAttachInput = z
+  .object({ child_id: z.string().min(1), run_id: z.string().min(1).optional(), op_id: z.string().min(1).optional() })
+  .strict();
+
+const ChildSetRoleInput = z
+  .object({ child_id: z.string().min(1), role: z.string().min(1), run_id: z.string().min(1).optional(), op_id: z.string().min(1).optional() })
+  .strict();
+
+const ChildSetLimitsInput = z
+  .object({ child_id: z.string().min(1), limits: ChildLimitsInput, run_id: z.string().min(1).optional(), op_id: z.string().min(1).optional() })
+  .strict();
+```
+
+`ChildLimitsInput` reprend la structure utilisée par `child_create`
+(`messages`, `wallclock_ms`, `cpu_percent`, etc.). Chaque réponse renvoie un
+manifeste synchronisé avec `role`, `limits`, `attached_at` et les corrélations
+actuelles afin que les clients puissent enchaîner des opérations idempotentes.
 
 ## Activation des modules MCP
 
@@ -156,9 +231,9 @@ Les flags suivants contrôlent l'exposition des outils facultatifs :
 | `--enable-cancellation` | `enableCancellation` | Active l'API d'annulation uniforme (en cours d'implémentation). |
 | `--enable-tx` | `enableTx` | Expose la gestion de transactions graphe (à venir). |
 | `--enable-bulk` | `enableBulk` | Active les opérations atomiques en lot (à venir). |
-| `--enable-idempotency` | `enableIdempotency` | Permet la ré-exécution avec `idempotencyKey` (à venir). |
-| `--enable-locks` | `enableLocks` | Active les verrous de graphe (à venir). |
-| `--enable-diff-patch` | `enableDiffPatch` | Expose `graph_diff`/`graph_patch` (à venir). |
+| `--enable-idempotency` | `enableIdempotency` | Active le cache idempotent (`child_create`, `child_spawn_codex`, `plan_run_bt`, `plan_run_reactive`, `cnp_announce`, `tx_begin`). |
+| `--enable-locks` | `enableLocks` | Active `graph_lock`/`graph_unlock` pour protéger les mutations. |
+| `--enable-diff-patch` | `enableDiffPatch` | Expose `graph_diff`/`graph_patch` (diff JSON + application). |
 | `--enable-plan-lifecycle` | `enablePlanLifecycle` | Contrôle plan_pause/plan_resume (à venir). |
 | `--enable-child-ops-fine` | `enableChildOpsFine` | Active les outils de réglage fin des enfants (à venir). |
 | `--enable-values-explain` | `enableValuesExplain` | Publie `values_explain` (à venir). |
@@ -167,6 +242,175 @@ Les flags suivants contrôlent l'exposition des outils facultatifs :
 Les modules marqués « à venir » seront ajoutés progressivement : cette référence
 sera enrichie au fur et à mesure (bus d'événements, cancellations uniformes,
 transactions, diff/patch, etc.).
+
+### Idempotence des outils
+
+Lorsque `enableIdempotency` est actif, plusieurs outils acceptent un champ
+optionnel `idempotency_key` afin de rejouer exactement la même réponse si la
+requête est répétée :
+
+* `child_create`
+* `child_spawn_codex`
+* `plan_run_bt`
+* `plan_run_reactive`
+* `cnp_announce`
+* `tx_begin`
+
+Chaque réponse inclut `idempotent` (booléen) et `idempotency_key` pour signaler
+si le résultat provient du cache. Les journaux serveur émettent également un
+évènement `*_replayed` lorsqu'une réponse est renvoyée sans ré-exécuter la
+mutation.
+
+### Blackboard & opérations bulk
+
+```ts
+const BbBatchSetInput = z
+  .object({
+    entries: z
+      .array(
+        z
+          .object({
+            key: z.string().min(1),
+            value: z.unknown(),
+            tags: z.array(z.string().min(1)).max(16).default([]),
+            ttl_ms: z.number().int().min(1).max(86_400_000).optional(),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(100),
+  })
+  .strict();
+
+interface BbBatchSetResult {
+  entries: SerializedBlackboardEntry[];
+}
+```
+
+* `bb_set` et `bb_batch_set` appliquent les mutations de manière atomique.
+  `bb_batch_set` rejette la totalité du lot si l'un des éléments ne peut pas être
+  cloné (valeur non sérialisable, par exemple une fonction).
+* `bb_get`, `bb_query` et `bb_watch` s'appuient sur le même registre et exposent
+  les versions séquentielles (`version`, `created_at`, `updated_at`, `expires_at`).
+
+```ts
+const StigBatchInput = z
+  .object({
+    entries: z
+      .array(
+        z
+          .object({
+            node_id: z.string().min(1),
+            type: z.string().min(1),
+            intensity: z.number().positive().max(10_000),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(200),
+  })
+  .strict();
+
+interface StigBatchResult {
+  changes: Array<{
+    point: { node_id: string; type: string; intensity: number; updated_at: number };
+    node_total: { node_id: string; intensity: number; updated_at: number };
+  }>;
+}
+```
+
+* `stig_batch` applique plusieurs dépôts de phéromones d'un seul tenant. Une
+  erreur (type vide, intensité non positive, etc.) restaure le champ et annule
+  l'ensemble du lot. Les événements ne sont émis qu'après validation complète.
+* `stig_mark`, `stig_decay` et `stig_snapshot` partagent les mêmes structures
+  sérialisées (`point`, `node_total`).
+
+```ts
+const GraphBatchMutateInput = z
+  .object({
+    graph_id: z.string().min(1),
+    operations: GraphMutateInputSchema.shape.operations,
+    expected_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    idempotency_key: z.string().min(1).optional(),
+  })
+  .strict();
+
+interface GraphBatchMutateResult {
+  graph_id: string;
+  base_version: number;
+  committed_version: number;
+  committed_at: number;
+  changed: boolean;
+  operations_applied: number;
+  applied: GraphMutationRecord[];
+  graph: NormalisedGraph;
+  owner: string | null;
+  note: string | null;
+  idempotent: boolean;
+  idempotency_key: string | null;
+}
+```
+
+* `graph_batch_mutate` rejoue les mêmes opérations que `graph_mutate` mais dans
+  une transaction éphémère : soit toutes les mutations sont commit, soit le
+  graphe est restauré. Le champ `expected_version` protège contre les conflits,
+  tandis que `owner`/`note` assurent la traçabilité dans le registre
+  `sc://snapshots/...`. En cas de clé d'idempotence, la réponse est rejouée sans
+  réappliquer les opérations.
+* Le champ `changed` indique si la version a effectivement progressé. Lorsque
+  toutes les opérations sont des no-op (`changed = false`), la version reste
+  inchangée et `committed_at` conserve le timestamp précédent.
+
+```ts
+const ChildBatchCreateInput = z
+  .object({
+    entries: z.array(ChildSpawnCodexInputSchema).min(1).max(16),
+  })
+  .strict();
+
+interface ChildBatchCreateResult {
+  children: ChildSpawnCodexResult[];
+  created: number; // enfants réellement démarrés (hors replays idempotents)
+  idempotent_entries: number;
+}
+```
+
+* `child_batch_create` enchaîne plusieurs `child_spawn_codex` avec rollback : en
+  cas d'échec, chaque runtime précédemment démarré est stoppé puis collecté.
+  `created` compte uniquement les nouveaux enfants démarrés, tandis que
+  `idempotent_entries` recense ceux qui proviennent du cache. Les entrées
+  réutilisent exactement le schéma de `child_spawn_codex` (clés d'idempotence
+  incluses).
+
+### `graph_diff` & `graph_patch`
+
+* `graph_diff({ graph_id, from, to })` accepte trois types de sélecteurs :
+  * `{ latest: true }` — version actuellement commitée.
+  * `{ version: <int> }` — version historique enregistrée dans le registre.
+  * `{ graph: <descriptor> }` — descripteur inline (même schéma que `graph_mutate`).
+  La réponse expose un patch RFC 6902 ainsi qu'un résumé `name|metadata|nodes|edges`.
+* `graph_patch({ graph_id, patch, base_version?, enforce_invariants?, owner? })`
+  applique le patch produit par `graph_diff`, vérifie les invariants (DAG,
+  labels, ports, cardinalités) et commit automatiquement via le
+  `GraphTransactionManager`. `base_version` protège contre les conflits
+  optimistes et `enforce_invariants` reste activé par défaut. Lorsque
+  `graph_lock` est actif, fournissez le même `owner` que celui ayant acquis le
+  verrou, sinon l'opération sera rejetée (`E-GRAPH-MUTATION-LOCKED`).
+
+Les deux outils publient leurs snapshots dans le registre `sc://graphs/<id>@vX`
+et mettent à jour les métadonnées de transaction (`snapshots/`).
+
+### `graph_lock` & `graph_unlock`
+
+* `graph_lock({ graph_id, holder, ttl_ms? })` acquiert un verrou coopératif sur
+  un graphe et retourne `{ lock_id, acquired_at, refreshed_at, expires_at }`.
+  Appeler à nouveau avec le même `holder` rafraîchit le TTL et réutilise le même
+  `lock_id`. Un verrou actif empêche tout autre `holder` de lancer `graph_patch`
+  ou une transaction (`tx_*`).
+* `graph_unlock({ lock_id })` libère le verrou. Si le TTL est déjà expiré, la
+  réponse signale `expired: true` mais nettoie l'entrée côté serveur.
 
 ## Exemples JSON-RPC
 

--- a/src/coord/blackboard.ts
+++ b/src/coord/blackboard.ts
@@ -16,6 +16,18 @@ export interface BlackboardSetOptions {
   ttlMs?: number;
 }
 
+/**
+ * Payload accepted by {@link BlackboardStore.batchSet}. Each entry mirrors the
+ * arguments of {@link BlackboardStore.set} but allows the caller to describe
+ * multiple mutations that should be applied atomically.
+ */
+export interface BlackboardBatchSetInput {
+  key: string;
+  value: unknown;
+  tags?: string[];
+  ttlMs?: number;
+}
+
 /** Filtering options consumed by {@link BlackboardStore.query}. */
 export interface BlackboardQueryOptions {
   /** Restrict the result set to the provided keys. */
@@ -116,6 +128,80 @@ export class BlackboardStore {
       previous,
     });
     return snapshot;
+  }
+
+  /**
+   * Applies multiple mutations atomically. Either every entry is committed and
+   * a matching history event is emitted, or the store is reverted to its prior
+   * state. The helper is primarily used by the MCP bulk tool so clients can
+   * refresh several keys in a single round-trip without risking partial
+   * updates.
+   */
+  batchSet(entries: ReadonlyArray<BlackboardBatchSetInput>): BlackboardEntrySnapshot[] {
+    this.evictExpired();
+    if (entries.length === 0) {
+      return [];
+    }
+
+    const originalEntries = new Map<string, BlackboardEntryInternal>();
+    for (const [key, entry] of this.entries.entries()) {
+      originalEntries.set(key, this.cloneInternal(entry));
+    }
+    const startingVersion = this.version;
+    const committedSnapshots: BlackboardEntrySnapshot[] = [];
+    const eventsToEmit: BlackboardEvent[] = [];
+    let nextVersion = startingVersion;
+
+    try {
+      for (const payload of entries) {
+        const timestamp = this.now();
+        const tags = normaliseTags(payload.tags ?? []);
+        const ttl = payload.ttlMs !== undefined ? Math.max(1, Math.floor(payload.ttlMs)) : null;
+        const expiresAt = ttl !== null ? timestamp + ttl : null;
+        const previousInternal = this.entries.get(payload.key);
+        const previousSnapshot = previousInternal ? this.cloneEntry(previousInternal) : undefined;
+
+        const createdAt = previousInternal?.createdAt ?? timestamp;
+        const entry: BlackboardEntryInternal = {
+          key: payload.key,
+          value: structuredClone(payload.value),
+          tags,
+          createdAt,
+          updatedAt: timestamp,
+          expiresAt,
+          version: 0,
+        };
+
+        nextVersion += 1;
+        entry.version = nextVersion;
+        this.entries.set(payload.key, this.cloneInternal(entry));
+
+        const snapshot = this.cloneEntry(entry);
+        committedSnapshots.push(snapshot);
+        eventsToEmit.push({
+          version: nextVersion,
+          kind: "set",
+          key: payload.key,
+          timestamp,
+          entry: snapshot,
+          previous: previousSnapshot,
+        });
+      }
+    } catch (error) {
+      this.entries.clear();
+      for (const [key, entry] of originalEntries.entries()) {
+        this.entries.set(key, entry);
+      }
+      this.version = startingVersion;
+      throw error;
+    }
+
+    this.version = nextVersion;
+    for (const event of eventsToEmit) {
+      this.recordEvent(event);
+    }
+
+    return committedSnapshots;
   }
 
   /** Retrieves an entry if it exists and has not expired yet. */
@@ -249,6 +335,18 @@ export class BlackboardStore {
       this.events.splice(0, this.events.length - this.historyLimit);
     }
     this.emitter.emit("event", this.cloneEvent(event));
+  }
+
+  private cloneInternal(entry: BlackboardEntryInternal): BlackboardEntryInternal {
+    return {
+      key: entry.key,
+      value: structuredClone(entry.value),
+      tags: [...entry.tags],
+      createdAt: entry.createdAt,
+      updatedAt: entry.updatedAt,
+      expiresAt: entry.expiresAt,
+      version: entry.version,
+    };
   }
 
   private cloneEntry(entry: BlackboardEntryInternal): BlackboardEntrySnapshot {

--- a/src/events/bridges.ts
+++ b/src/events/bridges.ts
@@ -1,0 +1,589 @@
+/**
+ * Helper utilities bridging existing coordination/event emitters with the unified
+ * {@link EventBus}. The functions provided here act as glue so legacy modules
+ * such as the blackboard or the stigmergic field can surface structured MCP
+ * events without pulling in the bus implementation directly.
+ */
+import type { EventBus, EventInput } from "./bus.js";
+import type { BlackboardEvent, BlackboardStore } from "../coord/blackboard.js";
+import type { StigmergyChangeEvent, StigmergyField } from "../coord/stigmergy.js";
+import type {
+  ChildRuntime,
+  ChildRuntimeLifecycleEvent,
+  ChildRuntimeMessage,
+} from "../childRuntime.js";
+import type {
+  ContractNetCoordinator,
+  ContractNetEvent,
+  ContractNetEventListener,
+} from "../coord/contractNet.js";
+import {
+  subscribeConsensusEvents,
+  type ConsensusEvent,
+  type ConsensusEventListener,
+} from "../coord/consensus.js";
+import type { CancellationEventPayload } from "../executor/cancel.js";
+import { subscribeCancellationEvents } from "../executor/cancel.js";
+import type {
+  ValueGraph,
+  ValueGraphEvent,
+  ValueGraphEventListener,
+} from "../values/valueGraph.js";
+
+/**
+ * Hints returned by correlation resolvers so callers can enrich emitted events
+ * with contextual identifiers (run, op, graph, ...). All properties are
+ * optional because some emitters do not expose any correlation data yet.
+ */
+export interface EventCorrelationHints {
+  jobId?: string | null;
+  runId?: string | null;
+  opId?: string | null;
+  graphId?: string | null;
+  nodeId?: string | null;
+  childId?: string | null;
+}
+
+/**
+ * Union describing the event currently being bridged. The context is forwarded
+ * to correlation resolvers so they can surface identifiers from the original
+ * payloads.
+ */
+export type ChildRuntimeBridgeContext =
+  | { kind: "message"; runtime: ChildRuntime; message: ChildRuntimeMessage }
+  | { kind: "lifecycle"; runtime: ChildRuntime; lifecycle: ChildRuntimeLifecycleEvent };
+
+/** Options consumed when bridging blackboard events to the {@link EventBus}. */
+export interface BlackboardBridgeOptions {
+  /** Blackboard instance to observe. */
+  blackboard: BlackboardStore;
+  /** Event bus receiving the translated events. */
+  bus: EventBus;
+  /**
+   * Optional resolver deriving correlation metadata (run/op identifiers) from
+   * the raw blackboard event. Keeping it injectable ensures tests can stub the
+   * behaviour until higher layers propagate correlation IDs.
+   */
+  resolveCorrelation?: (event: BlackboardEvent) => EventCorrelationHints | void;
+}
+
+/**
+ * Subscribes to the blackboard change stream and publishes structured events on
+ * the unified bus. The function returns a disposer so callers can detach the
+ * bridge when shutting the orchestrator down.
+ */
+export function bridgeBlackboardEvents(options: BlackboardBridgeOptions): () => void {
+  const { blackboard, bus, resolveCorrelation } = options;
+  let lastVersion = blackboard.getCurrentVersion();
+
+  const listener = (event: BlackboardEvent) => {
+    lastVersion = Math.max(lastVersion, event.version);
+    const correlation = resolveCorrelation?.(event) ?? {};
+
+    const level: EventInput["level"] = event.kind === "expire" ? "warn" : "info";
+    const payload = {
+      kind: event.kind,
+      key: event.key,
+      version: event.version,
+      timestamp: event.timestamp,
+      reason: event.reason ?? null,
+      entry: event.entry ?? null,
+      previous: event.previous ?? null,
+    };
+
+    bus.publish({
+      cat: "blackboard",
+      level,
+      jobId: correlation.jobId ?? null,
+      runId: correlation.runId ?? null,
+      opId: correlation.opId ?? null,
+      graphId: correlation.graphId ?? null,
+      nodeId: correlation.nodeId ?? null,
+      childId: correlation.childId ?? null,
+      msg: `bb_${event.kind}`,
+      data: payload,
+    });
+  };
+
+  const detach = blackboard.watch({ fromVersion: lastVersion, listener });
+  return () => {
+    detach();
+  };
+}
+
+/** Options consumed when bridging stigmergy events to the {@link EventBus}. */
+export interface StigmergyBridgeOptions {
+  /** Stigmergic field emitting change notifications. */
+  field: StigmergyField;
+  /** Event bus receiving the translated events. */
+  bus: EventBus;
+  /** Optional resolver enriching emitted events with correlation hints. */
+  resolveCorrelation?: (event: StigmergyChangeEvent) => EventCorrelationHints | void;
+}
+
+/**
+ * Observes stigmergic field mutations and mirrors them on the unified bus so
+ * downstream MCP clients can reason about pheromone dynamics in real time.
+ */
+export function bridgeStigmergyEvents(options: StigmergyBridgeOptions): () => void {
+  const { field, bus, resolveCorrelation } = options;
+
+  const detach = field.onChange((event) => {
+    const correlation = resolveCorrelation?.(event) ?? {};
+    bus.publish({
+      cat: "stigmergy",
+      level: "info",
+      jobId: correlation.jobId ?? null,
+      runId: correlation.runId ?? null,
+      opId: correlation.opId ?? null,
+      graphId: correlation.graphId ?? null,
+      nodeId: event.nodeId,
+      childId: correlation.childId ?? null,
+      msg: "stigmergy_change",
+      data: {
+        nodeId: event.nodeId,
+        type: event.type,
+        intensity: event.intensity,
+        totalIntensity: event.totalIntensity,
+        updatedAt: event.updatedAt,
+      },
+    });
+  });
+
+  return () => {
+    detach();
+  };
+}
+
+/** Options consumed when bridging cancellation events to the {@link EventBus}. */
+export interface CancellationBridgeOptions {
+  /** Event bus receiving structured cancellation lifecycle events. */
+  bus: EventBus;
+  /**
+   * Optional subscriber used to observe the cancellation registry. Mainly
+   * exposed for tests so they can stub deterministic feeds.
+   */
+  subscribe?: (listener: (event: CancellationEventPayload) => void) => () => void;
+  /**
+   * Optional resolver enriching emitted events with correlation hints such as
+   * job identifiers or related child runtimes.
+   */
+  resolveCorrelation?: (event: CancellationEventPayload) => EventCorrelationHints | void;
+}
+
+/** Options consumed when bridging child runtime events to the {@link EventBus}. */
+export interface ChildRuntimeBridgeOptions {
+  /** Child runtime emitting message and lifecycle events. */
+  runtime: ChildRuntime;
+  /** Event bus receiving structured child lifecycle outputs. */
+  bus: EventBus;
+  /** Optional resolver enriching emitted events with correlation hints. */
+  resolveCorrelation?: (context: ChildRuntimeBridgeContext) => EventCorrelationHints | void;
+}
+
+/** Options consumed when bridging Contract-Net events to the {@link EventBus}. */
+export interface ContractNetBridgeOptions {
+  /** Contract-Net coordinator emitting lifecycle updates. */
+  coordinator: ContractNetCoordinator;
+  /** Event bus receiving structured auction events. */
+  bus: EventBus;
+  /** Optional subscriber override, exposed for deterministic tests. */
+  subscribe?: (listener: ContractNetEventListener) => () => void;
+  /** Optional resolver enriching emitted events with correlation hints. */
+  resolveCorrelation?: (event: ContractNetEvent) => EventCorrelationHints | void;
+}
+
+/** Options consumed when bridging consensus events to the {@link EventBus}. */
+export interface ConsensusBridgeOptions {
+  /** Event bus receiving structured consensus decisions. */
+  bus: EventBus;
+  /** Optional subscriber override so tests can inject deterministic feeds. */
+  subscribe?: (listener: ConsensusEventListener) => () => void;
+  /** Optional resolver enriching emitted events with correlation hints. */
+  resolveCorrelation?: (event: ConsensusEvent) => EventCorrelationHints | void;
+}
+
+/** Options consumed when bridging value guard events to the {@link EventBus}. */
+export interface ValueGuardBridgeOptions {
+  /** Value graph emitting configuration and plan evaluation telemetry. */
+  graph: ValueGraph;
+  /** Event bus receiving structured value guard events. */
+  bus: EventBus;
+  /** Optional subscriber override to facilitate deterministic tests. */
+  subscribe?: (listener: ValueGraphEventListener) => () => void;
+  /** Optional resolver enriching emitted events with correlation hints. */
+  resolveCorrelation?: (event: ValueGraphEvent) => EventCorrelationHints | void;
+}
+
+/**
+ * Observes cancellation registry notifications and forwards them to the unified
+ * bus. The bridge differentiates between brand new requests and idempotent
+ * retries so MCP clients can surface the correct severity.
+ */
+export function bridgeCancellationEvents(options: CancellationBridgeOptions): () => void {
+  const { bus, subscribe = subscribeCancellationEvents, resolveCorrelation } = options;
+
+  const unsubscribe = subscribe((event) => {
+    const correlation = resolveCorrelation?.(event) ?? {};
+    const level: EventInput["level"] = event.outcome === "requested" ? "info" : "warn";
+    const message = event.outcome === "requested" ? "cancel_requested" : "cancel_repeat";
+
+    bus.publish({
+      cat: "cancel",
+      level,
+      jobId: correlation.jobId ?? event.jobId ?? null,
+      runId: correlation.runId ?? event.runId ?? null,
+      opId: correlation.opId ?? event.opId,
+      graphId: correlation.graphId ?? event.graphId ?? null,
+      nodeId: correlation.nodeId ?? event.nodeId ?? null,
+      childId: correlation.childId ?? event.childId ?? null,
+      msg: message,
+      data: {
+        opId: event.opId,
+        runId: event.runId ?? null,
+        jobId: event.jobId ?? null,
+        graphId: event.graphId ?? null,
+        nodeId: event.nodeId ?? null,
+        childId: event.childId ?? null,
+        reason: event.reason,
+        at: event.at,
+        outcome: event.outcome,
+      },
+    });
+  });
+
+  return () => {
+    unsubscribe();
+  };
+}
+
+/**
+ * Observes child runtime events and forwards them to the unified bus. Messages
+ * are categorised by stream while lifecycle notifications surface spawn/exit
+ * transitions so MCP clients can correlate orchestrator decisions.
+ */
+export function bridgeChildRuntimeEvents(options: ChildRuntimeBridgeOptions): () => void {
+  const { runtime, bus, resolveCorrelation } = options;
+
+  const handleCorrelation = (context: ChildRuntimeBridgeContext): EventCorrelationHints => {
+    return resolveCorrelation?.(context) ?? {};
+  };
+
+  const messageListener = (message: ChildRuntimeMessage) => {
+    const correlation = handleCorrelation({ kind: "message", runtime, message });
+    const level: EventInput["level"] = message.stream === "stderr" ? "warn" : "info";
+    // Promote correlation identifiers surfaced directly by the child payload
+    // so tooling receives run/op hints even when the resolver stays silent.
+    const parsed = message.parsed as Record<string, unknown> | null;
+    const jobId =
+      correlation.jobId ?? (parsed && typeof parsed.jobId === "string" ? (parsed.jobId as string) : null);
+    const runId =
+      correlation.runId ?? (parsed && typeof parsed.runId === "string" ? (parsed.runId as string) : null);
+    const opId =
+      correlation.opId ?? (parsed && typeof parsed.opId === "string" ? (parsed.opId as string) : null);
+    const childId =
+      correlation.childId ??
+      (parsed && typeof parsed.childId === "string" ? (parsed.childId as string) : runtime.childId);
+
+    bus.publish({
+      cat: "child",
+      level,
+      childId,
+      jobId,
+      runId,
+      opId,
+      graphId: correlation.graphId ?? null,
+      nodeId: correlation.nodeId ?? null,
+      msg: message.stream === "stderr" ? "child_stderr" : "child_stdout",
+      data: {
+        childId: runtime.childId,
+        stream: message.stream,
+        raw: message.raw,
+        parsed: message.parsed,
+        receivedAt: message.receivedAt,
+        sequence: message.sequence,
+      },
+    });
+  };
+
+  const lifecycleListener = (event: ChildRuntimeLifecycleEvent) => {
+    const correlation = handleCorrelation({ kind: "lifecycle", runtime, lifecycle: event });
+
+    let level: EventInput["level"] = "info";
+    let msg = "child_lifecycle";
+    const data: Record<string, unknown> = {
+      childId: runtime.childId,
+      phase: event.phase,
+      at: event.at,
+      pid: event.pid,
+      forced: event.forced,
+      reason: event.reason,
+    };
+
+    if (event.phase === "spawned") {
+      msg = "child_spawned";
+    } else if (event.phase === "exit") {
+      msg = "child_exit";
+      data.code = event.code;
+      data.signal = event.signal;
+      if (event.forced || (typeof event.code === "number" && event.code !== 0) || event.signal) {
+        level = "warn";
+      }
+    } else if (event.phase === "error") {
+      msg = "child_error";
+      level = "error";
+    }
+
+    bus.publish({
+      cat: "child",
+      level,
+      childId: correlation.childId ?? runtime.childId,
+      jobId: correlation.jobId ?? null,
+      runId: correlation.runId ?? null,
+      opId: correlation.opId ?? null,
+      graphId: correlation.graphId ?? null,
+      nodeId: correlation.nodeId ?? null,
+      msg,
+      data,
+    });
+  };
+
+  runtime.on("message", messageListener);
+  runtime.on("lifecycle", lifecycleListener);
+
+  return () => {
+    runtime.off("message", messageListener);
+    runtime.off("lifecycle", lifecycleListener);
+  };
+}
+
+/**
+ * Observes Contract-Net lifecycle events and forwards them to the unified bus
+ * so MCP tooling can audit announcements, bids and awards alongside other
+ * orchestration streams.
+ */
+export function bridgeContractNetEvents(options: ContractNetBridgeOptions): () => void {
+  const { coordinator, bus, subscribe = (listener) => coordinator.observe(listener), resolveCorrelation } = options;
+
+  const listener: ContractNetEventListener = (event) => {
+    const correlation = resolveCorrelation?.(event) ?? {};
+    let level: EventInput["level"] = "info";
+    let msg = "cnp_event";
+    let data: Record<string, unknown> = {};
+
+    switch (event.kind) {
+      case "agent_registered":
+        msg = event.updated ? "cnp_agent_updated" : "cnp_agent_registered";
+        data = { agent: event.agent, updated: event.updated };
+        break;
+      case "agent_unregistered":
+        msg = "cnp_agent_unregistered";
+        data = { agentId: event.agentId, remainingAssignments: event.remainingAssignments };
+        break;
+      case "call_announced":
+        msg = "cnp_call_announced";
+        data = { call: event.call };
+        break;
+      case "bid_recorded":
+        msg = event.previousKind ? "cnp_bid_updated" : "cnp_bid_recorded";
+        data = {
+          callId: event.callId,
+          agentId: event.agentId,
+          bid: event.bid,
+          previousKind: event.previousKind,
+        };
+        break;
+      case "call_awarded":
+        msg = "cnp_call_awarded";
+        data = { call: event.call, decision: event.decision };
+        break;
+      case "call_completed":
+        msg = "cnp_call_completed";
+        data = { call: event.call };
+        break;
+      default:
+        data = event as Record<string, unknown>;
+        break;
+    }
+
+    bus.publish({
+      cat: "contract_net",
+      level,
+      jobId: correlation.jobId ?? null,
+      runId: correlation.runId ?? null,
+      opId: correlation.opId ?? null,
+      graphId: correlation.graphId ?? null,
+      nodeId: correlation.nodeId ?? null,
+      childId: correlation.childId ?? null,
+      msg,
+      data,
+    });
+  };
+
+  const dispose = subscribe(listener);
+  return () => {
+    dispose();
+  };
+}
+
+/**
+ * Observes consensus computation events and forwards them to the unified bus so
+ * operators can audit quorum evaluations without adding bespoke hooks.
+ */
+export function bridgeConsensusEvents(options: ConsensusBridgeOptions): () => void {
+  const { bus, subscribe = subscribeConsensusEvents, resolveCorrelation } = options;
+
+  const dispose = subscribe((event) => {
+    const correlation = resolveCorrelation?.(event) ?? {};
+
+    let level: EventInput["level"] = event.satisfied ? "info" : "warn";
+    let msg = "consensus_decision";
+    if (event.tie && !event.outcome) {
+      msg = "consensus_tie_unresolved";
+      level = "warn";
+    } else if (!event.satisfied) {
+      msg = "consensus_decision_unsatisfied";
+    }
+
+    bus.publish({
+      cat: "consensus",
+      level,
+      jobId: correlation.jobId ?? event.jobId ?? null,
+      runId: correlation.runId ?? event.runId ?? null,
+      opId: correlation.opId ?? event.opId ?? null,
+      graphId: correlation.graphId ?? null,
+      nodeId: correlation.nodeId ?? null,
+      childId: correlation.childId ?? null,
+      msg,
+      data: {
+        source: event.source,
+        at: event.at,
+        mode: event.mode,
+        outcome: event.outcome,
+        satisfied: event.satisfied,
+        tie: event.tie,
+        threshold: event.threshold,
+        total_weight: event.totalWeight,
+        votes: event.votes,
+        tally: event.tally,
+        metadata: event.metadata ?? null,
+      },
+    });
+  });
+
+  return () => {
+    dispose();
+  };
+}
+
+/**
+ * Observes value guard events and forwards them to the unified bus. The bridge
+ * surfaces configuration updates alongside plan evaluations so MCP clients can
+ * audit guard outcomes without directly coupling to the `ValueGraph`.
+ */
+export function bridgeValueEvents(options: ValueGuardBridgeOptions): () => void {
+  const {
+    graph,
+    bus,
+    subscribe = (listener: ValueGraphEventListener) => graph.subscribe(listener),
+    resolveCorrelation,
+  } = options;
+
+  const listener: ValueGraphEventListener = (event) => {
+    const hints: EventCorrelationHints = {};
+    if (event.correlation) {
+      const { runId, opId, jobId, graphId, nodeId, childId } = event.correlation;
+      if (runId !== undefined) hints.runId = runId ?? null;
+      if (opId !== undefined) hints.opId = opId ?? null;
+      if (jobId !== undefined) hints.jobId = jobId ?? null;
+      if (graphId !== undefined) hints.graphId = graphId ?? null;
+      if (nodeId !== undefined) hints.nodeId = nodeId ?? null;
+      if (childId !== undefined) hints.childId = childId ?? null;
+    }
+
+    const resolved = resolveCorrelation?.(event);
+    if (resolved) {
+      for (const [key, value] of Object.entries(resolved)) {
+        if (value !== undefined) {
+          (hints as Record<string, unknown>)[key] = value;
+        }
+      }
+    }
+    let level: EventInput["level"] = "info";
+    let msg = "values_event";
+    let data: Record<string, unknown> = {};
+
+    switch (event.kind) {
+      case "config_updated":
+        msg = "values_config_updated";
+        data = {
+          summary: event.summary,
+        };
+        break;
+      case "plan_scored": {
+        msg = "values_scored";
+        const violations = event.result.violations.length;
+        if (violations > 0) {
+          level = "warn";
+        }
+        data = {
+          plan_id: event.planId,
+          plan_label: event.planLabel,
+          impacts_count: event.impacts.length,
+          impacts: event.impacts,
+          result: event.result,
+          violations_count: violations,
+        };
+        break;
+      }
+      case "plan_filtered": {
+        const allowed = event.decision.allowed;
+        msg = allowed ? "values_filter_allowed" : "values_filter_blocked";
+        level = allowed ? "info" : "warn";
+        data = {
+          plan_id: event.planId,
+          plan_label: event.planLabel,
+          impacts_count: event.impacts.length,
+          impacts: event.impacts,
+          decision: event.decision,
+        };
+        break;
+      }
+      case "plan_explained": {
+        const allowed = event.result.decision.allowed;
+        msg = allowed ? "values_explain_allowed" : "values_explain_blocked";
+        level = allowed ? "info" : "warn";
+        data = {
+          plan_id: event.planId,
+          plan_label: event.planLabel,
+          impacts_count: event.impacts.length,
+          impacts: event.impacts,
+          result: event.result,
+        };
+        break;
+      }
+      default:
+        data = event as Record<string, unknown>;
+        break;
+    }
+
+    bus.publish({
+      cat: "values",
+      level,
+      jobId: hints.jobId ?? null,
+      runId: hints.runId ?? null,
+      opId: hints.opId ?? null,
+      graphId: hints.graphId ?? null,
+      nodeId: hints.nodeId ?? null,
+      childId: hints.childId ?? null,
+      msg,
+      data,
+      ts: event.at,
+    });
+  };
+
+  const dispose = subscribe(listener);
+  return () => {
+    dispose();
+  };
+}

--- a/src/graph/diff.ts
+++ b/src/graph/diff.ts
@@ -1,0 +1,193 @@
+import type { NormalisedGraph, GraphAttributeValue } from "./types.js";
+
+/**
+ * JSON Patch operation supported by the diff/patch helpers. Only the subset of
+ * operations required for graph synchronisation is implemented so callers are
+ * not tempted to rely on exotic behaviours that would complicate invariants.
+ */
+export interface JsonPatchOperation {
+  op: "add" | "remove" | "replace";
+  path: string;
+  value?: unknown;
+}
+
+/** Result returned when diffing two graphs. */
+export interface GraphDiffResult {
+  /** Patch operations capable of transforming {@link base} into {@link target}. */
+  operations: JsonPatchOperation[];
+  /** Indicates whether the graphs differ structurally. */
+  changed: boolean;
+  /** High-level summary of the mutated top-level sections. */
+  summary: {
+    nameChanged: boolean;
+    metadataChanged: boolean;
+    nodesChanged: boolean;
+    edgesChanged: boolean;
+  };
+}
+
+/**
+ * Compute a RFC 6902 JSON Patch transforming {@link base} into {@link target}.
+ *
+ * The implementation intentionally focuses on top-level mutations (name,
+ * metadata, nodes, edges) to guarantee deterministic output without requiring
+ * a heavy structural diff dependency. Arrays are fully replaced whenever they
+ * diverge which keeps the patch readable and easy to apply.
+ */
+export function diffGraphs(base: NormalisedGraph, target: NormalisedGraph): GraphDiffResult {
+  const baseDoc = toDiffDocument(base);
+  const targetDoc = toDiffDocument(target);
+
+  const operations: JsonPatchOperation[] = [];
+
+  if (baseDoc.name !== targetDoc.name) {
+    operations.push({ op: "replace", path: "/name", value: targetDoc.name });
+  }
+
+  if (!recordsEqual(baseDoc.metadata, targetDoc.metadata)) {
+    emitRecordDiff("/metadata", baseDoc.metadata, targetDoc.metadata, operations);
+  }
+
+  const nodesChanged = !arraysEqual(baseDoc.nodes, targetDoc.nodes);
+  if (nodesChanged) {
+    operations.push({ op: "replace", path: "/nodes", value: targetDoc.nodes });
+  }
+
+  const edgesChanged = !arraysEqual(baseDoc.edges, targetDoc.edges);
+  if (edgesChanged) {
+    operations.push({ op: "replace", path: "/edges", value: targetDoc.edges });
+  }
+
+  const changed = operations.length > 0;
+  return {
+    operations,
+    changed,
+    summary: {
+      nameChanged: baseDoc.name !== targetDoc.name,
+      metadataChanged: !recordsEqual(baseDoc.metadata, targetDoc.metadata),
+      nodesChanged,
+      edgesChanged,
+    },
+  };
+}
+
+/** Canonical representation leveraged by {@link diffGraphs}. */
+interface DiffDocument {
+  name: string;
+  metadata: Record<string, GraphAttributeValue>;
+  nodes: Array<{
+    id: string;
+    label: string | null;
+    attributes: Record<string, GraphAttributeValue>;
+  }>;
+  edges: Array<{
+    from: string;
+    to: string;
+    label: string | null;
+    weight: number | null;
+    attributes: Record<string, GraphAttributeValue>;
+  }>;
+}
+
+/** Convert a normalised graph into the canonical representation used for diffs. */
+function toDiffDocument(graph: NormalisedGraph): DiffDocument {
+  return {
+    name: graph.name ?? "",
+    metadata: sortRecord(graph.metadata ?? {}),
+    nodes: graph.nodes
+      .map((node) => ({
+        id: node.id,
+        label: node.label ?? null,
+        attributes: sortRecord(node.attributes ?? {}),
+      }))
+      .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)),
+    edges: graph.edges
+      .map((edge) => ({
+        from: edge.from,
+        to: edge.to,
+        label: edge.label ?? null,
+        weight: typeof edge.weight === "number" ? Number(edge.weight) : null,
+        attributes: sortRecord(edge.attributes ?? {}),
+      }))
+      .sort((a, b) => {
+        if (a.from === b.from) {
+          return a.to < b.to ? -1 : a.to > b.to ? 1 : 0;
+        }
+        return a.from < b.from ? -1 : 1;
+      }),
+  };
+}
+
+/** Compare two records for equality (assuming both were sorted). */
+function recordsEqual(
+  left: Record<string, GraphAttributeValue>,
+  right: Record<string, GraphAttributeValue>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  for (const key of leftKeys) {
+    if (!(key in right)) {
+      return false;
+    }
+    if (left[key] !== right[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Compare two arrays via JSON serialization (values are already canonical). */
+function arraysEqual(left: unknown[], right: unknown[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (JSON.stringify(left[index]) !== JSON.stringify(right[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Emit per-key JSON Patch operations for record mutations. */
+function emitRecordDiff(
+  basePath: string,
+  base: Record<string, GraphAttributeValue>,
+  target: Record<string, GraphAttributeValue>,
+  operations: JsonPatchOperation[],
+): void {
+  const baseKeys = new Set(Object.keys(base));
+  const targetKeys = new Set(Object.keys(target));
+
+  for (const key of baseKeys) {
+    if (!targetKeys.has(key)) {
+      operations.push({ op: "remove", path: `${basePath}/${escapePointer(key)}` });
+    }
+  }
+  for (const key of targetKeys) {
+    const pointer = `${basePath}/${escapePointer(key)}`;
+    if (!baseKeys.has(key)) {
+      operations.push({ op: "add", path: pointer, value: target[key] });
+    } else if (base[key] !== target[key]) {
+      operations.push({ op: "replace", path: pointer, value: target[key] });
+    }
+  }
+}
+
+/** Sort record entries lexicographically for deterministic comparisons. */
+function sortRecord(values: Record<string, GraphAttributeValue>): Record<string, GraphAttributeValue> {
+  const sortedEntries = Object.entries(values).sort(([a], [b]) => a.localeCompare(b));
+  const result: Record<string, GraphAttributeValue> = {};
+  for (const [key, value] of sortedEntries) {
+    result[key] = value;
+  }
+  return result;
+}
+
+/** Escape a JSON pointer segment following RFC 6901. */
+function escapePointer(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}

--- a/src/graph/invariants.ts
+++ b/src/graph/invariants.ts
@@ -1,0 +1,244 @@
+import type { NormalisedGraph, GraphAttributeValue } from "./types.js";
+
+/** Violation reported when a graph breaks one of the enforced invariants. */
+export interface GraphInvariantViolation {
+  code: string;
+  message: string;
+  nodes?: string[];
+  edge?: { from: string; to: string };
+  details?: Record<string, unknown>;
+}
+
+/** Summary returned when evaluating the invariants for a graph. */
+export interface GraphInvariantReport {
+  ok: boolean;
+  violations: GraphInvariantViolation[];
+}
+
+/** Options controlling which invariants must be enforced. */
+export interface GraphInvariantOptions {
+  enforceDag?: boolean;
+  requireNodeLabels?: boolean;
+  requireEdgeLabels?: boolean;
+  requirePortAttributes?: boolean;
+  defaultMaxInDegree?: number;
+  defaultMaxOutDegree?: number;
+}
+
+/** Error thrown when invariants are violated. */
+export class GraphInvariantError extends Error {
+  constructor(readonly violations: GraphInvariantViolation[]) {
+    super(
+      violations
+        .map((violation) => `${violation.code}: ${violation.message}`)
+        .join("; "),
+    );
+    this.name = "GraphInvariantError";
+  }
+}
+
+/**
+ * Evaluate the invariants declared in the graph metadata and node attributes.
+ * Callers can override the derived options via {@link overrides}.
+ */
+export function evaluateGraphInvariants(
+  graph: NormalisedGraph,
+  overrides: GraphInvariantOptions = {},
+): GraphInvariantReport {
+  const options = deriveOptions(graph, overrides);
+  const violations: GraphInvariantViolation[] = [];
+
+  if (options.enforceDag) {
+    const cycles = detectCycles(graph);
+    if (cycles.length > 0) {
+      violations.push({
+        code: "E-GRAPH-CYCLE",
+        message: `cycles detected (${cycles.length}) in graph '${graph.graphId}'`,
+        details: { cycles },
+      });
+    }
+  }
+
+  if (options.requireNodeLabels) {
+    const missing = graph.nodes.filter((node) => !node.label || node.label.trim().length === 0).map((node) => node.id);
+    if (missing.length > 0) {
+      violations.push({
+        code: "E-NODE-LABEL",
+        message: "node labels are required when 'require_labels' metadata is true",
+        nodes: missing,
+      });
+    }
+  }
+
+  if (options.requireEdgeLabels) {
+    const missing = graph.edges
+      .filter((edge) => !edge.label || edge.label.trim().length === 0)
+      .map((edge) => ({ from: edge.from, to: edge.to }));
+    if (missing.length > 0) {
+      for (const entry of missing) {
+        violations.push({
+          code: "E-EDGE-LABEL",
+          message: `edge '${entry.from}' -> '${entry.to}' is missing a label`,
+          edge: entry,
+        });
+      }
+    }
+  }
+
+  if (options.requirePortAttributes) {
+    for (const edge of graph.edges) {
+      const fromPort = normalisePort(edge.attributes.from_port);
+      const toPort = normalisePort(edge.attributes.to_port);
+      if (!fromPort || !toPort) {
+        violations.push({
+          code: "E-EDGE-PORT",
+          message: `edge '${edge.from}' -> '${edge.to}' must declare 'from_port' and 'to_port' attributes`,
+          edge: { from: edge.from, to: edge.to },
+        });
+      }
+    }
+  }
+
+  const cardinalityViolations = enforceCardinality(graph, options);
+  violations.push(...cardinalityViolations);
+
+  return { ok: violations.length === 0, violations };
+}
+
+/** Assert that the invariants hold, throwing a {@link GraphInvariantError} when they do not. */
+export function assertGraphInvariants(
+  graph: NormalisedGraph,
+  overrides: GraphInvariantOptions = {},
+): void {
+  const report = evaluateGraphInvariants(graph, overrides);
+  if (!report.ok) {
+    throw new GraphInvariantError(report.violations);
+  }
+}
+
+/** Infer invariant options from metadata and node attributes. */
+function deriveOptions(graph: NormalisedGraph, overrides: GraphInvariantOptions): GraphInvariantOptions {
+  const metadata = normaliseRecord(graph.metadata ?? {});
+  return {
+    enforceDag:
+      overrides.enforceDag ?? (metadata.graph_kind === "dag" || metadata.dag === true || metadata.enforce_dag === true),
+    requireNodeLabels: overrides.requireNodeLabels ?? metadata.require_labels === true,
+    requireEdgeLabels: overrides.requireEdgeLabels ?? metadata.require_edge_labels === true,
+    requirePortAttributes: overrides.requirePortAttributes ?? metadata.require_ports === true,
+    defaultMaxInDegree: overrides.defaultMaxInDegree ?? parseDegree(metadata.max_in_degree),
+    defaultMaxOutDegree: overrides.defaultMaxOutDegree ?? parseDegree(metadata.max_out_degree),
+  } satisfies GraphInvariantOptions;
+}
+
+/** Parse a degree hint from metadata. */
+function parseDegree(value: GraphAttributeValue | undefined): number | undefined {
+  if (typeof value !== "number") {
+    return undefined;
+  }
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+/**
+ * Enforce per-node cardinality limits using metadata defaults and attribute-level overrides.
+ */
+function enforceCardinality(graph: NormalisedGraph, options: GraphInvariantOptions): GraphInvariantViolation[] {
+  const violations: GraphInvariantViolation[] = [];
+  const incoming = new Map<string, number>();
+  const outgoing = new Map<string, number>();
+  for (const node of graph.nodes) {
+    incoming.set(node.id, 0);
+    outgoing.set(node.id, 0);
+  }
+  for (const edge of graph.edges) {
+    incoming.set(edge.to, (incoming.get(edge.to) ?? 0) + 1);
+    outgoing.set(edge.from, (outgoing.get(edge.from) ?? 0) + 1);
+  }
+
+  for (const node of graph.nodes) {
+    const maxIn = parseDegree(node.attributes.max_in_degree) ?? options.defaultMaxInDegree;
+    const maxOut = parseDegree(node.attributes.max_out_degree) ?? options.defaultMaxOutDegree;
+    if (typeof maxIn === "number" && (incoming.get(node.id) ?? 0) > maxIn) {
+      violations.push({
+        code: "E-IN-DEGREE",
+        message: `node '${node.id}' exceeds max_in_degree (${incoming.get(node.id)} > ${maxIn})`,
+        nodes: [node.id],
+        details: { max: maxIn, actual: incoming.get(node.id) ?? 0 },
+      });
+    }
+    if (typeof maxOut === "number" && (outgoing.get(node.id) ?? 0) > maxOut) {
+      violations.push({
+        code: "E-OUT-DEGREE",
+        message: `node '${node.id}' exceeds max_out_degree (${outgoing.get(node.id)} > ${maxOut})`,
+        nodes: [node.id],
+        details: { max: maxOut, actual: outgoing.get(node.id) ?? 0 },
+      });
+    }
+  }
+
+  return violations;
+}
+
+/** Detect directed cycles using depth-first search. */
+function detectCycles(graph: NormalisedGraph): string[][] {
+  const adjacency = new Map<string, string[]>();
+  for (const node of graph.nodes) {
+    adjacency.set(node.id, []);
+  }
+  for (const edge of graph.edges) {
+    if (!adjacency.has(edge.from)) {
+      adjacency.set(edge.from, []);
+    }
+    adjacency.get(edge.from)!.push(edge.to);
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+  const cycles: string[][] = [];
+
+  const visit = (nodeId: string): void => {
+    visiting.add(nodeId);
+    stack.push(nodeId);
+    for (const neighbour of adjacency.get(nodeId) ?? []) {
+      if (visiting.has(neighbour)) {
+        const startIndex = stack.indexOf(neighbour);
+        if (startIndex >= 0) {
+          cycles.push(stack.slice(startIndex).concat(neighbour));
+        }
+        continue;
+      }
+      if (!visited.has(neighbour)) {
+        visit(neighbour);
+      }
+    }
+    visiting.delete(nodeId);
+    visited.add(nodeId);
+    stack.pop();
+  };
+
+  for (const nodeId of adjacency.keys()) {
+    if (!visited.has(nodeId)) {
+      visit(nodeId);
+    }
+  }
+
+  return cycles;
+}
+
+/** Normalise metadata/attribute records. */
+function normaliseRecord(record: Record<string, GraphAttributeValue>): Record<string, GraphAttributeValue> {
+  const output: Record<string, GraphAttributeValue> = {};
+  for (const [key, value] of Object.entries(record)) {
+    output[key] = value;
+  }
+  return output;
+}
+
+/** Normalise a port attribute value into a non-empty string. */
+function normalisePort(value: GraphAttributeValue | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/graph/locks.ts
+++ b/src/graph/locks.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from "node:crypto";
+
+/** Function returning the current epoch milliseconds, injectable for tests. */
+type Clock = () => number;
+
+/** Default TTL upper bound (24h) mirroring transaction guard rails. */
+const MAX_TTL_MS = 86_400_000;
+
+/** Internal snapshot describing an acquired graph lock. */
+export interface GraphLockSnapshot {
+  lockId: string;
+  graphId: string;
+  holder: string;
+  acquiredAt: number;
+  refreshedAt: number;
+  expiresAt: number | null;
+  ttlMs: number | null;
+}
+
+/** Base error used by the locking subsystem. */
+export class GraphLockError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GraphLockError";
+  }
+}
+
+/** Error thrown when another holder already protects the requested graph. */
+export class GraphLockHeldError extends GraphLockError {
+  public readonly code = "E-GRAPH-LOCK-HELD";
+  public readonly details: { graphId: string; holder: string; lockId: string; expiresAt: number | null };
+
+  constructor(graphId: string, holder: string, lockId: string, expiresAt: number | null) {
+    super(`graph '${graphId}' is locked by '${holder}'`);
+    this.name = "GraphLockHeldError";
+    this.details = { graphId, holder, lockId, expiresAt };
+  }
+}
+
+/** Error thrown when an operation references an unknown lock identifier. */
+export class GraphLockUnknownError extends GraphLockError {
+  public readonly code = "E-GRAPH-LOCK-NOT-FOUND";
+  public readonly details: { lockId: string };
+
+  constructor(lockId: string) {
+    super(`graph lock '${lockId}' is not active`);
+    this.name = "GraphLockUnknownError";
+    this.details = { lockId };
+  }
+}
+
+/** Error thrown when a mutation is attempted while a conflicting lock exists. */
+export class GraphMutationLockedError extends GraphLockError {
+  public readonly code = "E-GRAPH-MUTATION-LOCKED";
+  public readonly details: { graphId: string; holder: string; lockId: string; expiresAt: number | null };
+
+  constructor(graphId: string, holder: string, lockId: string, expiresAt: number | null) {
+    super(`graph '${graphId}' is locked by '${holder}'`);
+    this.name = "GraphMutationLockedError";
+    this.details = { graphId, holder, lockId, expiresAt };
+  }
+}
+
+/** Result describing a released lock. */
+export interface GraphLockReleaseResult {
+  lockId: string;
+  graphId: string;
+  holder: string;
+  releasedAt: number;
+  expired: boolean;
+  expiresAt: number | null;
+}
+
+/** Options accepted when acquiring a graph lock. */
+export interface AcquireGraphLockOptions {
+  ttlMs?: number | null;
+}
+
+/**
+ * Cooperative lock manager protecting graph mutations. The manager exposes
+ * optimistic APIs: callers either receive the lock immediately or a
+ * deterministic error that can be retried after the TTL expires.
+ */
+export class GraphLockManager {
+  private readonly locksByGraphId = new Map<string, GraphLockSnapshot>();
+  private readonly locksById = new Map<string, GraphLockSnapshot>();
+
+  constructor(private readonly clock: Clock = () => Date.now()) {}
+
+  /** Acquire a lock for the provided graph identifier. */
+  acquire(graphId: string, holder: string, options: AcquireGraphLockOptions = {}): GraphLockSnapshot {
+    const normalisedGraphId = normaliseGraphId(graphId);
+    const normalisedHolder = normaliseHolder(holder);
+    const now = this.clock();
+    this.pruneExpired(normalisedGraphId, now);
+
+    const existing = this.locksByGraphId.get(normalisedGraphId);
+    const ttlMs = normaliseTtl(options.ttlMs);
+    if (existing) {
+      if (existing.holder !== normalisedHolder) {
+        throw new GraphLockHeldError(normalisedGraphId, existing.holder, existing.lockId, existing.expiresAt);
+      }
+      const refreshed = {
+        ...existing,
+        refreshedAt: now,
+        ttlMs: ttlMs ?? existing.ttlMs,
+        expiresAt: computeExpiry(now, ttlMs ?? existing.ttlMs),
+      } satisfies GraphLockSnapshot;
+      this.store(refreshed);
+      return { ...refreshed };
+    }
+
+    const snapshot: GraphLockSnapshot = {
+      lockId: randomUUID(),
+      graphId: normalisedGraphId,
+      holder: normalisedHolder,
+      acquiredAt: now,
+      refreshedAt: now,
+      ttlMs,
+      expiresAt: computeExpiry(now, ttlMs),
+    };
+    this.store(snapshot);
+    return { ...snapshot };
+  }
+
+  /** Release the lock identified by {@link lockId}. */
+  release(lockId: string): GraphLockReleaseResult {
+    const record = this.locksById.get(lockId);
+    if (!record) {
+      throw new GraphLockUnknownError(lockId);
+    }
+    const now = this.clock();
+    this.locksById.delete(lockId);
+    const existing = this.locksByGraphId.get(record.graphId);
+    if (existing && existing.lockId === lockId) {
+      this.locksByGraphId.delete(record.graphId);
+    }
+    const expired = record.expiresAt !== null && record.expiresAt <= now;
+    return {
+      lockId: record.lockId,
+      graphId: record.graphId,
+      holder: record.holder,
+      releasedAt: now,
+      expired,
+      expiresAt: record.expiresAt,
+    };
+  }
+
+  /**
+   * Ensure the caller can mutate the target graph. Throws when a conflicting
+   * lock is active.
+   */
+  assertCanMutate(graphId: string, holder: string | null | undefined): void {
+    const normalisedGraphId = normaliseGraphId(graphId);
+    const now = this.clock();
+    this.pruneExpired(normalisedGraphId, now);
+    const active = this.locksByGraphId.get(normalisedGraphId);
+    if (!active) {
+      return;
+    }
+    const normalisedHolder = holder === undefined || holder === null ? null : normaliseHolder(holder);
+    if (normalisedHolder !== active.holder) {
+      throw new GraphMutationLockedError(active.graphId, active.holder, active.lockId, active.expiresAt);
+    }
+  }
+
+  /** Describe the current lock protecting the graph, if any. */
+  describe(graphId: string): GraphLockSnapshot | null {
+    const normalisedGraphId = normaliseGraphId(graphId);
+    const now = this.clock();
+    this.pruneExpired(normalisedGraphId, now);
+    const snapshot = this.locksByGraphId.get(normalisedGraphId);
+    return snapshot ? { ...snapshot } : null;
+  }
+
+  /** Describe the lock associated with the identifier, if it exists. */
+  describeById(lockId: string): GraphLockSnapshot | null {
+    const snapshot = this.locksById.get(lockId);
+    if (!snapshot) {
+      return null;
+    }
+    return { ...snapshot };
+  }
+
+  private store(snapshot: GraphLockSnapshot): void {
+    this.locksByGraphId.set(snapshot.graphId, snapshot);
+    this.locksById.set(snapshot.lockId, snapshot);
+  }
+
+  private pruneExpired(graphId: string, now: number): void {
+    const existing = this.locksByGraphId.get(graphId);
+    if (!existing) {
+      return;
+    }
+    if (existing.expiresAt !== null && existing.expiresAt <= now) {
+      this.locksByGraphId.delete(graphId);
+      this.locksById.delete(existing.lockId);
+    }
+  }
+}
+
+function normaliseGraphId(graphId: string): string {
+  if (!graphId || graphId.trim().length === 0) {
+    throw new GraphLockError("graph id must not be empty");
+  }
+  return graphId.trim();
+}
+
+function normaliseHolder(holder: string): string {
+  const trimmed = holder.trim();
+  if (trimmed.length === 0) {
+    throw new GraphLockError("holder must not be empty");
+  }
+  return trimmed;
+}
+
+function normaliseTtl(ttlMs: number | null | undefined): number | null {
+  if (ttlMs === null || ttlMs === undefined) {
+    return null;
+  }
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    return null;
+  }
+  return Math.min(Math.floor(ttlMs), MAX_TTL_MS);
+}
+
+function computeExpiry(now: number, ttlMs: number | null): number | null {
+  if (ttlMs === null) {
+    return null;
+  }
+  return now + ttlMs;
+}

--- a/src/graph/patch.ts
+++ b/src/graph/patch.ts
@@ -1,0 +1,227 @@
+import type { NormalisedGraph, GraphAttributeValue } from "./types.js";
+import type { JsonPatchOperation } from "./diff.js";
+
+/** Error thrown when a JSON Patch cannot be applied to the graph document. */
+export class GraphPatchApplyError extends Error {
+  constructor(message: string, readonly path: string) {
+    super(message);
+    this.name = "GraphPatchApplyError";
+  }
+}
+
+/**
+ * Apply JSON Patch operations on top of a normalised graph. The helper keeps the
+ * graph identifier and version untouched so {@link GraphTransactionManager}
+ * remains the single authority deciding when versions get incremented.
+ */
+export function applyGraphPatch(base: NormalisedGraph, patch: JsonPatchOperation[]): NormalisedGraph {
+  const document = toDocument(base);
+  for (const operation of patch) {
+    applyOperation(document, operation);
+  }
+  return fromDocument(document, base);
+}
+
+/** Intermediate structure updated by the JSON Patch application. */
+interface GraphDocument {
+  name: string;
+  metadata: Record<string, GraphAttributeValue>;
+  nodes: Array<{
+    id: string;
+    label: string | null;
+    attributes: Record<string, GraphAttributeValue>;
+  }>;
+  edges: Array<{
+    from: string;
+    to: string;
+    label: string | null;
+    weight: number | null;
+    attributes: Record<string, GraphAttributeValue>;
+  }>;
+}
+
+/** Convert a {@link NormalisedGraph} into a mutable document representation. */
+function toDocument(graph: NormalisedGraph): GraphDocument {
+  return {
+    name: graph.name ?? "",
+    metadata: cloneRecord(graph.metadata ?? {}),
+    nodes: graph.nodes.map((node) => ({
+      id: node.id,
+      label: node.label ?? null,
+      attributes: cloneRecord(node.attributes ?? {}),
+    })),
+    edges: graph.edges.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      label: edge.label ?? null,
+      weight: typeof edge.weight === "number" ? Number(edge.weight) : null,
+      attributes: cloneRecord(edge.attributes ?? {}),
+    })),
+  };
+}
+
+/** Convert the mutable document back into a normalised graph descriptor. */
+function fromDocument(document: GraphDocument, base: NormalisedGraph): NormalisedGraph {
+  return {
+    name: document.name,
+    graphId: base.graphId,
+    graphVersion: base.graphVersion,
+    metadata: cloneRecord(document.metadata),
+    nodes: document.nodes.map((node) => ({
+      id: node.id,
+      label: node.label ?? undefined,
+      attributes: cloneRecord(node.attributes),
+    })),
+    edges: document.edges.map((edge) => ({
+      from: edge.from,
+      to: edge.to,
+      label: edge.label ?? undefined,
+      weight: edge.weight ?? undefined,
+      attributes: cloneRecord(edge.attributes),
+    })),
+  };
+}
+
+/** Apply a single JSON Patch operation to the provided document. */
+function applyOperation(document: GraphDocument, operation: JsonPatchOperation): void {
+  const segments = parsePointer(operation.path);
+  if (segments.length === 0) {
+    throw new GraphPatchApplyError("root operations are not supported", operation.path);
+  }
+
+  switch (operation.op) {
+    case "replace":
+      replaceAtPointer(document, segments, operation.path, operation.value);
+      break;
+    case "add":
+      addAtPointer(document, segments, operation.path, operation.value);
+      break;
+    case "remove":
+      removeAtPointer(document, segments, operation.path);
+      break;
+    default:
+      throw new GraphPatchApplyError(`unsupported operation '${operation.op}'`, operation.path);
+  }
+}
+
+/** Replace a value located at the JSON pointer. */
+function replaceAtPointer(
+  document: GraphDocument,
+  segments: string[],
+  path: string,
+  value: unknown,
+): void {
+  const parent = resolveContainer(document, segments.slice(0, -1), path);
+  const key = segments.at(-1)!;
+  if (Array.isArray(parent)) {
+    const index = parseIndex(key, path, parent.length - 1);
+    parent[index] = cloneValue(value);
+  } else {
+    parent[key] = cloneValue(value);
+  }
+}
+
+/** Add a value at the pointer location (for objects only). */
+function addAtPointer(
+  document: GraphDocument,
+  segments: string[],
+  path: string,
+  value: unknown,
+): void {
+  const parent = resolveContainer(document, segments.slice(0, -1), path);
+  const key = segments.at(-1)!;
+  if (Array.isArray(parent)) {
+    if (key === "-") {
+      parent.push(cloneValue(value));
+    } else {
+      const index = parseIndex(key, path, parent.length);
+      parent.splice(index, 0, cloneValue(value));
+    }
+  } else {
+    if (Object.prototype.hasOwnProperty.call(parent, key)) {
+      throw new GraphPatchApplyError(`key '${key}' already exists`, path);
+    }
+    parent[key] = cloneValue(value);
+  }
+}
+
+/** Remove the value stored at the pointer location. */
+function removeAtPointer(document: GraphDocument, segments: string[], path: string): void {
+  const parent = resolveContainer(document, segments.slice(0, -1), path);
+  const key = segments.at(-1)!;
+  if (Array.isArray(parent)) {
+    const index = parseIndex(key, path, parent.length - 1);
+    parent.splice(index, 1);
+  } else {
+    if (!Object.prototype.hasOwnProperty.call(parent, key)) {
+      throw new GraphPatchApplyError(`key '${key}' does not exist`, path);
+    }
+    delete parent[key];
+  }
+}
+
+/** Resolve the container referenced by the pointer segments. */
+function resolveContainer(
+  document: GraphDocument,
+  segments: string[],
+  path: string,
+): Record<string, unknown> | unknown[] {
+  let current: unknown = document;
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      const index = parseIndex(segment, path, current.length - 1);
+      current = current[index];
+    } else if (typeof current === "object" && current !== null) {
+      if (!Object.prototype.hasOwnProperty.call(current, segment)) {
+        throw new GraphPatchApplyError(`path '${path}' is invalid`, path);
+      }
+      current = (current as Record<string, unknown>)[segment];
+    } else {
+      throw new GraphPatchApplyError(`path '${path}' cannot be resolved`, path);
+    }
+  }
+  if (!Array.isArray(current) && typeof current !== "object") {
+    throw new GraphPatchApplyError(`path '${path}' does not reference a container`, path);
+  }
+  return current as Record<string, unknown> | unknown[];
+}
+
+/** Parse a JSON pointer into individual segments. */
+function parsePointer(pointer: string): string[] {
+  if (!pointer.startsWith("/")) {
+    throw new GraphPatchApplyError("JSON pointer must start with '/'", pointer);
+  }
+  if (pointer === "/") {
+    return [];
+  }
+  return pointer
+    .slice(1)
+    .split("/")
+    .map((segment) => segment.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+/** Parse and validate an array index. */
+function parseIndex(segment: string, path: string, max: number): number {
+  if (!/^\d+$/.test(segment)) {
+    throw new GraphPatchApplyError(`segment '${segment}' is not a valid index`, path);
+  }
+  const index = Number(segment);
+  if (index < 0 || index > max) {
+    throw new GraphPatchApplyError(`index '${index}' is out of bounds`, path);
+  }
+  return index;
+}
+
+/** Deep clone a graph attribute record. */
+function cloneRecord(values: Record<string, GraphAttributeValue>): Record<string, GraphAttributeValue> {
+  const result: Record<string, GraphAttributeValue> = {};
+  for (const [key, value] of Object.entries(values)) {
+    result[key] = value;
+  }
+  return result;
+}
+
+/** Clone arbitrary JSON-compatible values. */
+function cloneValue<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/src/infra/idempotency.ts
+++ b/src/infra/idempotency.ts
@@ -1,0 +1,225 @@
+/**
+ * Lightweight in-memory registry storing the outcome of idempotent operations.
+ *
+ * The store keeps a TTL per key so retried requests can replay the exact same
+ * payload without re-executing the underlying side effects. Every entry records
+ * hit counters and timestamps which tests rely on to guarantee deterministic
+ * behaviour when fake timers are installed.
+ */
+export interface IdempotencyEntry<T> {
+  /** User provided key correlating retries for the same operation. */
+  readonly key: string;
+  /** Value persisted for the first successful execution. */
+  readonly value: T;
+  /** Monotonic timestamp recorded when the value was stored. */
+  readonly storedAt: number;
+  /** Timestamp after which the entry is considered expired. */
+  readonly expiresAt: number;
+  /** Number of times callers observed a replay (first call counts as 1). */
+  readonly hits: number;
+  /** Timestamp of the latest replay (mirrors {@link storedAt} for first call). */
+  readonly lastHitAt: number;
+}
+
+/** Options accepted when instantiating the registry. */
+export interface IdempotencyRegistryOptions {
+  /** Default TTL (milliseconds) applied when callers do not override it. */
+  defaultTtlMs?: number;
+  /** Optional clock used for testing (defaults to {@link Date.now}). */
+  clock?: () => number;
+}
+
+/** Result returned when looking up a key inside the registry. */
+export interface IdempotencyHit<T> {
+  /** Stored value, cloned defensively from the registry. */
+  value: T;
+  /** Indicates whether the result was replayed (`true`) or freshly stored. */
+  idempotent: boolean;
+  /** Metadata describing the snapshot kept in memory. */
+  entry: IdempotencyEntry<T>;
+}
+
+/** Internal representation retained in memory (mutable to update hit counters). */
+interface MutableIdempotencyEntry<T> extends IdempotencyEntry<T> {
+  hits: number;
+  lastHitAt: number;
+}
+
+/** Function returning a promise or synchronous value. */
+type MaybeAsyncFactory<T> = () => T | Promise<T>;
+
+/** Clamp used to avoid storing negative TTLs when callers provide invalid data. */
+const MIN_TTL_MS = 1;
+/** Default TTL (~10 minutes) offering a generous window for retries. */
+const DEFAULT_TTL_MS = 600_000;
+
+/**
+ * In-memory registry storing idempotent outcomes. The implementation favours a
+ * predictable behaviour over absolute performance as the orchestrator only
+ * keeps a few dozen entries at a time (tools and server enforce timeouts).
+ */
+export class IdempotencyRegistry {
+  private readonly entries = new Map<string, MutableIdempotencyEntry<unknown>>();
+  private readonly pending = new Map<string, Promise<MutableIdempotencyEntry<unknown>>>();
+  private readonly clock: () => number;
+  private readonly defaultTtlMs: number;
+
+  constructor(options: IdempotencyRegistryOptions = {}) {
+    this.clock = options.clock ?? (() => Date.now());
+    const ttl = options.defaultTtlMs ?? DEFAULT_TTL_MS;
+    this.defaultTtlMs = ttl > 0 ? ttl : DEFAULT_TTL_MS;
+  }
+
+  /** Number of live entries currently tracked. */
+  public size(): number {
+    return this.entries.size;
+  }
+
+  /** Remove every entry from the registry. Mainly used by tests. */
+  public clear(): void {
+    this.entries.clear();
+    this.pending.clear();
+  }
+
+  /** Retrieve an entry without updating the hit counter (used for diagnostics). */
+  public peek<T>(key: string): IdempotencyEntry<T> | null {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (this.isExpired(entry, this.clock())) {
+      this.entries.delete(key);
+      return null;
+    }
+    return { ...entry, value: this.clone(entry.value as T) };
+  }
+
+  /**
+   * Remember the outcome of an asynchronous operation. The factory is invoked
+   * at most once per key; concurrent callers await the same promise and replay
+   * the stored value once resolved.
+   */
+  public async remember<T>(
+    key: string,
+    factory: MaybeAsyncFactory<T>,
+    options: { ttlMs?: number } = {},
+  ): Promise<IdempotencyHit<T>> {
+    const now = this.clock();
+    const existing = this.entries.get(key);
+    if (existing && !this.isExpired(existing, now)) {
+      existing.hits += 1;
+      existing.lastHitAt = now;
+      return {
+        value: this.clone(existing.value as T),
+        idempotent: true,
+        entry: { ...existing, value: this.clone(existing.value as T) } as IdempotencyEntry<T>,
+      };
+    }
+
+    let pending = this.pending.get(key);
+    if (!pending) {
+      pending = this.executeFactory(key, factory, options.ttlMs);
+      this.pending.set(key, pending);
+    }
+
+    try {
+      const stored = await pending;
+      const value = this.clone(stored.value as T);
+      return {
+        value,
+        idempotent: existing !== undefined && !this.isExpired(existing, now),
+        entry: { ...stored, value: this.clone(stored.value as T) } as IdempotencyEntry<T>,
+      };
+    } finally {
+      this.pending.delete(key);
+    }
+  }
+  /**
+   * Synchronous variant used by helpers that must remain synchronous (e.g.
+   * `tx_begin`). The factory is executed immediately when the key is unknown.
+   */
+  public rememberSync<T>(key: string, factory: () => T, options: { ttlMs?: number } = {}): IdempotencyHit<T> {
+    const now = this.clock();
+    const existing = this.entries.get(key);
+    if (existing && !this.isExpired(existing, now)) {
+      existing.hits += 1;
+      existing.lastHitAt = now;
+      return {
+        value: this.clone(existing.value as T),
+        idempotent: true,
+        entry: { ...existing, value: this.clone(existing.value as T) } as IdempotencyEntry<T>,
+      };
+    }
+
+    const produced = factory();
+    const stored = this.storeInternal(key, produced, options.ttlMs);
+    return {
+      value: this.clone(stored.value as T),
+      idempotent: false,
+      entry: { ...stored, value: this.clone(stored.value as T) } as IdempotencyEntry<T>,
+    };
+  }
+
+  /** Manually remove expired entries. Called periodically by the server. */
+  public pruneExpired(now: number = this.clock()): void {
+    for (const [key, entry] of this.entries) {
+      if (this.isExpired(entry, now)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /** Persist a value without running a factory (used for fixtures/tests). */
+  public store<T>(key: string, value: T, options: { ttlMs?: number } = {}): IdempotencyEntry<T> {
+    const stored = this.storeInternal(key, value, options.ttlMs);
+    return { ...stored, value: this.clone(stored.value as T) } as IdempotencyEntry<T>;
+  }
+
+  private async executeFactory<T>(
+    key: string,
+    factory: MaybeAsyncFactory<T>,
+    ttlOverride?: number,
+  ): Promise<MutableIdempotencyEntry<unknown>> {
+    const value = await factory();
+    return this.storeInternal(key, value, ttlOverride);
+  }
+
+  private storeInternal<T>(key: string, value: T, ttlOverride?: number): MutableIdempotencyEntry<unknown> {
+    const now = this.clock();
+    const ttlMs = this.normaliseTtl(ttlOverride);
+    const entry: MutableIdempotencyEntry<unknown> = {
+      key,
+      value: this.clone(value),
+      storedAt: now,
+      expiresAt: now + ttlMs,
+      hits: 1,
+      lastHitAt: now,
+    };
+    this.entries.set(key, entry);
+    return entry;
+  }
+
+  private normaliseTtl(ttlMs?: number): number {
+    if (ttlMs === undefined || ttlMs === null || Number.isNaN(ttlMs)) {
+      return this.defaultTtlMs;
+    }
+    if (!Number.isFinite(ttlMs)) {
+      return this.defaultTtlMs;
+    }
+    return Math.max(MIN_TTL_MS, ttlMs);
+  }
+
+  private isExpired(entry: IdempotencyEntry<unknown>, now: number): boolean {
+    return now >= entry.expiresAt;
+  }
+
+  private clone<T>(value: T): T {
+    try {
+      return structuredClone(value);
+    } catch {
+      return value;
+    }
+  }
+}
+
+

--- a/src/monitor/dashboard.ts
+++ b/src/monitor/dashboard.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { EventStore, OrchestratorEvent } from "../eventStore.js";
 import { GraphState, GraphStateMetrics } from "../graphState.js";
+import type { ChildRuntimeLimits } from "../childRuntime.js";
 import { ChildSupervisor } from "../childSupervisor.js";
 import { StructuredLogger } from "../logger.js";
 import { StigmergyField } from "../coord/stigmergy.js";
@@ -36,6 +37,12 @@ export interface DashboardSnapshot {
     lastHeartbeatAt: number | null;
     lastActivityAt: number | null;
     waitingFor: string | null;
+    /** High-level role currently advertised for the child. */
+    role: string | null;
+    /** Timestamp of the latest explicit attachment acknowledgement, when available. */
+    attachedAt: number | null;
+    /** Declarative runtime limits captured from the supervisor, if any. */
+    limits: ChildRuntimeLimits | null;
   }>;
 }
 
@@ -515,6 +522,9 @@ function buildSnapshot(
       lastHeartbeatAt: child.lastHeartbeatAt,
       lastActivityAt,
       waitingFor: child.waitingFor,
+      role: child.role,
+      attachedAt: child.attachedAt,
+      limits: child.limits,
     };
   });
   return {

--- a/src/tools/coordTools.ts
+++ b/src/tools/coordTools.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  BlackboardBatchSetInput,
   BlackboardEntrySnapshot,
   BlackboardEvent,
   BlackboardStore,
@@ -21,11 +22,13 @@ import { StructuredLogger } from "../logger.js";
 import {
   ConsensusConfigSchema,
   majority,
+  publishConsensusEvent,
   quorum,
   weighted,
   type ConsensusDecision,
   type ConsensusVote,
 } from "../coord/consensus.js";
+import { IdempotencyRegistry } from "../infra/idempotency.js";
 
 /**
  * Error raised when a requested blackboard key cannot be found. The dedicated
@@ -56,6 +59,8 @@ export interface CoordinationToolContext {
   contractNet: ContractNetCoordinator;
   /** Structured logger used for auditability. */
   logger: StructuredLogger;
+  /** Optional idempotency registry replaying cached coordination results. */
+  idempotency?: IdempotencyRegistry;
 }
 
 /** Schema validating the payload accepted by the `bb_set` tool. */
@@ -66,6 +71,24 @@ export const BbSetInputSchema = z.object({
   ttl_ms: z.number().int().min(1).max(86_400_000).optional(),
 });
 export const BbSetInputShape = BbSetInputSchema.shape;
+
+/** Schema validating the payload accepted by the `bb_batch_set` tool. */
+export const BbBatchSetInputSchema = z.object({
+  entries: z
+    .array(
+      z
+        .object({
+          key: z.string().min(1, "key must not be empty"),
+          value: z.unknown(),
+          tags: z.array(z.string().min(1)).max(16).default([]),
+          ttl_ms: z.number().int().min(1).max(86_400_000).optional(),
+        })
+        .strict(),
+    )
+    .min(1, "at least one entry must be provided")
+    .max(100, "cannot update more than 100 entries at once"),
+});
+export const BbBatchSetInputShape = BbBatchSetInputSchema.shape;
 
 /** Schema validating the payload accepted by the `bb_get` tool. */
 export const BbGetInputSchema = z.object({
@@ -131,6 +154,24 @@ export const StigMarkInputSchema = z.object({
 });
 export const StigMarkInputShape = StigMarkInputSchema.shape;
 
+export const StigBatchInputSchema = z
+  .object({
+    entries: z
+      .array(
+        z
+          .object({
+            node_id: z.string().min(1, "node_id must not be empty"),
+            type: z.string().min(1, "type must not be empty"),
+            intensity: z.number().positive().max(10_000, "intensity must remain bounded"),
+          })
+          .strict(),
+      )
+      .min(1, "at least one entry must be provided")
+      .max(200, "cannot apply more than 200 entries at once"),
+  })
+  .strict();
+export const StigBatchInputShape = StigBatchInputSchema.shape;
+
 /** Schema validating the payload accepted by the `stig_decay` tool. */
 export const StigDecayInputSchema = z.object({
   half_life_ms: z.number().int().positive().max(86_400_000, "half_life_ms too large"),
@@ -171,12 +212,18 @@ export const CnpAnnounceInputSchema = z
       )
       .max(128)
       .optional(),
+    idempotency_key: z.string().min(1).optional(),
   })
   .strict();
 export const CnpAnnounceInputShape = CnpAnnounceInputSchema.shape;
 
 /** Result returned by {@link handleBbSet}. */
 export interface BbSetResult extends SerializedBlackboardEntry {}
+
+/** Result returned by {@link handleBbBatchSet}. */
+export interface BbBatchSetResult extends Record<string, unknown> {
+  entries: SerializedBlackboardEntry[];
+}
 
 /** Result returned by {@link handleBbGet}. */
 export interface BbGetResult extends Record<string, unknown> {
@@ -244,6 +291,11 @@ export interface StigDecayResult extends Record<string, unknown> {
   changes: SerializedStigmergyChange[];
 }
 
+/** Result returned by {@link handleStigBatch}. */
+export interface StigBatchResult extends Record<string, unknown> {
+  changes: SerializedStigmergyChange[];
+}
+
 /** Result returned by {@link handleStigSnapshot}. */
 export interface StigSnapshotResult extends Record<string, unknown> {
   generated_at: number;
@@ -293,6 +345,8 @@ export interface CnpAnnounceResult extends Record<string, unknown> {
   awarded_effective_cost: number;
   bids: SerializedContractNetBid[];
   heuristics: SerializedContractNetHeuristics;
+  idempotent: boolean;
+  idempotency_key: string | null;
 }
 
 /**
@@ -314,6 +368,29 @@ export function handleBbSet(
     ttl_ms: input.ttl_ms ?? null,
   });
   return serialiseEntry(snapshot);
+}
+
+/**
+ * Atomically applies multiple {@link handleBbSet} style mutations on the
+ * blackboard. The helper ensures downstream observers receive a consistent
+ * batch even if one of the values cannot be cloned.
+ */
+export function handleBbBatchSet(
+  context: CoordinationToolContext,
+  input: z.infer<typeof BbBatchSetInputSchema>,
+): BbBatchSetResult {
+  const payloads: BlackboardBatchSetInput[] = input.entries.map((entry) => ({
+    key: entry.key,
+    value: entry.value,
+    tags: entry.tags,
+    ttlMs: entry.ttl_ms,
+  }));
+  const snapshots = context.blackboard.batchSet(payloads);
+  context.logger.info("bb_batch_set", {
+    entries: snapshots.length,
+    keys: snapshots.map((entry) => entry.key),
+  });
+  return { entries: snapshots.map(serialiseEntry) };
 }
 
 /** Retrieves a single entry when available. */
@@ -445,6 +522,30 @@ export function handleStigDecay(
   };
 }
 
+/** Applies several pheromone markings atomically. */
+export function handleStigBatch(
+  context: CoordinationToolContext,
+  input: z.infer<typeof StigBatchInputSchema>,
+): StigBatchResult {
+  const applied = context.stigmergy.batchMark(
+    input.entries.map((entry) => ({
+      nodeId: entry.node_id,
+      type: entry.type,
+      intensity: entry.intensity,
+    })),
+  );
+  const serialised = applied.map((change) => ({
+    point: serialisePoint(change.point),
+    node_total: serialiseTotal(change.nodeTotal),
+  }));
+  const uniqueNodes = new Set(serialised.map((change) => change.point.node_id));
+  context.logger.info("stig_batch", {
+    entries: input.entries.length,
+    nodes: uniqueNodes.size,
+  });
+  return { changes: serialised };
+}
+
 /** Returns a deterministic snapshot of the stigmergic field. */
 export function handleStigSnapshot(
   context: CoordinationToolContext,
@@ -488,42 +589,63 @@ export function handleCnpAnnounce(
   context: CoordinationToolContext,
   input: z.infer<typeof CnpAnnounceInputSchema>,
 ): CnpAnnounceResult {
-  const announcement = context.contractNet.announce({
-    taskId: input.task_id,
-    payload: input.payload,
-    tags: input.tags,
-    metadata: input.metadata,
-    deadlineMs: input.deadline_ms ?? null,
-    autoBid: input.auto_bid,
-    heuristics: {
-      preferAgents: input.heuristics?.prefer_agents,
-      agentBias: input.heuristics?.agent_bias,
-      busyPenalty: input.heuristics?.busy_penalty,
-      preferenceBonus: input.heuristics?.preference_bonus,
-    },
-  });
+  const execute = (): Omit<CnpAnnounceResult, "idempotent" | "idempotency_key"> => {
+    const announcement = context.contractNet.announce({
+      taskId: input.task_id,
+      payload: input.payload,
+      tags: input.tags,
+      metadata: input.metadata,
+      deadlineMs: input.deadline_ms ?? null,
+      autoBid: input.auto_bid,
+      heuristics: {
+        preferAgents: input.heuristics?.prefer_agents,
+        agentBias: input.heuristics?.agent_bias,
+        busyPenalty: input.heuristics?.busy_penalty,
+        preferenceBonus: input.heuristics?.preference_bonus,
+      },
+    });
 
-  if (input.manual_bids) {
-    for (const bid of input.manual_bids) {
-      context.contractNet.bid(announcement.callId, bid.agent_id, bid.cost, {
-        metadata: bid.metadata ?? {},
+    if (input.manual_bids) {
+      for (const bid of input.manual_bids) {
+        context.contractNet.bid(announcement.callId, bid.agent_id, bid.cost, {
+          metadata: bid.metadata ?? {},
+        });
+      }
+    }
+
+    const decision = context.contractNet.award(announcement.callId);
+    const snapshot = context.contractNet.getCall(announcement.callId);
+    if (!snapshot) {
+      throw new Error(`call ${announcement.callId} disappeared after award`);
+    }
+
+    context.logger.info("cnp_announce", {
+      call_id: snapshot.callId,
+      bids: snapshot.bids.length,
+      awarded_agent_id: decision.agentId,
+      idempotency_key: input.idempotency_key ?? null,
+    });
+
+    return serialiseContractNetResult(snapshot, decision);
+  };
+
+  const key = input.idempotency_key ?? null;
+  if (context.idempotency && key) {
+    const hit = context.idempotency.rememberSync(`cnp_announce:${key}`, execute);
+    if (hit.idempotent) {
+      const snapshot = hit.value as ReturnType<typeof execute>;
+      context.logger.info("cnp_announce_replayed", {
+        call_id: snapshot.call_id,
+        awarded_agent_id: snapshot.awarded_agent_id,
+        idempotency_key: key,
       });
     }
+    const snapshot = hit.value as ReturnType<typeof execute>;
+    return { ...snapshot, idempotent: hit.idempotent, idempotency_key: key } as CnpAnnounceResult;
   }
 
-  const decision = context.contractNet.award(announcement.callId);
-  const snapshot = context.contractNet.getCall(announcement.callId);
-  if (!snapshot) {
-    throw new Error(`call ${announcement.callId} disappeared after award`);
-  }
-
-  context.logger.info("cnp_announce", {
-    call_id: snapshot.callId,
-    bids: snapshot.bids.length,
-    awarded_agent_id: decision.agentId,
-  });
-
-  return serialiseContractNetResult(snapshot, decision);
+  const snapshot = execute();
+  return { ...snapshot, idempotent: false, idempotency_key: key } as CnpAnnounceResult;
 }
 
 /**
@@ -570,6 +692,29 @@ export function handleConsensusVote(
     total_weight: decision.totalWeight,
   });
 
+  // Broadcast the computed decision so observers subscribed to the consensus
+  // bridge receive a structured update on quorum evaluations triggered via the
+  // coordination tool surface.
+  publishConsensusEvent({
+    kind: "decision",
+    source: "consensus_vote",
+    mode: decision.mode,
+    outcome: decision.outcome,
+    satisfied: decision.satisfied,
+    tie: decision.tie,
+    threshold: decision.threshold ?? null,
+    totalWeight: decision.totalWeight,
+    tally: decision.tally,
+    votes: votes.length,
+    metadata: {
+      requested_mode: config.mode,
+      requested_quorum: config.quorum ?? null,
+      weights: config.weights ?? {},
+      tie_breaker: config.tie_breaker,
+      prefer_value: config.prefer_value ?? null,
+    },
+  });
+
   return {
     mode: decision.mode,
     outcome: decision.outcome,
@@ -585,7 +730,7 @@ export function handleConsensusVote(
 function serialiseContractNetResult(
   snapshot: ContractNetCallSnapshot,
   decision: ContractNetAwardDecision,
-): CnpAnnounceResult {
+): Omit<CnpAnnounceResult, "idempotent" | "idempotency_key"> {
   return {
     call_id: snapshot.callId,
     task_id: snapshot.taskId,

--- a/src/tools/graphBatchTools.ts
+++ b/src/tools/graphBatchTools.ts
@@ -1,0 +1,168 @@
+import { z } from "zod";
+
+import {
+  GraphTransactionManager,
+  GraphTransactionError,
+  GraphVersionConflictError,
+} from "../graph/tx.js";
+import type { GraphLockManager } from "../graph/locks.js";
+import type { ResourceRegistry } from "../resources/registry.js";
+import { IdempotencyRegistry } from "../infra/idempotency.js";
+import {
+  GraphMutateInputSchema,
+  handleGraphMutate,
+  normaliseGraphPayload,
+  serialiseNormalisedGraph,
+  type GraphMutateInput,
+  type GraphMutationRecord,
+} from "./graphTools.js";
+
+/** Context injected in the graph batch mutation handler. */
+export interface GraphBatchToolContext {
+  transactions: GraphTransactionManager;
+  resources: ResourceRegistry;
+  locks: GraphLockManager;
+  idempotency?: IdempotencyRegistry;
+}
+
+const GraphBatchOperationSchema = GraphMutateInputSchema.shape.operations.element;
+
+/** Schema accepted by the `graph_batch_mutate` tool. */
+export const GraphBatchMutateInputSchema = z
+  .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    operations: z
+      .array(GraphBatchOperationSchema)
+      .min(1, "at least one operation must be provided")
+      .max(200, "cannot apply more than 200 operations at once"),
+    expected_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    idempotency_key: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const GraphBatchMutateInputShape = GraphBatchMutateInputSchema.shape;
+
+export type GraphBatchMutateInput = z.infer<typeof GraphBatchMutateInputSchema>;
+
+interface GraphBatchMutateSnapshot extends Record<string, unknown> {
+  graph_id: string;
+  base_version: number;
+  committed_version: number;
+  committed_at: number;
+  changed: boolean;
+  operations_applied: number;
+  applied: GraphMutationRecord[];
+  graph: ReturnType<typeof serialiseNormalisedGraph>;
+  owner: string | null;
+  note: string | null;
+}
+
+/** Result returned by {@link handleGraphBatchMutate}. */
+export interface GraphBatchMutateResult extends GraphBatchMutateSnapshot {
+  idempotent: boolean;
+  idempotency_key: string | null;
+}
+
+/**
+ * Applies a batch of idempotent graph operations on the latest committed
+ * descriptor. The helper opens an ephemeral transaction, ensuring callers
+ * observe the mutation atomically while replaying cached results when an
+ * idempotency key is provided.
+ */
+export async function handleGraphBatchMutate(
+  context: GraphBatchToolContext,
+  input: GraphBatchMutateInput,
+): Promise<GraphBatchMutateResult> {
+  const execute = async (): Promise<GraphBatchMutateSnapshot> => {
+    const committed = context.transactions.getCommittedState(input.graph_id);
+    if (!committed) {
+      throw new GraphTransactionError(`graph '${input.graph_id}' has no committed state`);
+    }
+
+    if (input.expected_version !== undefined && committed.version !== input.expected_version) {
+      throw new GraphVersionConflictError(input.graph_id, committed.version, input.expected_version);
+    }
+
+    context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+
+    const tx = context.transactions.begin(committed.graph, {
+      owner: input.owner ?? null,
+      note: input.note ?? null,
+    });
+    context.resources.recordGraphSnapshot({
+      graphId: tx.graphId,
+      txId: tx.txId,
+      baseVersion: tx.baseVersion,
+      startedAt: tx.startedAt,
+      graph: tx.workingCopy,
+      owner: tx.owner,
+      note: tx.note,
+      expiresAt: tx.expiresAt,
+    });
+
+    let committedResult: ReturnType<GraphTransactionManager["commit"]> | null = null;
+    try {
+      const mutateInput: GraphMutateInput = {
+        graph: serialiseNormalisedGraph(tx.workingCopy),
+        operations: input.operations as GraphMutateInput["operations"],
+      };
+      const mutation = handleGraphMutate(mutateInput);
+      const normalised = normaliseGraphPayload(mutation.graph);
+
+      context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+      committedResult = context.transactions.commit(tx.txId, normalised);
+
+      context.resources.markGraphSnapshotCommitted({
+        graphId: committedResult.graphId,
+        txId: committedResult.txId,
+        committedAt: committedResult.committedAt,
+        finalVersion: committedResult.version,
+        finalGraph: committedResult.graph,
+      });
+      context.resources.recordGraphVersion({
+        graphId: committedResult.graphId,
+        version: committedResult.version,
+        committedAt: committedResult.committedAt,
+        graph: committedResult.graph,
+      });
+
+      const changed = mutation.applied.some((entry) => entry.changed);
+      return {
+        graph_id: committedResult.graphId,
+        base_version: tx.baseVersion,
+        committed_version: committedResult.version,
+        committed_at: committedResult.committedAt,
+        changed,
+        operations_applied: mutation.applied.length,
+        applied: mutation.applied,
+        graph: serialiseNormalisedGraph(committedResult.graph),
+        owner: tx.owner,
+        note: tx.note,
+      };
+    } catch (error) {
+      try {
+        context.transactions.rollback(tx.txId);
+        context.resources.markGraphSnapshotRolledBack(tx.graphId, tx.txId);
+      } catch {
+        // Ignored: the initial error is more relevant for callers.
+      }
+      throw error;
+    }
+  };
+
+  const key = input.idempotency_key ?? null;
+  if (context.idempotency && key) {
+    const hit = await context.idempotency.remember<GraphBatchMutateSnapshot>(
+      `graph_batch_mutate:${key}`,
+      execute,
+    );
+    const snapshot = hit.value as GraphBatchMutateSnapshot;
+    return { ...snapshot, idempotent: hit.idempotent, idempotency_key: key };
+  }
+
+  const snapshot = await execute();
+  return { ...snapshot, idempotent: false, idempotency_key: key };
+}
+

--- a/src/tools/graphDiffTools.ts
+++ b/src/tools/graphDiffTools.ts
@@ -1,0 +1,258 @@
+import { z } from "zod";
+
+import { diffGraphs, type GraphDiffResult as InternalDiffResult, type JsonPatchOperation } from "../graph/diff.js";
+import { applyGraphPatch } from "../graph/patch.js";
+import { evaluateGraphInvariants, GraphInvariantError, type GraphInvariantReport } from "../graph/invariants.js";
+import type { GraphLockManager } from "../graph/locks.js";
+import {
+  GraphTransactionManager,
+  GraphTransactionError,
+  GraphVersionConflictError,
+  type BeginTransactionResult,
+} from "../graph/tx.js";
+import type { NormalisedGraph } from "../graph/types.js";
+import type { ResourceRegistry, ResourceGraphPayload } from "../resources/registry.js";
+import {
+  GraphDescriptorSchema,
+  normaliseGraphPayload,
+  serialiseNormalisedGraph,
+  type GraphDescriptorPayload,
+} from "./graphTools.js";
+
+/** Context injected in the diff/patch tool handlers. */
+export interface GraphDiffToolContext {
+  transactions: GraphTransactionManager;
+  resources: ResourceRegistry;
+  locks: GraphLockManager;
+}
+
+/** Schema describing a graph selector used by the diff tool. */
+const GraphSelectorSchema = z.union([
+  z.object({ latest: z.literal(true) }).strict(),
+  z.object({ version: z.number().int().nonnegative() }).strict(),
+  z.object({ graph: GraphDescriptorSchema }).strict(),
+]);
+
+/** Schema describing a RFC 6902 operation accepted by graph_patch. */
+export const GraphPatchOperationSchema = z
+  .object({
+    op: z.enum(["add", "remove", "replace"]),
+    path: z.string().min(1, "path must not be empty"),
+    value: z.unknown().optional(),
+  })
+  .strict();
+
+/** Schema accepted by the graph_diff tool. */
+export const GraphDiffInputSchema = z
+  .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    from: GraphSelectorSchema,
+    to: GraphSelectorSchema,
+  })
+  .strict();
+
+/** Schema accepted by the graph_patch tool. */
+export const GraphPatchInputSchema = z
+  .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    base_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    enforce_invariants: z.boolean().default(true),
+    patch: z.array(GraphPatchOperationSchema).min(1, "at least one patch operation is required"),
+  })
+  .strict();
+
+export const GraphDiffInputShape = GraphDiffInputSchema.shape;
+export const GraphPatchInputShape = GraphPatchInputSchema.shape;
+
+export type GraphDiffInput = z.infer<typeof GraphDiffInputSchema>;
+export type GraphPatchInput = z.infer<typeof GraphPatchInputSchema>;
+export type GraphPatchOperationInput = z.infer<typeof GraphPatchOperationSchema>;
+
+/** Summary describing the source of a selector resolved by graph_diff. */
+export interface GraphSelectorSummary {
+  source: "latest" | "version" | "descriptor";
+  version: number | null;
+}
+
+/** Result returned by {@link handleGraphDiff}. */
+export interface GraphDiffResult extends Record<string, unknown> {
+  graph_id: string;
+  from: GraphSelectorSummary;
+  to: GraphSelectorSummary;
+  changed: boolean;
+  operations: JsonPatchOperation[];
+  summary: InternalDiffResult["summary"];
+}
+
+/** Result returned by {@link handleGraphPatch}. */
+export interface GraphPatchResult extends Record<string, unknown> {
+  graph_id: string;
+  base_version: number;
+  committed_version: number;
+  changed: boolean;
+  operations_applied: number;
+  invariants: GraphInvariantReport | null;
+  graph: GraphDescriptorPayload;
+}
+
+/** Compute a diff between two graph selectors. */
+export function handleGraphDiff(context: GraphDiffToolContext, input: GraphDiffInput): GraphDiffResult {
+  const resolvedFrom = resolveGraphSelector(context, input.graph_id, input.from);
+  const resolvedTo = resolveGraphSelector(context, input.graph_id, input.to);
+
+  const diff = diffGraphs(resolvedFrom.graph, resolvedTo.graph);
+  return {
+    graph_id: input.graph_id,
+    from: resolvedFrom.summary,
+    to: resolvedTo.summary,
+    changed: diff.changed,
+    operations: diff.operations,
+    summary: diff.summary,
+  };
+}
+
+/** Apply a JSON Patch on top of the latest committed graph. */
+export function handleGraphPatch(context: GraphDiffToolContext, input: GraphPatchInput): GraphPatchResult {
+  const committed = ensureCommittedState(context, input.graph_id);
+  if (input.base_version !== undefined && input.base_version !== committed.version) {
+    throw new GraphVersionConflictError(input.graph_id, committed.version, input.base_version);
+  }
+
+  context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+
+  const tx = context.transactions.begin(committed.graph, {
+    owner: input.owner ?? null,
+    note: input.note ?? null,
+  });
+  context.resources.recordGraphSnapshot({
+    graphId: tx.graphId,
+    txId: tx.txId,
+    baseVersion: tx.baseVersion,
+    startedAt: tx.startedAt,
+    graph: tx.workingCopy,
+    owner: tx.owner,
+    note: tx.note,
+    expiresAt: tx.expiresAt,
+  });
+
+  let invariants: GraphInvariantReport | null = null;
+  let committedResult: ReturnType<GraphTransactionManager["commit"]> | null = null;
+  try {
+    const patched = applyGraphPatch(committed.graph, input.patch);
+    const normalised = normaliseGraphPayload(serialiseNormalisedGraph(patched));
+
+    if (input.enforce_invariants) {
+      invariants = evaluateGraphInvariants(normalised);
+      if (!invariants.ok) {
+        throw new GraphInvariantError(invariants.violations);
+      }
+    }
+
+    const diff = diffGraphs(committed.graph, normalised);
+    const changed = diff.changed;
+
+    context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+    context.transactions.setWorkingCopy(tx.txId, normalised);
+    committedResult = context.transactions.commit(tx.txId, normalised);
+
+    context.resources.markGraphSnapshotCommitted({
+      graphId: committedResult.graphId,
+      txId: committedResult.txId,
+      committedAt: committedResult.committedAt,
+      finalVersion: committedResult.version,
+      finalGraph: committedResult.graph,
+    });
+    context.resources.recordGraphVersion({
+      graphId: committedResult.graphId,
+      version: committedResult.version,
+      committedAt: committedResult.committedAt,
+      graph: committedResult.graph,
+    });
+
+    return {
+      graph_id: committedResult.graphId,
+      base_version: tx.baseVersion,
+      committed_version: committedResult.version,
+      changed,
+      operations_applied: input.patch.length,
+      invariants,
+      graph: serialiseNormalisedGraph(committedResult.graph),
+    };
+  } catch (error) {
+    try {
+      context.transactions.rollback(tx.txId);
+    } catch (rollbackError) {
+      // Ignored: the transaction has already failed, the caller is primarily interested in the original error.
+      void rollbackError;
+    }
+    context.resources.markGraphSnapshotRolledBack(tx.graphId, tx.txId);
+    throw error;
+  }
+}
+
+/** Resolve a selector into a normalised graph and a descriptive summary. */
+function resolveGraphSelector(
+  context: GraphDiffToolContext,
+  graphId: string,
+  selector: z.infer<typeof GraphSelectorSchema>,
+): { graph: NormalisedGraph; summary: GraphSelectorSummary } {
+  if ("graph" in selector) {
+    const normalised = normaliseGraphPayload(selector.graph);
+    return {
+      graph: normalised,
+      summary: { source: "descriptor", version: normalised.graphVersion ?? null },
+    };
+  }
+  if ("version" in selector) {
+    const resource = context.resources.read(`sc://graphs/${graphId}@v${selector.version}`);
+    const payload = resource.payload as ResourceGraphPayload;
+    return {
+      graph: structuredClone(payload.graph) as NormalisedGraph,
+      summary: { source: "version", version: payload.version },
+    };
+  }
+  const resource = context.resources.read(`sc://graphs/${graphId}`);
+  const payload = resource.payload as ResourceGraphPayload;
+  return {
+    graph: structuredClone(payload.graph) as NormalisedGraph,
+    summary: { source: "latest", version: payload.version },
+  };
+}
+
+/** Ensure the transaction manager knows about the latest committed graph state. */
+function ensureCommittedState(
+  context: GraphDiffToolContext,
+  graphId: string,
+): { graph: NormalisedGraph; version: number } {
+  const committed = context.transactions.getCommittedState(graphId);
+  if (committed) {
+    return { graph: committed.graph, version: committed.version };
+  }
+
+  const resource = context.resources.read(`sc://graphs/${graphId}`);
+  const payload = resource.payload as ResourceGraphPayload;
+  bootstrapCommittedState(context.transactions, payload.graph);
+  const refreshed = context.transactions.getCommittedState(graphId);
+  if (!refreshed) {
+    throw new GraphTransactionError(`unable to register committed state for graph '${graphId}'`);
+  }
+  return { graph: refreshed.graph, version: refreshed.version };
+}
+
+/** Register a committed graph in the transaction manager without mutating it. */
+function bootstrapCommittedState(transactions: GraphTransactionManager, graph: NormalisedGraph): void {
+  let tx: BeginTransactionResult | null = null;
+  try {
+    tx = transactions.begin(graph);
+  } finally {
+    if (tx) {
+      try {
+        transactions.rollback(tx.txId);
+      } catch (error) {
+        void error;
+      }
+    }
+  }
+}

--- a/src/tools/graphLockTools.ts
+++ b/src/tools/graphLockTools.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+import type { GraphLockManager, GraphLockSnapshot, GraphLockReleaseResult } from "../graph/locks.js";
+
+/** Context injected in the graph lock MCP tool handlers. */
+export interface GraphLockToolContext {
+  locks: GraphLockManager;
+}
+
+/** Schema accepted by the graph_lock tool. */
+export const GraphLockInputSchema = z
+  .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    holder: z.string().trim().min(1, "holder is required").max(120, "holder is too long"),
+    ttl_ms: z.number().int().positive().max(86_400_000).optional(),
+  })
+  .strict();
+
+/** Schema accepted by the graph_unlock tool. */
+export const GraphUnlockInputSchema = z
+  .object({
+    lock_id: z.string().uuid(),
+  })
+  .strict();
+
+export const GraphLockInputShape = GraphLockInputSchema.shape;
+export const GraphUnlockInputShape = GraphUnlockInputSchema.shape;
+
+export type GraphLockInput = z.infer<typeof GraphLockInputSchema>;
+export type GraphUnlockInput = z.infer<typeof GraphUnlockInputSchema>;
+
+/** Result returned when a graph lock is acquired. */
+export interface GraphLockResult extends Record<string, unknown> {
+  lock_id: string;
+  graph_id: string;
+  holder: string;
+  acquired_at: number;
+  refreshed_at: number;
+  expires_at: number | null;
+}
+
+/** Result returned when a graph lock is released. */
+export interface GraphUnlockResult extends Record<string, unknown> {
+  lock_id: string;
+  graph_id: string;
+  holder: string;
+  released_at: number;
+  expired: boolean;
+  expires_at: number | null;
+}
+
+/** Acquire or refresh the lock guarding a graph. */
+export function handleGraphLock(context: GraphLockToolContext, input: GraphLockInput): GraphLockResult {
+  const snapshot = context.locks.acquire(input.graph_id, input.holder, { ttlMs: input.ttl_ms ?? null });
+  return formatLockSnapshot(snapshot);
+}
+
+/** Release the lock guarding a graph. */
+export function handleGraphUnlock(context: GraphLockToolContext, input: GraphUnlockInput): GraphUnlockResult {
+  const result = context.locks.release(input.lock_id);
+  return formatLockRelease(result);
+}
+
+function formatLockSnapshot(snapshot: GraphLockSnapshot): GraphLockResult {
+  return {
+    lock_id: snapshot.lockId,
+    graph_id: snapshot.graphId,
+    holder: snapshot.holder,
+    acquired_at: snapshot.acquiredAt,
+    refreshed_at: snapshot.refreshedAt,
+    expires_at: snapshot.expiresAt,
+  };
+}
+
+function formatLockRelease(result: GraphLockReleaseResult): GraphUnlockResult {
+  return {
+    lock_id: result.lockId,
+    graph_id: result.graphId,
+    holder: result.holder,
+    released_at: result.releasedAt,
+    expired: result.expired,
+    expires_at: result.expiresAt,
+  };
+}

--- a/src/tools/txTools.ts
+++ b/src/tools/txTools.ts
@@ -1,0 +1,291 @@
+import { z } from "zod";
+
+import {
+  GraphTransactionManager,
+  GraphTransactionError,
+  GraphVersionConflictError,
+  type BeginTransactionResult,
+} from "../graph/tx.js";
+import type { GraphLockManager } from "../graph/locks.js";
+import { IdempotencyRegistry } from "../infra/idempotency.js";
+import { normaliseGraphPayload, serialiseNormalisedGraph, GraphDescriptorSchema, GraphMutateInputSchema, handleGraphMutate } from "./graphTools.js";
+import type { GraphMutateInput } from "./graphTools.js";
+import type { ResourceGraphPayload, ResourceRegistry } from "../resources/registry.js";
+import type { NormalisedGraph } from "../graph/types.js";
+
+/** Context injected in the transaction tool handlers. */
+export interface TxToolContext {
+  /** Shared transaction manager guarding optimistic concurrency. */
+  transactions: GraphTransactionManager;
+  /** Resource registry capturing snapshots and committed versions. */
+  resources: ResourceRegistry;
+  /** Cooperative lock manager guarding graph mutations. */
+  locks: GraphLockManager;
+  /** Optional idempotency registry replaying cached transaction descriptors. */
+  idempotency?: IdempotencyRegistry;
+}
+
+/** Schema accepted by the `tx_begin` tool. */
+export const TxBeginInputSchema = z
+  .object({
+    graph_id: z.string().min(1, "graph_id is required"),
+    expected_version: z.number().int().nonnegative().optional(),
+    owner: z.string().trim().min(1).max(120).optional(),
+    note: z.string().trim().min(1).max(240).optional(),
+    ttl_ms: z.number().int().positive().max(86_400_000).optional(),
+    graph: GraphDescriptorSchema.optional(),
+    idempotency_key: z.string().min(1).optional(),
+  })
+  .strict();
+
+/** Schema accepted by the `tx_apply` tool. */
+export const TxApplyInputSchema = z
+  .object({
+    tx_id: z.string().uuid(),
+    operations: z
+      .array(GraphMutateInputSchema.shape.operations.element)
+      .min(1, "at least one operation must be provided"),
+  })
+  .strict();
+
+/** Schema accepted by the `tx_commit` tool. */
+export const TxCommitInputSchema = z
+  .object({
+    tx_id: z.string().uuid(),
+  })
+  .strict();
+
+/** Schema accepted by the `tx_rollback` tool. */
+export const TxRollbackInputSchema = z
+  .object({
+    tx_id: z.string().uuid(),
+  })
+  .strict();
+
+export const TxBeginInputShape = TxBeginInputSchema.shape;
+export const TxApplyInputShape = TxApplyInputSchema.shape;
+export const TxCommitInputShape = TxCommitInputSchema.shape;
+export const TxRollbackInputShape = TxRollbackInputSchema.shape;
+
+export type TxBeginInput = z.infer<typeof TxBeginInputSchema>;
+export type TxApplyInput = z.infer<typeof TxApplyInputSchema>;
+export type TxCommitInput = z.infer<typeof TxCommitInputSchema>;
+export type TxRollbackInput = z.infer<typeof TxRollbackInputSchema>;
+
+/** Result returned by {@link handleTxBegin}. */
+export interface TxBeginResult {
+  tx_id: string;
+  graph_id: string;
+  base_version: number;
+  started_at: number;
+  owner: string | null;
+  note: string | null;
+  expires_at: number | null;
+  graph: ReturnType<typeof serialiseNormalisedGraph>;
+  idempotent: boolean;
+  idempotency_key: string | null;
+}
+
+/** Result returned by {@link handleTxApply}. */
+export interface TxApplyResult {
+  tx_id: string;
+  graph_id: string;
+  base_version: number;
+  /** Indicates the optimistic version the graph would reach if committed. */
+  preview_version: number;
+  owner: string | null;
+  note: string | null;
+  expires_at: number | null;
+  /** Set to true when at least one operation mutated the working copy. */
+  changed: boolean;
+  applied: ReturnType<typeof handleGraphMutate>["applied"];
+  graph: ReturnType<typeof serialiseNormalisedGraph>;
+}
+
+/** Result returned by {@link handleTxCommit}. */
+export interface TxCommitResult {
+  tx_id: string;
+  graph_id: string;
+  version: number;
+  committed_at: number;
+  graph: ReturnType<typeof serialiseNormalisedGraph>;
+}
+
+/** Result returned by {@link handleTxRollback}. */
+export interface TxRollbackResult {
+  tx_id: string;
+  graph_id: string;
+  version: number;
+  rolled_back_at: number;
+  snapshot: ReturnType<typeof serialiseNormalisedGraph>;
+}
+
+/** Opens a new transaction, returning a working copy that can be mutated server-side. */
+export function handleTxBegin(context: TxToolContext, input: TxBeginInput): TxBeginResult {
+  const execute = (): TxBeginSnapshot => {
+    const baseGraph = resolveBaseGraph(context, input);
+    if (input.expected_version !== undefined && baseGraph.graphVersion !== input.expected_version) {
+      throw new GraphVersionConflictError(input.graph_id, baseGraph.graphVersion, input.expected_version);
+    }
+
+    context.locks.assertCanMutate(input.graph_id, input.owner ?? null);
+
+    const opened = context.transactions.begin(baseGraph, {
+      owner: input.owner ?? null,
+      note: input.note ?? null,
+      ttlMs: input.ttl_ms ?? null,
+    });
+
+    context.resources.recordGraphSnapshot({
+      graphId: opened.graphId,
+      txId: opened.txId,
+      baseVersion: opened.baseVersion,
+      startedAt: opened.startedAt,
+      graph: opened.workingCopy,
+      owner: opened.owner,
+      note: opened.note,
+      expiresAt: opened.expiresAt,
+    });
+
+    return formatBeginResult(opened);
+  };
+
+  const key = input.idempotency_key ?? null;
+  if (context.idempotency && key) {
+    const hit = context.idempotency.rememberSync<TxBeginSnapshot>(`tx_begin:${key}`, execute);
+    const snapshot = hit.value as TxBeginSnapshot;
+    return { ...snapshot, idempotent: hit.idempotent, idempotency_key: key } as TxBeginResult;
+  }
+
+  const snapshot = execute();
+  return { ...snapshot, idempotent: false, idempotency_key: key } as TxBeginResult;
+}
+
+/** Applies graph operations to the transaction working copy. */
+export function handleTxApply(context: TxToolContext, input: TxApplyInput): TxApplyResult {
+  // Retrieve a defensive copy so mutations occur on a fresh descriptor.
+  const workingCopy = context.transactions.getWorkingCopy(input.tx_id);
+  const metadata = context.transactions.describe(input.tx_id);
+
+  context.locks.assertCanMutate(metadata.graphId, metadata.owner);
+
+  const mutateInput: GraphMutateInput = {
+    graph: serialiseNormalisedGraph(workingCopy),
+    operations: input.operations as GraphMutateInput["operations"],
+  };
+  const result = handleGraphMutate(mutateInput);
+  context.transactions.setWorkingCopy(input.tx_id, normaliseGraphPayload(result.graph));
+
+  const changed = result.applied.some((entry) => entry.changed);
+  const previewVersion = changed ? metadata.baseVersion + 1 : metadata.baseVersion;
+
+  return {
+    tx_id: input.tx_id,
+    graph_id: metadata.graphId,
+    base_version: metadata.baseVersion,
+    preview_version: previewVersion,
+    owner: metadata.owner,
+    note: metadata.note,
+    expires_at: metadata.expiresAt,
+    changed,
+    applied: result.applied,
+    graph: result.graph,
+  };
+}
+
+/** Commits the transaction, returning the updated graph descriptor. */
+export function handleTxCommit(context: TxToolContext, input: TxCommitInput): TxCommitResult {
+  const metadata = context.transactions.describe(input.tx_id);
+  context.locks.assertCanMutate(metadata.graphId, metadata.owner);
+
+  const workingCopy = context.transactions.getWorkingCopy(input.tx_id);
+  const committed = context.transactions.commit(input.tx_id, workingCopy);
+
+  context.resources.markGraphSnapshotCommitted({
+    graphId: committed.graphId,
+    txId: committed.txId,
+    committedAt: committed.committedAt,
+    finalVersion: committed.version,
+    finalGraph: committed.graph,
+  });
+  context.resources.recordGraphVersion({
+    graphId: committed.graphId,
+    version: committed.version,
+    committedAt: committed.committedAt,
+    graph: committed.graph,
+  });
+
+  return {
+    tx_id: committed.txId,
+    graph_id: committed.graphId,
+    version: committed.version,
+    committed_at: committed.committedAt,
+    graph: serialiseNormalisedGraph(committed.graph),
+  };
+}
+
+/** Rolls back the transaction, returning the original snapshot. */
+export function handleTxRollback(context: TxToolContext, input: TxRollbackInput): TxRollbackResult {
+  const rolled = context.transactions.rollback(input.tx_id);
+  context.resources.markGraphSnapshotRolledBack(rolled.graphId, rolled.txId);
+  return {
+    tx_id: rolled.txId,
+    graph_id: rolled.graphId,
+    version: rolled.version,
+    rolled_back_at: rolled.rolledBackAt,
+    snapshot: serialiseNormalisedGraph(rolled.snapshot),
+  };
+}
+
+/** Formats the begin result into the tool payload. */
+type TxBeginSnapshot = Omit<TxBeginResult, "idempotent" | "idempotency_key">;
+
+function formatBeginResult(opened: BeginTransactionResult): TxBeginSnapshot {
+  return {
+    tx_id: opened.txId,
+    graph_id: opened.graphId,
+    base_version: opened.baseVersion,
+    started_at: opened.startedAt,
+    owner: opened.owner,
+    note: opened.note,
+    expires_at: opened.expiresAt,
+    graph: serialiseNormalisedGraph(opened.workingCopy),
+  };
+}
+
+/**
+ * Retrieves the base graph used to open a transaction, either from the request
+ * payload or from the committed state tracked by the manager/registry.
+ */
+function resolveBaseGraph(context: TxToolContext, input: TxBeginInput): NormalisedGraph {
+  if (input.graph) {
+    const normalised = normaliseGraphPayload(input.graph);
+    if (normalised.graphId !== input.graph_id) {
+      throw new GraphTransactionError(
+        `graph payload id '${normalised.graphId}' does not match requested graph_id '${input.graph_id}'`,
+      );
+    }
+    return normalised;
+  }
+
+  const state = context.transactions.getCommittedState(input.graph_id);
+  if (state) {
+    return state.graph;
+  }
+
+  try {
+    const resource = context.resources.read(`sc://graphs/${input.graph_id}`);
+    if (resource.kind !== "graph") {
+      throw new GraphTransactionError(`graph '${input.graph_id}' is not available for transactions`);
+    }
+    const payload = resource.payload as ResourceGraphPayload;
+    return structuredClone(payload.graph) as NormalisedGraph;
+  } catch (error) {
+    if (error instanceof GraphTransactionError) {
+      throw error;
+    }
+    throw new GraphTransactionError(
+      error instanceof Error ? error.message : `graph '${input.graph_id}' is not available for transactions`,
+    );
+  }
+}

--- a/tests/agents.supervisor.stagnation.test.ts
+++ b/tests/agents.supervisor.stagnation.test.ts
@@ -50,6 +50,9 @@ function createChild(overrides: Partial<ChildRecordSnapshot>): ChildRecordSnapsh
     exitSignal: overrides.exitSignal ?? null,
     forcedTermination: overrides.forcedTermination ?? false,
     stopReason: overrides.stopReason ?? null,
+    role: overrides.role ?? null,
+    limits: overrides.limits ?? null,
+    attachedAt: overrides.attachedAt ?? null,
   };
 }
 

--- a/tests/agents.supervisor.unblock.test.ts
+++ b/tests/agents.supervisor.unblock.test.ts
@@ -42,6 +42,9 @@ function childSnapshot(childId: string): ChildRecordSnapshot {
     exitSignal: null,
     forcedTermination: false,
     stopReason: null,
+    role: null,
+    limits: null,
+    attachedAt: null,
   };
 }
 

--- a/tests/bulk.bb-graph-child-stig.test.ts
+++ b/tests/bulk.bb-graph-child-stig.test.ts
@@ -1,0 +1,393 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import { ContractNetCoordinator } from "../src/coord/contractNet.js";
+import { StructuredLogger } from "../src/logger.js";
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import { GraphLockManager } from "../src/graph/locks.js";
+import { ResourceRegistry } from "../src/resources/registry.js";
+import { IdempotencyRegistry } from "../src/infra/idempotency.js";
+import {
+  BbBatchSetInputSchema,
+  handleBbBatchSet,
+  StigBatchInputSchema,
+  handleStigBatch,
+  type CoordinationToolContext,
+} from "../src/tools/coordTools.js";
+import {
+  GraphBatchMutateInputSchema,
+  handleGraphBatchMutate,
+  type GraphBatchToolContext,
+} from "../src/tools/graphBatchTools.js";
+import {
+  handleGraphGenerate,
+  normaliseGraphPayload,
+} from "../src/tools/graphTools.js";
+import { ChildSupervisor } from "../src/childSupervisor.js";
+import {
+  ChildBatchCreateInputSchema,
+  ChildToolContext,
+  handleChildBatchCreate,
+} from "../src/tools/childTools.js";
+import { StigmergyInvalidTypeError } from "../src/coord/stigmergy.js";
+import { GraphMutationLockedError } from "../src/graph/locks.js";
+import { GraphVersionConflictError } from "../src/graph/tx.js";
+import { ChildLimitExceededError } from "../src/childSupervisor.js";
+
+/**
+ * Builds a coordination context backed by deterministic clocks so the tests can
+ * reason about TTLs and versioning without flakiness.
+ */
+function createCoordinationContext(clock: { now: number }): CoordinationToolContext {
+  const now = () => clock.now;
+  return {
+    blackboard: new BlackboardStore({ now }),
+    stigmergy: new StigmergyField({ now }),
+    contractNet: new ContractNetCoordinator({ now }),
+    logger: new StructuredLogger(),
+  };
+}
+
+function createGraphBatchFixture(clock: { now: number }): {
+  context: GraphBatchToolContext;
+  graphId: string;
+  baseVersion: number;
+} {
+  const transactions = new GraphTransactionManager();
+  const locks = new GraphLockManager(() => clock.now);
+  const resources = new ResourceRegistry();
+  const idempotency = new IdempotencyRegistry({ clock: () => clock.now });
+  const generated = handleGraphGenerate({ name: "pipeline", preset: "lint_test_build_package" });
+  const baseline = normaliseGraphPayload(generated.graph);
+  const opened = transactions.begin(baseline);
+  const committed = transactions.commit(opened.txId, opened.workingCopy);
+  const context: GraphBatchToolContext = { transactions, resources, locks, idempotency };
+  return { context, graphId: committed.graphId, baseVersion: committed.version };
+}
+
+const mockRunnerPath = fileURLToPath(new URL("./fixtures/mock-runner.js", import.meta.url));
+
+async function createChildBatchFixture(options: {
+  maxChildren?: number;
+} = {}): Promise<{
+  context: ChildToolContext;
+  supervisor: ChildSupervisor;
+  logger: StructuredLogger;
+  cleanup: () => Promise<void>;
+}> {
+  const childrenRoot = await mkdtemp(path.join(tmpdir(), "child-batch-"));
+  const supervisor = new ChildSupervisor({
+    childrenRoot,
+    defaultCommand: process.execPath,
+    defaultArgs: [mockRunnerPath, "--role", "friendly"],
+    idleTimeoutMs: 200,
+    idleCheckIntervalMs: 40,
+    maxChildren: options.maxChildren,
+  });
+  const logFile = path.join(childrenRoot, "child-batch.log");
+  const logger = new StructuredLogger({ logFile });
+  const idempotency = new IdempotencyRegistry({ clock: () => Date.now() });
+  const context: ChildToolContext = { supervisor, logger, idempotency };
+  const cleanup = async () => {
+    await supervisor.disposeAll();
+    await logger.flush();
+    await rm(childrenRoot, { recursive: true, force: true });
+  };
+  return { context, supervisor, logger, cleanup };
+}
+
+function getRuntimeCount(supervisor: ChildSupervisor): number {
+  const internal = supervisor as unknown as { runtimes: Map<string, unknown> };
+  return internal.runtimes.size;
+}
+
+describe("bulk tools", () => {
+  describe("bb_batch_set", () => {
+    it("applies all mutations atomically with sequential versions", () => {
+      const clock = { now: 10_000 };
+      const context = createCoordinationContext(clock);
+
+      const parsed = BbBatchSetInputSchema.parse({
+        entries: [
+          { key: "alpha", value: { status: "ready" }, tags: ["coord"], ttl_ms: 5_000 },
+          { key: "beta", value: 42 },
+        ],
+      });
+
+      const result = handleBbBatchSet(context, parsed);
+      expect(result.entries).to.have.lengthOf(2);
+
+      const alpha = context.blackboard.get("alpha");
+      const beta = context.blackboard.get("beta");
+      expect(alpha).to.not.be.undefined;
+      expect(beta).to.not.be.undefined;
+      expect(alpha?.value).to.deep.equal({ status: "ready" });
+      expect(alpha?.tags).to.deep.equal(["coord"]);
+      expect(alpha?.expiresAt).to.equal(15_000);
+      expect(beta?.value).to.equal(42);
+      expect(alpha?.version).to.equal(1);
+      expect(beta?.version).to.equal(2);
+
+      const events = context.blackboard.getEventsSince(0);
+      expect(events.map((event) => ({ version: event.version, key: event.key }))).to.deep.equal([
+        { version: 1, key: "alpha" },
+        { version: 2, key: "beta" },
+      ]);
+    });
+
+    it("rolls back the batch when one entry cannot be cloned", () => {
+      const clock = { now: 25_000 };
+      const context = createCoordinationContext(clock);
+
+      const initial = context.blackboard.set("alpha", { status: "seed" });
+      expect(initial.version).to.equal(1);
+
+      expect(() =>
+        handleBbBatchSet(
+          context,
+          BbBatchSetInputSchema.parse({
+            entries: [
+              { key: "alpha", value: { status: "updated" } },
+              // Functions cannot be cloned and therefore trigger the rollback path.
+              { key: "beta", value: () => "boom" },
+            ],
+          }),
+        ),
+      ).to.throw();
+
+      const after = context.blackboard.get("alpha");
+      expect(after?.value).to.deep.equal({ status: "seed" });
+      expect(context.blackboard.get("beta")).to.be.undefined;
+      expect(context.blackboard.getCurrentVersion()).to.equal(initial.version);
+      expect(context.blackboard.getEventsSince(initial.version)).to.have.lengthOf(0);
+    });
+  });
+
+  describe("graph_batch_mutate", () => {
+    it("commits graph operations atomically and supports idempotent replays", async () => {
+      const clock = { now: 5_000 };
+      const { context, graphId, baseVersion } = createGraphBatchFixture(clock);
+
+      const parsed = GraphBatchMutateInputSchema.parse({
+        graph_id: graphId,
+        expected_version: baseVersion,
+        operations: [
+          { op: "add_node", node: { id: "qa", label: "QA" } },
+          { op: "add_edge", edge: { from: "build", to: "qa", weight: 1 } },
+        ],
+        idempotency_key: "graph-batch-commit",
+      });
+
+      const result = await handleGraphBatchMutate(context, parsed);
+      expect(result.changed).to.equal(true);
+      expect(result.idempotent).to.equal(false);
+      expect(result.base_version).to.equal(baseVersion);
+      expect(result.committed_version).to.equal(baseVersion + 1);
+      const committed = context.transactions.getCommittedState(graphId);
+      expect(committed?.version).to.equal(result.committed_version);
+
+      const replay = await handleGraphBatchMutate(context, parsed);
+      expect(replay.idempotent).to.equal(true);
+      expect(replay.committed_version).to.equal(result.committed_version);
+      const committedAfterReplay = context.transactions.getCommittedState(graphId);
+      expect(committedAfterReplay?.version).to.equal(result.committed_version);
+    });
+
+    it("rejects when a conflicting lock is held and leaves the graph unchanged", async () => {
+      const clock = { now: 9_000 };
+      const { context, graphId, baseVersion } = createGraphBatchFixture(clock);
+      context.locks.acquire(graphId, "other-holder", { ttlMs: 1_000 });
+
+      const parsed = GraphBatchMutateInputSchema.parse({
+        graph_id: graphId,
+        owner: "batch-owner",
+        expected_version: baseVersion,
+        operations: [{ op: "add_node", node: { id: "orphan" } }],
+      });
+
+      await handleGraphBatchMutate(context, parsed)
+        .then(() => expect.fail("expected GraphMutationLockedError"))
+        .catch((error) => {
+          expect(error).to.be.instanceOf(GraphMutationLockedError);
+        });
+      const committed = context.transactions.getCommittedState(graphId);
+      expect(committed?.version).to.equal(baseVersion);
+    });
+
+    it("rejects when the expected version does not match", async () => {
+      const clock = { now: 12_000 };
+      const { context, graphId, baseVersion } = createGraphBatchFixture(clock);
+
+      const parsed = GraphBatchMutateInputSchema.parse({
+        graph_id: graphId,
+        expected_version: Math.max(0, baseVersion - 1),
+        operations: [{ op: "add_node", node: { id: "noop" } }],
+      });
+
+      await handleGraphBatchMutate(context, parsed)
+        .then(() => expect.fail("expected GraphVersionConflictError"))
+        .catch((error) => {
+          expect(error).to.be.instanceOf(GraphVersionConflictError);
+        });
+      const committed = context.transactions.getCommittedState(graphId);
+      expect(committed?.version).to.equal(baseVersion);
+    });
+
+    it("reports unchanged operations without bumping the graph version", async () => {
+      const clock = { now: 15_000 };
+      const { context, graphId, baseVersion } = createGraphBatchFixture(clock);
+
+      const parsed = GraphBatchMutateInputSchema.parse({
+        graph_id: graphId,
+        expected_version: baseVersion,
+        operations: [
+          // Adding an existing node merges attributes without modifying the graph structure.
+          { op: "add_node", node: { id: "build" } },
+        ],
+      });
+
+      const result = await handleGraphBatchMutate(context, parsed);
+      expect(result.changed).to.equal(false);
+      expect(result.operations_applied).to.equal(1);
+      expect(result.committed_version).to.equal(baseVersion);
+      const committed = context.transactions.getCommittedState(graphId);
+      expect(committed?.version).to.equal(baseVersion);
+    });
+  });
+
+  describe("child_batch_create", () => {
+    it("spawns multiple children and reports idempotent replays", async () => {
+      const fixture = await createChildBatchFixture();
+      const context = fixture.context;
+
+      try {
+        const parsed = ChildBatchCreateInputSchema.parse({
+          entries: [
+            {
+              prompt: { system: "Tu es un copilote.", user: ["Analyse"] },
+              role: "planner",
+              idempotency_key: "child-batch-1",
+            },
+            {
+              prompt: { system: "Tu es un copilote.", user: ["Synthèse"] },
+              role: "reviewer",
+              idempotency_key: "child-batch-2",
+            },
+          ],
+        });
+
+        const result = await handleChildBatchCreate(context, parsed);
+        expect(result.children).to.have.lengthOf(2);
+        expect(result.created).to.equal(2);
+        expect(result.idempotent_entries).to.equal(0);
+        for (const child of result.children) {
+          expect(child.idempotent).to.equal(false);
+          const status = fixture.supervisor.status(child.child_id);
+          expect(status.index.childId).to.equal(child.child_id);
+        }
+
+        const replay = await handleChildBatchCreate(context, parsed);
+        expect(replay.idempotent_entries).to.equal(2);
+        expect(replay.created).to.equal(0);
+        replay.children.forEach((child) => {
+          expect(child.idempotent).to.equal(true);
+        });
+
+        for (const child of result.children) {
+          await fixture.supervisor.cancel(child.child_id, { signal: "SIGINT", timeoutMs: 200 });
+          await fixture.supervisor.waitForExit(child.child_id, 1000);
+          fixture.supervisor.gc(child.child_id);
+        }
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it("rolls back spawned children when the supervisor rejects a later entry", async () => {
+      const fixture = await createChildBatchFixture({ maxChildren: 1 });
+      const context = fixture.context;
+
+      try {
+        const parsed = ChildBatchCreateInputSchema.parse({
+          entries: [
+            {
+              prompt: { system: "Assistant", user: ["Tâche A"] },
+              role: "executor",
+              idempotency_key: "child-batch-limit-1",
+            },
+            {
+              prompt: { system: "Assistant", user: ["Tâche B"] },
+              role: "executor",
+              idempotency_key: "child-batch-limit-2",
+            },
+          ],
+        });
+
+        const originalCreateChild = fixture.supervisor.createChild.bind(fixture.supervisor);
+        let spawnCount = 0;
+        // Force the supervisor to reject the second spawn to exercise the rollback path deterministically.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fixture.supervisor.createChild as any) = async (...args: Parameters<typeof originalCreateChild>) => {
+          spawnCount += 1;
+          if (spawnCount === 2) {
+            throw new ChildLimitExceededError(1, 1);
+          }
+          return originalCreateChild(...args);
+        };
+
+        await handleChildBatchCreate(context, parsed)
+          .then(() => expect.fail("expected ChildLimitExceededError"))
+          .catch((error) => {
+            expect(error).to.have.property("name", "ChildLimitExceededError");
+          });
+        // Restore the supervisor behaviour for cleanup to avoid masking other scenarios.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fixture.supervisor.createChild as any) = originalCreateChild;
+        expect(getRuntimeCount(fixture.supervisor)).to.equal(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  });
+
+  describe("stig_batch", () => {
+    it("deposits multiple pheromones atomically", () => {
+      const clock = { now: 42_000 };
+      const context = createCoordinationContext(clock);
+
+      const parsed = StigBatchInputSchema.parse({
+        entries: [
+          { node_id: "triage", type: "backlog", intensity: 2.5 },
+          { node_id: "triage", type: "latency", intensity: 1.25 },
+        ],
+      });
+
+      const result = handleStigBatch(context, parsed);
+      expect(result.changes).to.have.lengthOf(2);
+      const total = context.stigmergy.getNodeIntensity("triage");
+      expect(total?.intensity).to.be.closeTo(3.75, 1e-6);
+      expect(result.changes[0]?.point.node_id).to.equal("triage");
+    });
+
+    it("rolls back when one entry cannot be normalised", () => {
+      const clock = { now: 55_000 };
+      const context = createCoordinationContext(clock);
+
+      const parsed = StigBatchInputSchema.parse({
+        entries: [
+          { node_id: "alpha", type: "load", intensity: 1 },
+          { node_id: "alpha", type: "   ", intensity: 2 },
+        ],
+      });
+
+      expect(() => handleStigBatch(context, parsed)).to.throw(StigmergyInvalidTypeError);
+      expect(context.stigmergy.fieldSnapshot().points).to.have.lengthOf(0);
+    });
+  });
+});

--- a/tests/cancel.plan.run.test.ts
+++ b/tests/cancel.plan.run.test.ts
@@ -15,15 +15,43 @@ describe("plan cancellation registry", () => {
   });
 
   it("cancels every operation associated with a run identifier", () => {
-    registerCancellation("op-1", { runId: "run-cascade" });
-    registerCancellation("op-2", { runId: "run-cascade" });
+    registerCancellation("op-1", {
+      runId: "run-cascade",
+      jobId: "job-1",
+      graphId: "graph-7",
+      nodeId: "node-3",
+      childId: "child-1",
+    });
+    registerCancellation("op-2", {
+      runId: "run-cascade",
+      jobId: "job-1",
+      graphId: "graph-7",
+      nodeId: "node-4",
+      childId: "child-2",
+    });
     registerCancellation("op-ignored", { runId: "other" });
 
     const outcomes = cancelRun("run-cascade", { reason: "manual" });
 
     expect(outcomes).to.deep.equal([
-      { opId: "op-1", outcome: "requested" },
-      { opId: "op-2", outcome: "requested" },
+      {
+        opId: "op-1",
+        outcome: "requested",
+        runId: "run-cascade",
+        jobId: "job-1",
+        graphId: "graph-7",
+        nodeId: "node-3",
+        childId: "child-1",
+      },
+      {
+        opId: "op-2",
+        outcome: "requested",
+        runId: "run-cascade",
+        jobId: "job-1",
+        graphId: "graph-7",
+        nodeId: "node-4",
+        childId: "child-2",
+      },
     ]);
 
     expect(isCancelled("op-1")).to.equal(true);
@@ -34,6 +62,8 @@ describe("plan cancellation registry", () => {
     const second = getCancellation("op-2");
     expect(first?.reason).to.equal("manual");
     expect(second?.reason).to.equal("manual");
+    expect(first?.jobId).to.equal("job-1");
+    expect(second?.nodeId).to.equal("node-4");
   });
 
   it("returns an empty array when no operations are registered for the run", () => {

--- a/tests/child.spawn-attach-limits.test.ts
+++ b/tests/child.spawn-attach-limits.test.ts
@@ -1,0 +1,104 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ChildSupervisor } from "../src/childSupervisor.js";
+import {
+  ChildAttachInputSchema,
+  ChildSetLimitsInputSchema,
+  ChildSetRoleInputSchema,
+  ChildSpawnCodexInputSchema,
+  ChildToolContext,
+  handleChildAttach,
+  handleChildSetLimits,
+  handleChildSetRole,
+  handleChildSpawnCodex,
+} from "../src/tools/childTools.js";
+import { StructuredLogger } from "../src/logger.js";
+
+const mockRunnerPath = fileURLToPath(new URL("./fixtures/mock-runner.js", import.meta.url));
+
+describe("child spawn/attach/limits tools", () => {
+  it("spawns a codex child, updates role and limits, then refreshes the manifest", async () => {
+    const childrenRoot = await mkdtemp(path.join(tmpdir(), "child-spawn-codex-"));
+    const supervisor = new ChildSupervisor({
+      childrenRoot,
+      defaultCommand: process.execPath,
+      defaultArgs: [mockRunnerPath, "--role", "friendly"],
+      idleTimeoutMs: 200,
+      idleCheckIntervalMs: 40,
+    });
+    const logFile = path.join(childrenRoot, "spawn-tools.log");
+    const logger = new StructuredLogger({ logFile });
+    const context: ChildToolContext = { supervisor, logger };
+
+    try {
+      const spawnInput = ChildSpawnCodexInputSchema.parse({
+        role: "planner",
+        prompt: { system: "Tu es un copilote.", user: ["Analyse le plan"] },
+        limits: { tokens: 2048, wallclock_ms: 30_000 },
+        model_hint: "gpt-test",
+        idempotency_key: "spawn-1",
+      });
+
+      const spawned = await handleChildSpawnCodex(context, spawnInput);
+
+      expect(spawned.child_id).to.match(/^child-\d{13}-[a-f0-9]{6}$/);
+      expect(spawned.role).to.equal("planner");
+      expect(spawned.limits).to.deep.equal({ tokens: 2048, wallclock_ms: 30_000 });
+      expect(spawned.idempotent).to.equal(false);
+      expect(spawned.index_snapshot.role).to.equal("planner");
+      expect(spawned.index_snapshot.limits).to.deep.equal({ tokens: 2048, wallclock_ms: 30_000 });
+
+      const manifestRaw = await readFile(spawned.manifest_path, "utf8");
+      const manifest = JSON.parse(manifestRaw) as Record<string, unknown>;
+      expect(manifest.role).to.equal("planner");
+      expect(manifest.limits).to.deep.equal({ tokens: 2048, wallclock_ms: 30_000 });
+      expect(manifest.prompt).to.deep.equal(spawnInput.prompt);
+
+      const roleUpdate = ChildSetRoleInputSchema.parse({
+        child_id: spawned.child_id,
+        role: "reviewer",
+        manifest_extras: { updated_by: "test" },
+      });
+      const roleResult = await handleChildSetRole(context, roleUpdate);
+      expect(roleResult.role).to.equal("reviewer");
+      expect(roleResult.index_snapshot.role).to.equal("reviewer");
+
+      const limitsUpdate = ChildSetLimitsInputSchema.parse({
+        child_id: spawned.child_id,
+        limits: { tokens: 1024 },
+        manifest_extras: { note: "tight-budget" },
+      });
+      const limitsResult = await handleChildSetLimits(context, limitsUpdate);
+      expect(limitsResult.limits).to.deep.equal({ tokens: 1024 });
+      expect(limitsResult.index_snapshot.limits).to.deep.equal({ tokens: 1024 });
+
+      const manifestAfterLimits = JSON.parse(await readFile(spawned.manifest_path, "utf8")) as Record<string, unknown>;
+      expect(manifestAfterLimits.role).to.equal("reviewer");
+      expect(manifestAfterLimits.limits).to.deep.equal({ tokens: 1024 });
+      expect(manifestAfterLimits.updated_by).to.equal("test");
+      expect(manifestAfterLimits.note).to.equal("tight-budget");
+
+      const attachInput = ChildAttachInputSchema.parse({
+        child_id: spawned.child_id,
+        manifest_extras: { refresh: true },
+      });
+      const attachResult = await handleChildAttach(context, attachInput);
+      expect(attachResult.attached_at).to.be.a("number");
+      const manifestAfterAttach = JSON.parse(await readFile(spawned.manifest_path, "utf8")) as Record<string, unknown>;
+      expect(manifestAfterAttach.refresh).to.equal(true);
+
+      await supervisor.cancel(spawned.child_id, { signal: "SIGINT", timeoutMs: 200 });
+      await supervisor.waitForExit(spawned.child_id, 1000);
+    } finally {
+      await supervisor.disposeAll();
+      await logger.flush();
+      await rm(childrenRoot, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/tests/e2e.rewrite.recovery.test.ts
+++ b/tests/e2e.rewrite.recovery.test.ts
@@ -49,6 +49,9 @@ class LoopingChildSupervisorStub implements SupervisorChildManager {
       exitSignal: null,
       forcedTermination: false,
       stopReason: null,
+      role: "analyst",
+      limits: null,
+      attachedAt: null,
     };
   }
 

--- a/tests/e2e.stigmergy.autoscaling.test.ts
+++ b/tests/e2e.stigmergy.autoscaling.test.ts
@@ -105,6 +105,9 @@ describe("stigmergy driven autoscaling", function () {
         exitSignal: null,
         forcedTermination: false,
         stopReason: null,
+        role: null,
+        limits: null,
+        attachedAt: null,
       });
       return Promise.resolve();
     });

--- a/tests/events.bridges.test.ts
+++ b/tests/events.bridges.test.ts
@@ -1,0 +1,509 @@
+import { EventEmitter } from "node:events";
+
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import { EventBus } from "../src/events/bus.js";
+import {
+  bridgeBlackboardEvents,
+  bridgeChildRuntimeEvents,
+  bridgeCancellationEvents,
+  bridgeConsensusEvents,
+  bridgeContractNetEvents,
+  bridgeValueEvents,
+  bridgeStigmergyEvents,
+} from "../src/events/bridges.js";
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import { ContractNetCoordinator } from "../src/coord/contractNet.js";
+import {
+  registerCancellation,
+  requestCancellation,
+  resetCancellationRegistry,
+} from "../src/executor/cancel.js";
+import {
+  publishConsensusEvent,
+  resetConsensusEventClock,
+  setConsensusEventClock,
+} from "../src/coord/consensus.js";
+import type {
+  ChildRuntime,
+  ChildRuntimeLifecycleEvent,
+  ChildRuntimeMessage,
+} from "../src/childRuntime.js";
+import { ValueGraph } from "../src/values/valueGraph.js";
+
+describe("event bridges", () => {
+  beforeEach(() => {
+    resetCancellationRegistry();
+    resetConsensusEventClock();
+  });
+
+  it("mirrors blackboard mutations on the unified event bus", () => {
+    // Manual monotonic clock keeps timestamps predictable for assertions.
+    let now = 0;
+    const nowFn = () => now;
+    const bus = new EventBus({ historyLimit: 10, now: nowFn });
+    const store = new BlackboardStore({ historyLimit: 10, now: nowFn });
+
+    bridgeBlackboardEvents({
+      blackboard: store,
+      bus,
+      resolveCorrelation: (event) => {
+        if (event.key === "task") {
+          return { runId: "run-77", opId: `op-${event.version}` };
+        }
+        return {};
+      },
+    });
+
+    now = 1;
+    store.set("task", { state: "queued" }, { tags: ["plan"], ttlMs: 4 });
+    now = 2;
+    store.set("log", { state: "transient" }, { ttlMs: 3 });
+    now = 3;
+    const deleted = store.delete("task");
+    expect(deleted).to.equal(true);
+    now = 6;
+    const expired = store.evictExpired();
+    expect(expired).to.have.lengthOf(1);
+
+    const events = bus.list({ cats: ["blackboard"] });
+    expect(events.map((event) => event.msg)).to.deep.equal([
+      "bb_set",
+      "bb_set",
+      "bb_delete",
+      "bb_expire",
+    ]);
+    const [taskSet, logSet, taskDelete, logExpire] = events;
+    expect(taskSet.runId).to.equal("run-77");
+    expect(taskSet.opId).to.equal("op-1");
+    expect(taskSet.data).to.deep.include({ key: "task", kind: "set" });
+    expect(logSet.runId).to.equal(null);
+    expect(taskDelete.msg).to.equal("bb_delete");
+    expect(taskDelete.runId).to.equal("run-77");
+    expect(taskDelete.opId).to.equal("op-3");
+    expect(logExpire.level).to.equal("warn");
+    expect(logExpire.data).to.deep.include({ kind: "expire", key: "log", reason: "ttl" });
+  });
+
+  it("publishes stigmergy changes with node metadata", () => {
+    // Deterministic clock shared between the field and event bus.
+    let now = 0;
+    const nowFn = () => now;
+    const bus = new EventBus({ historyLimit: 10, now: nowFn });
+    const field = new StigmergyField({ now: nowFn });
+
+    bridgeStigmergyEvents({
+      field,
+      bus,
+      resolveCorrelation: () => ({ graphId: "graph-42" }),
+    });
+
+    now = 1;
+    field.mark("node-1", "routing", 1.5);
+    now = 5;
+    const changes = field.evaporate(2);
+    expect(changes).to.have.length.greaterThan(0);
+
+    const events = bus.list({ cats: ["stigmergy"] });
+    expect(events).to.have.lengthOf(2);
+    const [markEvent, evaporateEvent] = events;
+    expect(markEvent.nodeId).to.equal("node-1");
+    expect(markEvent.graphId).to.equal("graph-42");
+    expect(markEvent.data).to.deep.include({ type: "routing", intensity: 1.5 });
+    expect(evaporateEvent.msg).to.equal("stigmergy_change");
+    expect(evaporateEvent.data).to.deep.include({ nodeId: "node-1" });
+    expect(evaporateEvent.data.totalIntensity).to.be.lessThan(1.5);
+  });
+
+  it("routes cancellation lifecycle events with correlation metadata", () => {
+    let tick = 0;
+    const now = () => ++tick;
+    const bus = new EventBus({ historyLimit: 5, now });
+
+    const dispose = bridgeCancellationEvents({ bus });
+
+    const handle = registerCancellation("op-cancel", {
+      runId: "run-99",
+      jobId: "job-77",
+      graphId: "graph-5",
+      nodeId: "node-2",
+      childId: "child-9",
+      createdAt: 0,
+    });
+    const firstOutcome = requestCancellation(handle.opId, { reason: "timeout", at: 50 });
+    const secondOutcome = requestCancellation(handle.opId, { at: 60 });
+
+    expect(firstOutcome).to.equal("requested");
+    expect(secondOutcome).to.equal("already_cancelled");
+
+    const events = bus.list({ cats: ["cancel"] });
+    expect(events).to.have.lengthOf(2);
+
+    const [requested, repeated] = events;
+    expect(requested.msg).to.equal("cancel_requested");
+    expect(requested.level).to.equal("info");
+    expect(requested.runId).to.equal("run-99");
+    expect(requested.opId).to.equal("op-cancel");
+    expect(requested.jobId).to.equal("job-77");
+    expect(requested.graphId).to.equal("graph-5");
+    expect(requested.nodeId).to.equal("node-2");
+    expect(requested.childId).to.equal("child-9");
+    expect(requested.data).to.deep.include({
+      outcome: "requested",
+      reason: "timeout",
+      jobId: "job-77",
+      graphId: "graph-5",
+      nodeId: "node-2",
+      childId: "child-9",
+    });
+
+    expect(repeated.msg).to.equal("cancel_repeat");
+    expect(repeated.level).to.equal("warn");
+    expect(repeated.runId).to.equal("run-99");
+    expect(repeated.jobId).to.equal("job-77");
+    expect(repeated.graphId).to.equal("graph-5");
+    expect(repeated.data).to.deep.include({ outcome: "already_cancelled", jobId: "job-77" });
+
+    dispose();
+  });
+
+  it("bridges contract-net auctions and bids to the event bus", () => {
+    let tick = 0;
+    const now = () => ++tick;
+    const bus = new EventBus({ historyLimit: 20, now });
+    const coordinator = new ContractNetCoordinator({ now });
+
+    const dispose = bridgeContractNetEvents({
+      coordinator,
+      bus,
+      resolveCorrelation: (event) => {
+        if (event.kind === "call_announced") {
+          return { runId: "run-auction", opId: `op-${event.call.callId}` };
+        }
+        if (event.kind === "bid_recorded") {
+          return { opId: `op-${event.callId}` };
+        }
+        if (event.kind === "call_awarded" || event.kind === "call_completed") {
+          return { runId: "run-auction", opId: `op-${event.call.callId}` };
+        }
+        return {};
+      },
+    });
+
+    const agent = coordinator.registerAgent("agent-77", { baseCost: 25, reliability: 0.8 });
+    const call = coordinator.announce({ taskId: "task-42" });
+    coordinator.bid(call.callId, agent.agentId, 10, { metadata: { note: "manual" } });
+    const decision = coordinator.award(call.callId);
+    expect(decision.agentId).to.equal(agent.agentId);
+    const completion = coordinator.complete(call.callId);
+    expect(completion.status).to.equal("completed");
+    const removed = coordinator.unregisterAgent(agent.agentId);
+    expect(removed).to.equal(true);
+
+    const events = bus.list({ cats: ["contract_net"] });
+    expect(events.map((event) => event.msg)).to.deep.equal([
+      "cnp_agent_registered",
+      "cnp_bid_recorded",
+      "cnp_call_announced",
+      "cnp_bid_updated",
+      "cnp_call_awarded",
+      "cnp_call_completed",
+      "cnp_agent_unregistered",
+    ]);
+
+    const [registered, autoBid, announced, manualBid, awarded, completed, unregistered] = events;
+
+    expect(registered.runId).to.equal(null);
+    expect(registered.data).to.deep.include({ updated: false });
+
+    expect(autoBid.opId).to.equal(`op-${call.callId}`);
+    expect(autoBid.data).to.deep.include({ callId: call.callId, previousKind: null });
+    expect(autoBid.data).to.have.nested.property("bid.kind", "heuristic");
+
+    expect(announced.runId).to.equal("run-auction");
+    expect(announced.opId).to.equal(`op-${call.callId}`);
+    expect(announced.data).to.have.nested.property("call.status", "open");
+    expect(announced.data).to.have.nested.property("call.bids").that.is.an("array");
+
+    expect(manualBid.msg).to.equal("cnp_bid_updated");
+    expect(manualBid.data).to.deep.include({ previousKind: "heuristic" });
+    expect(manualBid.data).to.have.nested.property("bid.kind", "manual");
+
+    expect(awarded.runId).to.equal("run-auction");
+    expect(awarded.data).to.have.nested.property("decision.agentId", agent.agentId);
+    expect(awarded.data).to.have.nested.property("call.status", "awarded");
+
+    expect(completed.runId).to.equal("run-auction");
+    expect(completed.data).to.have.nested.property("call.status", "completed");
+
+    expect(unregistered.data).to.deep.include({ agentId: agent.agentId });
+    expect(unregistered.data).to.have.property("remainingAssignments", 0);
+
+    dispose();
+
+    coordinator.announce({ taskId: "task-ignored", autoBid: false });
+    const afterDisposeEvents = bus.list({ cats: ["contract_net"] });
+    expect(afterDisposeEvents).to.have.lengthOf(7);
+  });
+
+  it("bridges consensus decisions onto the unified bus", () => {
+    let tick = 0;
+    const now = () => ++tick;
+    setConsensusEventClock(now);
+    const bus = new EventBus({ historyLimit: 10, now });
+
+    const dispose = bridgeConsensusEvents({ bus });
+
+    publishConsensusEvent({
+      kind: "decision",
+      source: "plan_join",
+      mode: "quorum",
+      outcome: "success",
+      satisfied: true,
+      tie: false,
+      threshold: 2,
+      totalWeight: 3,
+      tally: { success: 2, error: 1 },
+      votes: 3,
+      runId: "run-501",
+      opId: "op-join-1",
+      metadata: { policy: "quorum", winning_child_id: "child-9" },
+    });
+
+    publishConsensusEvent({
+      kind: "decision",
+      source: "consensus_vote",
+      mode: "weighted",
+      outcome: null,
+      satisfied: false,
+      tie: true,
+      threshold: 4,
+      totalWeight: 4,
+      tally: { approve: 2, reject: 2 },
+      votes: 4,
+      jobId: "job-300",
+      metadata: { requested_quorum: 4 },
+    });
+
+    const events = bus.list({ cats: ["consensus"] });
+    expect(events).to.have.lengthOf(2);
+
+    const [satisfied, tie] = events;
+    expect(satisfied.msg).to.equal("consensus_decision");
+    expect(satisfied.level).to.equal("info");
+    expect(satisfied.runId).to.equal("run-501");
+    expect(satisfied.opId).to.equal("op-join-1");
+    expect(satisfied.data).to.deep.include({
+      mode: "quorum",
+      outcome: "success",
+      satisfied: true,
+      threshold: 2,
+      votes: 3,
+    });
+    expect(satisfied.data).to.have.nested.property("metadata.policy", "quorum");
+    expect(satisfied.data).to.have.nested.property("metadata.winning_child_id", "child-9");
+
+    expect(tie.msg).to.equal("consensus_tie_unresolved");
+    expect(tie.level).to.equal("warn");
+    expect(tie.jobId).to.equal("job-300");
+    expect(tie.data).to.deep.include({
+      mode: "weighted",
+      outcome: null,
+      tie: true,
+      votes: 4,
+    });
+    expect(tie.data).to.have.nested.property("metadata.requested_quorum", 4);
+
+    dispose();
+    resetConsensusEventClock();
+  });
+
+  it("bridges child runtime lifecycle and output streams to the event bus", () => {
+    let tick = 0;
+    const now = () => ++tick;
+    const bus = new EventBus({ historyLimit: 10, now });
+
+    class FakeChildRuntime extends EventEmitter {
+      // Minimal stub mirroring the ChildRuntime shape for subscription tests.
+      childId = "child-007";
+    }
+
+    const runtime = new FakeChildRuntime() as unknown as ChildRuntime;
+
+    const dispose = bridgeChildRuntimeEvents({
+      runtime,
+      bus,
+      resolveCorrelation: (context) => {
+        if (context.kind === "lifecycle" && context.lifecycle.phase === "exit") {
+          return { jobId: "job-child-007" };
+        }
+        return {};
+      },
+    });
+
+    const spawned: ChildRuntimeLifecycleEvent = {
+      phase: "spawned",
+      at: 1,
+      pid: 321,
+      forced: false,
+      reason: null,
+    };
+    runtime.emit("lifecycle", spawned);
+
+    const stdoutMessage: ChildRuntimeMessage = {
+      raw: JSON.stringify({ type: "response", runId: "run-501", opId: "op-22" }),
+      parsed: { type: "response", runId: "run-501", opId: "op-22" },
+      stream: "stdout",
+      receivedAt: 2,
+      sequence: 0,
+    };
+    runtime.emit("message", stdoutMessage);
+
+    const stderrMessage: ChildRuntimeMessage = {
+      raw: "fatal: disk full",
+      parsed: null,
+      stream: "stderr",
+      receivedAt: 3,
+      sequence: 1,
+    };
+    runtime.emit("message", stderrMessage);
+
+    const errored: ChildRuntimeLifecycleEvent = {
+      phase: "error",
+      at: 4,
+      pid: 321,
+      forced: false,
+      reason: "runtime-crashed",
+    };
+    runtime.emit("lifecycle", errored);
+
+    const exited: ChildRuntimeLifecycleEvent = {
+      phase: "exit",
+      at: 5,
+      pid: 321,
+      forced: true,
+      code: 1,
+      signal: "SIGTERM",
+      reason: null,
+    };
+    runtime.emit("lifecycle", exited);
+
+    const events = bus.list({ cats: ["child"] });
+    expect(events).to.have.lengthOf(5);
+    expect(events.map((event) => event.msg)).to.deep.equal([
+      "child_spawned",
+      "child_stdout",
+      "child_stderr",
+      "child_error",
+      "child_exit",
+    ]);
+
+    const [, stdoutEvent, stderrEvent, errorEvent, exitEvent] = events;
+    expect(stdoutEvent.runId).to.equal("run-501");
+    expect(stdoutEvent.opId).to.equal("op-22");
+    expect(stdoutEvent.level).to.equal("info");
+    expect(stdoutEvent.data).to.deep.include({ raw: stdoutMessage.raw, sequence: 0 });
+
+    expect(stderrEvent.level).to.equal("warn");
+    expect(stderrEvent.data).to.deep.include({ raw: stderrMessage.raw, stream: "stderr" });
+
+    expect(errorEvent.level).to.equal("error");
+    expect(errorEvent.data).to.deep.include({ reason: "runtime-crashed" });
+
+    expect(exitEvent.level).to.equal("warn");
+    expect(exitEvent.jobId).to.equal("job-child-007");
+    expect(exitEvent.data).to.deep.include({ code: 1, signal: "SIGTERM", forced: true });
+
+    dispose();
+
+    runtime.emit("message", {
+      raw: "ignored",
+      parsed: null,
+      stream: "stdout",
+      receivedAt: 6,
+      sequence: 2,
+    } satisfies ChildRuntimeMessage);
+
+    const postDisposeEvents = bus.list({ cats: ["child"] });
+    expect(postDisposeEvents).to.have.lengthOf(5);
+  });
+
+  it("bridges value guard evaluations to the event bus", () => {
+    let tick = 0;
+    const now = () => ++tick;
+    const bus = new EventBus({ historyLimit: 10, now });
+    const graph = new ValueGraph({ now });
+
+    const dispose = bridgeValueEvents({
+      graph,
+      bus,
+    });
+
+    const summary = graph.set({
+      values: [{ id: "safety", weight: 1, tolerance: 0.25 }],
+    });
+    expect(summary.version).to.equal(1);
+
+    const impacts = [
+      { value: "safety", impact: "risk" as const, severity: 0.8, rationale: "missing tests", nodeId: "node-1" },
+    ];
+
+    const correlation = { runId: "run-guard", opId: "op-plan-risk" } as const;
+
+    const score = graph.score({ id: "plan-risk", label: "Risky plan", impacts }, { correlation });
+    expect(score.violations).to.have.length.greaterThan(0);
+
+    const decision = graph.filter({ id: "plan-risk", label: "Risky plan", impacts }, { correlation });
+    expect(decision.allowed).to.equal(false);
+
+    const explanation = graph.explain({ id: "plan-risk", label: "Risky plan", impacts }, { correlation });
+    expect(explanation.decision.allowed).to.equal(false);
+
+    const events = bus.list({ cats: ["values"] });
+    expect(events.map((event) => event.msg)).to.deep.equal([
+      "values_config_updated",
+      "values_scored",
+      "values_filter_blocked",
+      "values_explain_blocked",
+    ]);
+
+    const [configUpdated, scored, filtered, explained] = events;
+
+    expect(configUpdated.level).to.equal("info");
+    expect(configUpdated.data).to.have.nested.property("summary.version", 1);
+
+    expect(scored.level).to.equal("warn");
+    expect(scored.runId).to.equal("run-guard");
+    expect(scored.opId).to.equal("op-plan-risk");
+    expect(scored.data).to.include({
+      plan_id: "plan-risk",
+      plan_label: "Risky plan",
+      impacts_count: impacts.length,
+      violations_count: 1,
+    });
+    expect(scored.data)
+      .to.have.nested.property("result.violations")
+      .that.is.an("array")
+      .with.length.greaterThan(0);
+
+    expect(filtered.msg).to.equal("values_filter_blocked");
+    expect(filtered.level).to.equal("warn");
+    expect(filtered.data).to.have.nested.property("decision.allowed", false);
+
+    expect(explained.msg).to.equal("values_explain_blocked");
+    expect(explained.data)
+      .to.have.nested.property("result.decision.allowed", false);
+    expect(explained.data)
+      .to.have.nested.property("result.violations")
+      .that.is.an("array")
+      .with.length.greaterThan(0);
+
+    dispose();
+
+    graph.score({ id: "plan-risk", label: "Risky plan", impacts });
+    const afterDispose = bus.list({ cats: ["values"] });
+    expect(afterDispose).to.have.lengthOf(4);
+  });
+});

--- a/tests/graph.diff-patch.test.ts
+++ b/tests/graph.diff-patch.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import { GraphLockManager, GraphMutationLockedError } from "../src/graph/locks.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+import { ResourceRegistry } from "../src/resources/registry.js";
+import type { ResourceGraphPayload } from "../src/resources/registry.js";
+import {
+  GraphDiffInputSchema,
+  GraphPatchInputSchema,
+  handleGraphDiff,
+  handleGraphPatch,
+  type GraphDiffToolContext,
+} from "../src/tools/graphDiffTools.js";
+import { serialiseNormalisedGraph } from "../src/tools/graphTools.js";
+
+/** Build a deterministic base graph exercising the diff/patch helpers. */
+function createBaseGraph(): NormalisedGraph {
+  return {
+    name: "release_pipeline",
+    graphId: "pipeline",
+    graphVersion: 1,
+    metadata: {
+      graph_kind: "dag",
+      require_labels: true,
+      require_ports: true,
+      require_edge_labels: true,
+      max_in_degree: 2,
+      max_out_degree: 3,
+    },
+    nodes: [
+      { id: "ingest", label: "Ingest", attributes: { role: "source", max_out_degree: 2 } },
+      { id: "process", label: "Process", attributes: { role: "worker", max_in_degree: 2 } },
+      { id: "publish", label: "Publish", attributes: { role: "sink", max_in_degree: 2 } },
+    ],
+    edges: [
+      {
+        from: "ingest",
+        to: "process",
+        label: "ingest->process",
+        weight: 1,
+        attributes: { from_port: "out", to_port: "in" },
+      },
+      {
+        from: "process",
+        to: "publish",
+        label: "process->publish",
+        weight: 1,
+        attributes: { from_port: "out", to_port: "in" },
+      },
+    ],
+  } satisfies NormalisedGraph;
+}
+
+/** Register the base graph as a committed version in the registry and manager. */
+function seedCommittedGraph(context: GraphDiffToolContext, graph: NormalisedGraph): NormalisedGraph {
+  const tx = context.transactions.begin(graph);
+  context.resources.recordGraphSnapshot({
+    graphId: tx.graphId,
+    txId: tx.txId,
+    baseVersion: tx.baseVersion,
+    startedAt: tx.startedAt,
+    graph: tx.workingCopy,
+    owner: tx.owner,
+    note: tx.note,
+    expiresAt: tx.expiresAt,
+  });
+  const committed = context.transactions.commit(tx.txId, graph);
+  context.resources.markGraphSnapshotCommitted({
+    graphId: committed.graphId,
+    txId: committed.txId,
+    committedAt: committed.committedAt,
+    finalVersion: committed.version,
+    finalGraph: committed.graph,
+  });
+  context.resources.recordGraphVersion({
+    graphId: committed.graphId,
+    version: committed.version,
+    committedAt: committed.committedAt,
+    graph: committed.graph,
+  });
+  return committed.graph;
+}
+
+describe("graph diff & patch tools", () => {
+  let transactions: GraphTransactionManager;
+  let resources: ResourceRegistry;
+  let context: GraphDiffToolContext;
+  let baseGraph: NormalisedGraph;
+  let locks: GraphLockManager;
+
+  beforeEach(() => {
+    transactions = new GraphTransactionManager();
+    resources = new ResourceRegistry();
+    locks = new GraphLockManager(() => Date.now());
+    context = { transactions, resources, locks };
+    baseGraph = seedCommittedGraph(context, createBaseGraph());
+  });
+
+  it("produces a JSON Patch and applies it while enforcing invariants", () => {
+    const target: NormalisedGraph = {
+      ...baseGraph,
+      name: "release_pipeline_v2",
+      metadata: {
+        ...baseGraph.metadata,
+        release_channel: "stable",
+      },
+      nodes: [
+        ...baseGraph.nodes,
+        { id: "review", label: "Review", attributes: { role: "qa", max_in_degree: 2 } },
+      ],
+      edges: [
+        baseGraph.edges[0]!,
+        {
+          from: "process",
+          to: "review",
+          label: "process->review",
+          weight: 1,
+          attributes: { from_port: "out", to_port: "in" },
+        },
+        {
+          from: "review",
+          to: "publish",
+          label: "review->publish",
+          weight: 1,
+          attributes: { from_port: "out", to_port: "in" },
+        },
+      ],
+    } satisfies NormalisedGraph;
+
+    const diffInput = GraphDiffInputSchema.parse({
+      graph_id: baseGraph.graphId,
+      from: { latest: true },
+      to: { graph: serialiseNormalisedGraph(target) },
+    });
+    const diffResult = handleGraphDiff(context, diffInput);
+
+    expect(diffResult.changed).to.equal(true);
+    expect(diffResult.operations).to.not.be.empty;
+    expect(diffResult.summary.nodesChanged).to.equal(true);
+    expect(diffResult.summary.edgesChanged).to.equal(true);
+
+    const patchInput = GraphPatchInputSchema.parse({
+      graph_id: baseGraph.graphId,
+      base_version: baseGraph.graphVersion,
+      patch: diffResult.operations,
+      enforce_invariants: true,
+    });
+    const patchResult = handleGraphPatch(context, patchInput);
+
+    expect(patchResult.graph.nodes.map((node) => node.id)).to.include("review");
+    expect(patchResult.graph.edges).to.have.length(3);
+    expect(patchResult.changed).to.equal(true);
+    expect(patchResult.committed_version).to.equal(baseGraph.graphVersion + 1);
+    expect(patchResult.invariants?.ok ?? true).to.equal(true);
+
+    const latest = resources.read(`sc://graphs/${patchResult.graph_id}`);
+    const payload = latest.payload as ResourceGraphPayload;
+    expect(payload.version).to.equal(patchResult.committed_version);
+    expect(payload.graph.nodes.map((node) => node.id)).to.include("review");
+  });
+
+  it("rejects conflicting patches when a different holder owns the lock", () => {
+    const target: NormalisedGraph = {
+      ...baseGraph,
+      metadata: { ...baseGraph.metadata, release_channel: "beta" },
+    } satisfies NormalisedGraph;
+
+    const diffInput = GraphDiffInputSchema.parse({
+      graph_id: baseGraph.graphId,
+      from: { latest: true },
+      to: { graph: serialiseNormalisedGraph(target) },
+    });
+    const diffResult = handleGraphDiff(context, diffInput);
+
+    locks.acquire(baseGraph.graphId, "owner_a", { ttlMs: 5_000 });
+
+    const conflicting = GraphPatchInputSchema.parse({
+      graph_id: baseGraph.graphId,
+      base_version: baseGraph.graphVersion,
+      owner: "owner_b",
+      patch: diffResult.operations,
+      enforce_invariants: true,
+    });
+
+    expect(() => handleGraphPatch(context, conflicting)).to.throw(GraphMutationLockedError);
+
+    const allowed = GraphPatchInputSchema.parse({
+      graph_id: baseGraph.graphId,
+      base_version: baseGraph.graphVersion,
+      owner: "owner_a",
+      patch: diffResult.operations,
+      enforce_invariants: true,
+    });
+    const result = handleGraphPatch(context, allowed);
+    expect(result.changed).to.equal(true);
+    expect(result.graph.metadata?.release_channel).to.equal("beta");
+  });
+});

--- a/tests/graph.invariants.enforced.test.ts
+++ b/tests/graph.invariants.enforced.test.ts
@@ -1,0 +1,97 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import type { NormalisedGraph } from "../src/graph/types.js";
+import {
+  assertGraphInvariants,
+  evaluateGraphInvariants,
+  GraphInvariantError,
+} from "../src/graph/invariants.js";
+
+function createGraph(partial?: Partial<NormalisedGraph>): NormalisedGraph {
+  return {
+    name: "invariants",
+    graphId: "inv",
+    graphVersion: 1,
+    metadata: {},
+    nodes: [
+      { id: "alpha", label: "Alpha", attributes: {} },
+      { id: "beta", label: "Beta", attributes: {} },
+      { id: "gamma", label: "Gamma", attributes: {} },
+    ],
+    edges: [
+      { from: "alpha", to: "beta", label: "alpha->beta", attributes: { from_port: "out", to_port: "in" } },
+      { from: "beta", to: "gamma", label: "beta->gamma", attributes: { from_port: "out", to_port: "in" } },
+    ],
+    ...partial,
+  } satisfies NormalisedGraph;
+}
+
+describe("graph invariants", () => {
+  it("detects cycles when the graph declares itself as a DAG", () => {
+    const graph = createGraph({
+      metadata: { graph_kind: "dag" },
+      edges: [
+        { from: "alpha", to: "beta", label: "alpha->beta", attributes: { from_port: "out", to_port: "in" } },
+        { from: "beta", to: "gamma", label: "beta->gamma", attributes: { from_port: "out", to_port: "in" } },
+        { from: "gamma", to: "alpha", label: "gamma->alpha", attributes: { from_port: "out", to_port: "in" } },
+      ],
+    });
+
+    expect(() => assertGraphInvariants(graph)).to.throw(GraphInvariantError).that.satisfies((error: unknown) => {
+      const invariantError = error as GraphInvariantError;
+      expect(invariantError.violations.some((violation) => violation.code === "E-GRAPH-CYCLE")).to.equal(true);
+      return true;
+    });
+  });
+
+  it("requires node labels when metadata opts in", () => {
+    const graph = createGraph({ metadata: { require_labels: true } });
+    graph.nodes[1]!.label = "";
+
+    const report = evaluateGraphInvariants(graph);
+    expect(report.ok).to.equal(false);
+    const violation = report.violations.find((entry) => entry.code === "E-NODE-LABEL");
+    expect(violation).to.not.be.undefined;
+    expect(violation?.nodes).to.deep.equal(["beta"]);
+  });
+
+  it("requires port attributes when enabled", () => {
+    const graph = createGraph({ metadata: { require_ports: true } });
+    graph.edges[0]!.attributes = {};
+
+    expect(() => assertGraphInvariants(graph)).to.throw(GraphInvariantError).that.satisfies((error: unknown) => {
+      const invariantError = error as GraphInvariantError;
+      expect(invariantError.violations.some((violation) => violation.code === "E-EDGE-PORT")).to.equal(true);
+      return true;
+    });
+  });
+
+  it("enforces cardinality hints from metadata and node attributes", () => {
+    const graph = createGraph({ metadata: { max_in_degree: 1 } });
+    graph.edges.push({
+      from: "alpha",
+      to: "beta",
+      label: "alpha->beta#2",
+      attributes: { from_port: "out", to_port: "in" },
+    });
+
+    const report = evaluateGraphInvariants(graph);
+    expect(report.ok).to.equal(false);
+    expect(report.violations.some((violation) => violation.code === "E-IN-DEGREE")).to.equal(true);
+  });
+
+  it("accepts a graph respecting every declared invariant", () => {
+    const graph = createGraph({
+      metadata: {
+        graph_kind: "dag",
+        require_labels: true,
+        require_ports: true,
+        require_edge_labels: true,
+        max_in_degree: 2,
+      },
+    });
+
+    expect(() => assertGraphInvariants(graph)).to.not.throw();
+  });
+});

--- a/tests/graph.locks.concurrent.test.ts
+++ b/tests/graph.locks.concurrent.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import {
+  GraphLockManager,
+  GraphLockHeldError,
+  GraphLockUnknownError,
+  GraphMutationLockedError,
+} from "../src/graph/locks.js";
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import type { NormalisedGraph } from "../src/graph/types.js";
+import { ResourceRegistry } from "../src/resources/registry.js";
+import {
+  TxBeginInputSchema,
+  TxApplyInputSchema,
+  TxCommitInputSchema,
+  handleTxBegin,
+  handleTxApply,
+  handleTxCommit,
+  type TxToolContext,
+} from "../src/tools/txTools.js";
+import { serialiseNormalisedGraph } from "../src/tools/graphTools.js";
+
+function createGraph(): NormalisedGraph {
+  return {
+    name: "workflow",
+    graphId: "g1",
+    graphVersion: 1,
+    metadata: { graph_kind: "dag" },
+    nodes: [
+      { id: "plan", label: "Plan" },
+      { id: "build", label: "Build" },
+    ],
+    edges: [
+      { from: "plan", to: "build", label: "plan->build", weight: 1 },
+    ],
+  } satisfies NormalisedGraph;
+}
+
+describe("graph locks", () => {
+  let now: number;
+  let locks: GraphLockManager;
+
+  beforeEach(() => {
+    now = Date.now();
+    locks = new GraphLockManager(() => now);
+  });
+
+  it("supports re-entrance and TTL refresh for the same holder", () => {
+    now = 1_000;
+    const first = locks.acquire("g1", "owner_a", { ttlMs: 5_000 });
+    expect(first.expiresAt).to.equal(6_000);
+
+    now = 2_000;
+    const refreshed = locks.acquire("g1", "owner_a", { ttlMs: 7_000 });
+    expect(refreshed.lockId).to.equal(first.lockId);
+    expect(refreshed.refreshedAt).to.equal(2_000);
+    expect(refreshed.expiresAt).to.equal(9_000);
+  });
+
+  it("rejects competing holders until the previous lock expires", () => {
+    now = 1_000;
+    locks.acquire("g1", "owner_a", { ttlMs: 2_000 });
+
+    expect(() => locks.acquire("g1", "owner_b", { ttlMs: 2_000 })).to.throw(GraphLockHeldError);
+
+    now = 3_100;
+    const second = locks.acquire("g1", "owner_b", { ttlMs: 2_000 });
+    expect(second.holder).to.equal("owner_b");
+    expect(second.lockId).to.not.be.undefined;
+
+    const release = locks.release(second.lockId);
+    expect(release.expired).to.equal(false);
+
+    expect(() => locks.release(second.lockId)).to.throw(GraphLockUnknownError);
+  });
+
+  it("blocks transactions once a new holder acquires the graph", () => {
+    const baseGraph = createGraph();
+    const transactions = new GraphTransactionManager();
+    const resources = new ResourceRegistry();
+    const txContext: TxToolContext = { transactions, resources, locks };
+
+    now = 1_000;
+    locks.acquire(baseGraph.graphId, "owner_a", { ttlMs: 2_000 });
+
+    const begin = handleTxBegin(
+      txContext,
+      TxBeginInputSchema.parse({
+        graph_id: baseGraph.graphId,
+        owner: "owner_a",
+        graph: serialiseNormalisedGraph(baseGraph),
+      }),
+    );
+
+    const apply = handleTxApply(
+      txContext,
+      TxApplyInputSchema.parse({
+        tx_id: begin.tx_id,
+        operations: [
+          {
+            op: "add_node",
+            node: { id: "qa", label: "QA" },
+          },
+        ],
+      }),
+    );
+    expect(apply.changed).to.equal(true);
+
+    now = 3_500;
+    locks.acquire(baseGraph.graphId, "owner_b", { ttlMs: 2_000 });
+
+    expect(() =>
+      handleTxCommit(
+        txContext,
+        TxCommitInputSchema.parse({
+          tx_id: begin.tx_id,
+        }),
+      ),
+    ).to.throw(GraphMutationLockedError);
+  });
+});

--- a/tests/graphState.test.ts
+++ b/tests/graphState.test.ts
@@ -80,6 +80,9 @@ describe("GraphState", () => {
       exitSignal: null,
       forcedTermination: false,
       stopReason: null,
+      role: "navigator",
+      limits: { cpu_ms: 1_500, tokens: 5_000 },
+      attachedAt: baseTs + 50,
     };
 
     state.syncChildIndexSnapshot(snapshot);
@@ -94,6 +97,9 @@ describe("GraphState", () => {
     expect(synced?.exitCode).to.be.null;
     expect(synced?.exitSignal).to.be.null;
     expect(synced?.forcedTermination).to.equal(false);
+    expect(synced?.role).to.equal("navigator");
+    expect(synced?.limits).to.deep.equal({ cpu_ms: 1_500, tokens: 5_000 });
+    expect(synced?.attachedAt).to.equal(baseTs + 50);
 
     const terminatedSnapshot: ChildRecordSnapshot = {
       ...snapshot,
@@ -112,6 +118,9 @@ describe("GraphState", () => {
     expect(terminated?.exitSignal).to.equal("SIGTERM");
     expect(terminated?.forcedTermination).to.equal(true);
     expect(terminated?.stopReason).to.equal("timeout");
+    expect(terminated?.role).to.equal("navigator");
+    expect(terminated?.limits).to.deep.equal({ cpu_ms: 1_500, tokens: 5_000 });
+    expect(terminated?.attachedAt).to.equal(baseTs + 50);
   });
 
   it("ignore les instantanés inconnus sans lever d'erreur", () => {
@@ -130,6 +139,9 @@ describe("GraphState", () => {
       exitSignal: null,
       forcedTermination: false,
       stopReason: null,
+      role: null,
+      limits: null,
+      attachedAt: null,
     };
 
     expect(() => state.syncChildIndexSnapshot(orphanSnapshot)).to.not.throw();

--- a/tests/idempotency.replay.test.ts
+++ b/tests/idempotency.replay.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import { IdempotencyRegistry } from "../src/infra/idempotency.js";
+import { ChildCreateInputSchema, handleChildCreate, type ChildToolContext } from "../src/tools/childTools.js";
+import type { ChildSupervisor } from "../src/childSupervisor.js";
+import type { ChildRuntimeStatus } from "../src/childRuntime.js";
+import type { ChildRecordSnapshot } from "../src/state/childrenIndex.js";
+import {
+  PlanRunBTInputSchema,
+  PlanRunReactiveInputSchema,
+  handlePlanRunBT,
+  handlePlanRunReactive,
+  type PlanToolContext,
+} from "../src/tools/planTools.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import { handleCnpAnnounce, CnpAnnounceInputSchema, type CoordinationToolContext } from "../src/tools/coordTools.js";
+import { ContractNetCoordinator } from "../src/coord/contractNet.js";
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import { handleTxBegin, TxBeginInputSchema, type TxToolContext } from "../src/tools/txTools.js";
+import { GraphTransactionManager } from "../src/graph/tx.js";
+import { ResourceRegistry } from "../src/resources/registry.js";
+import { GraphLockManager } from "../src/graph/locks.js";
+import type { StructuredLogger } from "../src/logger.js";
+
+function createLoggerSpy(): StructuredLogger {
+  return {
+    info: sinon.spy(),
+    warn: sinon.spy(),
+    error: sinon.spy(),
+    debug: sinon.spy(),
+  } as unknown as StructuredLogger;
+}
+
+describe("idempotency cache integrations", () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("replays child_create once the result is cached", async () => {
+    const registry = new IdempotencyRegistry({ defaultTtlMs: 1_000, clock: () => clock.now });
+    const logger = createLoggerSpy();
+    const runtimeStatus: ChildRuntimeStatus = {
+      childId: "child-1",
+      pid: 1234,
+      command: "node",
+      args: ["child.js"],
+      workdir: "/tmp/child-1",
+      startedAt: 10,
+      lastHeartbeatAt: null,
+      lifecycle: "running",
+      closed: false,
+      exit: null,
+      resourceUsage: null,
+    };
+    const indexSnapshot: ChildRecordSnapshot = {
+      childId: "child-1",
+      pid: 1234,
+      workdir: "/tmp/child-1",
+      state: "running",
+      startedAt: 10,
+      lastHeartbeatAt: null,
+      retries: 0,
+      metadata: {},
+      endedAt: null,
+      exitCode: null,
+      exitSignal: null,
+      forcedTermination: false,
+      stopReason: null,
+      role: null,
+      limits: null,
+      attachedAt: null,
+    };
+    const runtime = {
+      manifestPath: "/tmp/child-1/manifest.json",
+      logPath: "/tmp/child-1/log.ndjson",
+      getStatus: () => runtimeStatus,
+    };
+    const createChild = sinon.stub().resolves({ childId: "child-1", runtime, index: indexSnapshot, readyMessage: null });
+    const send = sinon.stub().resolves();
+
+    const context: ChildToolContext = {
+      supervisor: { createChild, send } as unknown as ChildSupervisor,
+      logger,
+      contractNet: undefined,
+      supervisorAgent: undefined,
+      loopDetector: undefined,
+      idempotency: registry,
+    };
+
+    const input = ChildCreateInputSchema.parse({
+      command: "node",
+      args: ["--version"],
+      wait_for_ready: false,
+      idempotency_key: "child-alpha",
+    });
+
+    const first = await handleChildCreate(context, input);
+    const second = await handleChildCreate(context, input);
+
+    expect(first.idempotent).to.equal(false);
+    expect(second.idempotent).to.equal(true);
+    expect(second.child_id).to.equal(first.child_id);
+    expect(createChild.calledOnce).to.equal(true);
+
+    clock.tick(1_001);
+    const third = await handleChildCreate(context, input);
+    expect(third.idempotent).to.equal(false);
+    expect(createChild.callCount).to.equal(2);
+  });
+
+  it("returns cached plan_run_bt results on retries", async () => {
+    const registry = new IdempotencyRegistry({ defaultTtlMs: 5_000, clock: () => clock.now });
+    const logger = createLoggerSpy();
+    const events: Array<{ kind: string; payload: unknown }> = [];
+    const context: PlanToolContext = {
+      supervisor: {} as PlanToolContext["supervisor"],
+      graphState: {} as PlanToolContext["graphState"],
+      logger,
+      childrenRoot: "/tmp",
+      defaultChildRuntime: "codex",
+      emitEvent: (event) => events.push(event),
+      stigmergy: new StigmergyField(),
+      idempotency: registry,
+    };
+    const input = PlanRunBTInputSchema.parse({
+      tree: {
+        id: "cached-run",
+        root: { type: "task", id: "root", node_id: "root", tool: "noop", input_key: "payload" },
+      },
+      variables: { payload: { message: "ping" } },
+      idempotency_key: "plan-1",
+    });
+
+    const first = await handlePlanRunBT(context, input);
+    const second = await handlePlanRunBT(context, input);
+
+    expect(first.idempotent).to.equal(false);
+    expect(second.idempotent).to.equal(true);
+    expect(second.run_id).to.equal(first.run_id);
+    expect(logger.info.calledWithMatch("plan_run_bt_replayed", { idempotency_key: "plan-1" })).to.equal(true);
+  });
+
+  it("replays plan_run_reactive results on retries", async () => {
+    const registry = new IdempotencyRegistry({ defaultTtlMs: 5_000, clock: () => clock.now });
+    const logger = createLoggerSpy();
+    const events: Array<{ kind: string; payload: unknown }> = [];
+    const context: PlanToolContext = {
+      supervisor: {} as PlanToolContext["supervisor"],
+      graphState: {} as PlanToolContext["graphState"],
+      logger,
+      childrenRoot: "/tmp",
+      defaultChildRuntime: "codex",
+      emitEvent: (event) => events.push(event),
+      stigmergy: new StigmergyField(),
+      idempotency: registry,
+    };
+    const input = PlanRunReactiveInputSchema.parse({
+      tree: {
+        id: "cached-reactive",
+        root: { type: "task", id: "root", node_id: "root", tool: "noop", input_key: "payload" },
+      },
+      variables: { payload: { message: "ping" } },
+      tick_ms: 25,
+      idempotency_key: "plan-reactive-1",
+    });
+
+    const execution = handlePlanRunReactive(context, input);
+    await clock.tickAsync(25);
+    const first = await execution;
+    const second = await handlePlanRunReactive(context, input);
+
+    expect(first.idempotent).to.equal(false);
+    expect(second.idempotent).to.equal(true);
+    expect(second.run_id).to.equal(first.run_id);
+    expect(logger.info.calledWithMatch("plan_run_reactive_replayed", { idempotency_key: "plan-reactive-1" })).to.equal(true);
+  });
+
+  it("replays cnp_announce decisions when the key matches", () => {
+    const registry = new IdempotencyRegistry({ defaultTtlMs: 2_000, clock: () => clock.now });
+    const logger = createLoggerSpy();
+    const contractNet = new ContractNetCoordinator();
+    const announceSpy = sinon.spy(contractNet, "announce");
+    const bidSpy = sinon.spy(contractNet, "bid");
+    contractNet.registerAgent("agent-a", { baseCost: 3, reliability: 1 });
+
+    const context: CoordinationToolContext = {
+      blackboard: new BlackboardStore(),
+      stigmergy: new StigmergyField(),
+      contractNet,
+      logger,
+      idempotency: registry,
+    };
+
+    const input = CnpAnnounceInputSchema.parse({
+      task_id: "demo",
+      payload: { task: "write" },
+      tags: ["test"],
+      auto_bid: true,
+      manual_bids: [{ agent_id: "agent-a", cost: 3 }],
+      idempotency_key: "auction-1",
+    });
+
+    const first = handleCnpAnnounce(context, input);
+    const second = handleCnpAnnounce(context, input);
+
+    expect(first.idempotent).to.equal(false);
+    expect(second.idempotent).to.equal(true);
+    expect(second.call_id).to.equal(first.call_id);
+    expect(announceSpy.calledOnce).to.equal(true);
+    expect(bidSpy.calledOnce).to.equal(true);
+    expect(logger.info.calledWithMatch("cnp_announce_replayed", { idempotency_key: "auction-1" })).to.equal(true);
+  });
+
+  it("returns the same transaction descriptor when tx_begin retries", () => {
+    const registry = new IdempotencyRegistry({ defaultTtlMs: 3_000, clock: () => clock.now });
+    const transactions = new GraphTransactionManager();
+    const locks = new GraphLockManager(() => clock.now);
+    const resources = new ResourceRegistry({ blackboard: new BlackboardStore() });
+
+    const context: TxToolContext = { transactions, resources, locks, idempotency: registry };
+    const graphDescriptor = {
+      graph_id: "graph-1",
+      graph_version: 1,
+      name: "demo",
+      nodes: [{ id: "alpha" }],
+      edges: [],
+    } as const;
+    const input = TxBeginInputSchema.parse({
+      graph_id: graphDescriptor.graph_id,
+      graph: graphDescriptor,
+      idempotency_key: "tx-alpha",
+    });
+
+    const first = handleTxBegin(context, input);
+    const second = handleTxBegin(context, input);
+
+    expect(first.idempotent).to.equal(false);
+    expect(second.idempotent).to.equal(true);
+    expect(second.tx_id).to.equal(first.tx_id);
+    expect(transactions.describe(first.tx_id).txId).to.equal(first.tx_id);
+  });
+});
+

--- a/tests/plan.bt.events.test.ts
+++ b/tests/plan.bt.events.test.ts
@@ -14,6 +14,8 @@ import { StigmergyField } from "../src/coord/stigmergy.js";
 interface RecordedEvent {
   kind: string;
   payload?: unknown;
+  jobId?: string | null;
+  childId?: string | null;
 }
 
 describe("plan behaviour tree events", () => {
@@ -42,7 +44,12 @@ describe("plan behaviour tree events", () => {
       childrenRoot: "/tmp",
       defaultChildRuntime: "codex",
       emitEvent: (event) => {
-        events.push({ kind: event.kind, payload: event.payload });
+        events.push({
+          kind: event.kind,
+          payload: event.payload,
+          jobId: event.jobId ?? null,
+          childId: event.childId ?? null,
+        });
       },
       stigmergy: new StigmergyField(),
     };
@@ -69,6 +76,12 @@ describe("plan behaviour tree events", () => {
 
     expect(result.run_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+    expect(result.job_id).to.equal(null);
+    expect(result.graph_id).to.equal(null);
+    expect(result.node_id).to.equal(null);
+    expect(result.child_id).to.equal(null);
+    expect(result.idempotent).to.equal(false);
+    expect(result.idempotency_key).to.equal(null);
 
     const startEvent = events.find((evt) => (evt.payload as { phase?: string })?.phase === "start");
     expect(startEvent, "start event present").to.exist;
@@ -86,6 +99,58 @@ describe("plan behaviour tree events", () => {
     const completeEvent = events.find((evt) => (evt.payload as { phase?: string })?.phase === "complete");
     expect(completeEvent, "complete event present").to.exist;
     expect((completeEvent!.payload as { status?: string }).status).to.equal(result.status);
+  });
+
+  it("propagates provided correlation hints for plan_run_bt telemetry", async () => {
+    const { context, events } = buildContext();
+    const input = PlanRunBTInputSchema.parse({
+      tree: {
+        id: "demo-correlated",
+        root: {
+          type: "task",
+          id: "root",
+          node_id: "root",
+          tool: "noop",
+          input_key: "payload",
+        },
+      },
+      variables: { payload: { message: "ping" } },
+      run_id: "bt-run-123",
+      op_id: "bt-op-456",
+      job_id: "job-789",
+      graph_id: "graph-42",
+      node_id: "plan-node-1",
+      child_id: "child-17",
+    });
+
+    const result = await handlePlanRunBT(context, input);
+
+    expect(result.run_id).to.equal("bt-run-123");
+    expect(result.op_id).to.equal("bt-op-456");
+    expect(result.job_id).to.equal("job-789");
+    expect(result.graph_id).to.equal("graph-42");
+    expect(result.node_id).to.equal("plan-node-1");
+    expect(result.child_id).to.equal("child-17");
+    expect(result.idempotent).to.equal(false);
+    expect(result.idempotency_key).to.equal(null);
+
+    const startEvent = events.find((evt) => (evt.payload as { phase?: string })?.phase === "start");
+    expect(startEvent, "start event present").to.exist;
+    const startPayload = startEvent!.payload as {
+      run_id?: string | null;
+      op_id?: string | null;
+      job_id?: string | null;
+      graph_id?: string | null;
+      node_id?: string | null;
+      child_id?: string | null;
+    };
+    expect(startEvent!.jobId).to.equal("job-789");
+    expect(startPayload.run_id).to.equal("bt-run-123");
+    expect(startPayload.op_id).to.equal("bt-op-456");
+    expect(startPayload.job_id).to.equal("job-789");
+    expect(startPayload.graph_id).to.equal("graph-42");
+    expect(startPayload.node_id).to.equal("plan-node-1");
+    expect(startPayload.child_id).to.equal("child-17");
   });
 
   it("tracks reactive scheduler phases with consistent identifiers", async () => {
@@ -111,6 +176,10 @@ describe("plan behaviour tree events", () => {
 
     expect(result.run_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+    expect(result.job_id).to.equal(null);
+    expect(result.graph_id).to.equal(null);
+    expect(result.node_id).to.equal(null);
+    expect(result.child_id).to.equal(null);
 
     const phases = events
       .map((evt) => (evt.payload as { phase?: string })?.phase)
@@ -126,5 +195,60 @@ describe("plan behaviour tree events", () => {
     );
     expect(distinctRunIds.size).to.equal(1);
     expect([...distinctRunIds][0]).to.equal(result.run_id);
+  });
+
+  it("propagates provided correlation hints for plan_run_reactive telemetry", async () => {
+    const { context, events } = buildContext();
+    const input = PlanRunReactiveInputSchema.parse({
+      tree: {
+        id: "demo-reactive",
+        root: {
+          type: "task",
+          id: "root",
+          node_id: "root",
+          tool: "noop",
+          input_key: "payload",
+        },
+      },
+      variables: { payload: { message: "pong" } },
+      tick_ms: 15,
+      run_id: "reactive-run",
+      op_id: "reactive-op",
+      job_id: "job-reactive",
+      graph_id: "graph-reactive",
+      node_id: "node-reactive",
+      child_id: "child-reactive",
+    });
+
+    const execution = handlePlanRunReactive(context, input);
+    await clock.tickAsync(15);
+    const result = await execution;
+
+    expect(result.run_id).to.equal("reactive-run");
+    expect(result.op_id).to.equal("reactive-op");
+    expect(result.job_id).to.equal("job-reactive");
+    expect(result.graph_id).to.equal("graph-reactive");
+    expect(result.node_id).to.equal("node-reactive");
+    expect(result.child_id).to.equal("child-reactive");
+    expect(result.idempotent).to.equal(false);
+    expect(result.idempotency_key).to.equal(null);
+
+    const startEvent = events.find((evt) => (evt.payload as { phase?: string })?.phase === "start");
+    expect(startEvent, "start event present").to.exist;
+    const startPayload = startEvent!.payload as {
+      run_id?: string | null;
+      op_id?: string | null;
+      job_id?: string | null;
+      graph_id?: string | null;
+      node_id?: string | null;
+      child_id?: string | null;
+    };
+    expect(startEvent!.jobId).to.equal("job-reactive");
+    expect(startPayload.run_id).to.equal("reactive-run");
+    expect(startPayload.op_id).to.equal("reactive-op");
+    expect(startPayload.job_id).to.equal("job-reactive");
+    expect(startPayload.graph_id).to.equal("graph-reactive");
+    expect(startPayload.node_id).to.equal("node-reactive");
+    expect(startPayload.child_id).to.equal("child-reactive");
   });
 });

--- a/tests/plan.dry-run.test.ts
+++ b/tests/plan.dry-run.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { StructuredLogger } from "../src/logger.js";
+import { GraphState } from "../src/graphState.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import { ValueGraph } from "../src/values/valueGraph.js";
+import {
+  PlanDryRunInputSchema,
+  type PlanToolContext,
+  handlePlanDryRun,
+} from "../src/tools/planTools.js";
+
+describe("plan dry run integration", () => {
+  let tmpDir: string;
+  let logger: StructuredLogger;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "plan-dry-run-"));
+    logger = new StructuredLogger({ logFile: path.join(tmpDir, "orchestrator.log") });
+  });
+
+  afterEach(async () => {
+    await logger.flush();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildContext(overrides: Partial<PlanToolContext> = {}): PlanToolContext {
+    const base: PlanToolContext = {
+      supervisor: {} as never,
+      graphState: new GraphState(),
+      logger,
+      childrenRoot: tmpDir,
+      defaultChildRuntime: "codex",
+      emitEvent: () => {
+        /* intentionally left blank for dry-run tests */
+      },
+      stigmergy: new StigmergyField(),
+    };
+    return { ...base, ...overrides };
+  }
+
+  it("aggregates node impacts and surfaces value guard explanations", () => {
+    const valueGraph = new ValueGraph();
+    valueGraph.set({
+      defaultThreshold: 0.7,
+      values: [
+        { id: "privacy", weight: 1, tolerance: 0.2 },
+        { id: "safety", weight: 1, tolerance: 0.4 },
+        { id: "compliance", weight: 1, tolerance: 0.5 },
+      ],
+    });
+
+    const context = buildContext({ valueGuard: { graph: valueGraph, registry: new Map() } });
+
+    const input = PlanDryRunInputSchema.parse({
+      plan_id: "plan-42",
+      plan_label: "Risky experiment",
+      threshold: 0.6,
+      graph: {
+        id: "demo-graph",
+        nodes: [
+          { id: "alpha", kind: "task", label: "Alpha", attributes: { bt_tool: "noop" } },
+          { id: "beta", kind: "task", label: "Beta", attributes: { bt_tool: "noop" } },
+        ],
+        edges: [{ id: "edge-alpha-beta", from: { nodeId: "alpha" }, to: { nodeId: "beta" } }],
+      },
+      nodes: [
+        {
+          id: "alpha",
+          label: "Alpha",
+          value_impacts: [
+            { value: "privacy", impact: "risk", severity: 0.9 },
+            { value: "safety", impact: "support", severity: 0.4, nodeId: "custom-node" },
+          ],
+        },
+      ],
+      impacts: [{ value: "compliance", impact: "risk", severity: 0.6, source: "global" }],
+    });
+
+    const result = handlePlanDryRun(context, input);
+
+    expect(result.compiled_tree).to.not.equal(null);
+    expect(result.compiled_tree?.id).to.equal("demo-graph");
+    expect(result.nodes).to.have.length(1);
+    expect(result.nodes[0]?.impacts).to.have.length(2);
+    expect(result.nodes[0]?.impacts[0]?.nodeId).to.equal("alpha");
+    expect(result.nodes[0]?.impacts[1]?.nodeId).to.equal("custom-node");
+
+    expect(result.impacts).to.have.length(3);
+
+    expect(result.value_guard).to.not.equal(null);
+    expect(result.value_guard?.decision.allowed).to.equal(false);
+    const privacyViolation = result.value_guard?.violations.find((violation) => violation.value === "privacy");
+    expect(privacyViolation).to.not.equal(undefined);
+    expect(privacyViolation?.nodeId).to.equal("alpha");
+    expect(privacyViolation?.primaryContributor?.impact.nodeId).to.equal("alpha");
+  });
+
+  it("returns null explanations when the value guard is disabled", () => {
+    const context = buildContext();
+
+    const input = PlanDryRunInputSchema.parse({
+      plan_id: "plan-no-guard",
+      impacts: [{ value: "privacy", impact: "risk", severity: 0.2 }],
+    });
+
+    const result = handlePlanDryRun(context, input);
+
+    expect(result.value_guard).to.equal(null);
+    expect(result.impacts).to.have.length(1);
+    expect(result.compiled_tree).to.equal(null);
+  });
+
+  it("propagates correlation hints to value guard telemetry", () => {
+    const valueGraph = new ValueGraph();
+    valueGraph.set({
+      defaultThreshold: 0.2,
+      values: [
+        { id: "privacy", weight: 1, tolerance: 0.1 },
+        { id: "safety", weight: 1, tolerance: 0.2 },
+      ],
+    });
+
+    const capturedEvents: unknown[] = [];
+    const unsubscribe = valueGraph.subscribe((event) => {
+      capturedEvents.push(event);
+    });
+
+    const context = buildContext({ valueGuard: { graph: valueGraph, registry: new Map() } });
+
+    const input = PlanDryRunInputSchema.parse({
+      plan_id: "plan-correlation",
+      run_id: "run-123",
+      op_id: "op-456",
+      job_id: "job-789",
+      graph_id: "graph-321",
+      node_id: "node-654",
+      child_id: "child-987",
+      impacts: [{ value: "privacy", impact: "risk", severity: 0.4 }],
+    });
+
+    handlePlanDryRun(context, input);
+
+    unsubscribe();
+
+    expect(capturedEvents).to.have.length(1);
+    const [event] = capturedEvents as Array<{
+      kind: string;
+      correlation: {
+        runId: string | null;
+        opId: string | null;
+        jobId: string | null;
+        graphId: string | null;
+        nodeId: string | null;
+        childId: string | null;
+      } | null;
+    }>;
+    expect(event.kind).to.equal("plan_explained");
+    expect(event.correlation).to.not.equal(null);
+    expect(event.correlation?.runId).to.equal("run-123");
+    expect(event.correlation?.opId).to.equal("op-456");
+    expect(event.correlation?.jobId).to.equal("job-789");
+    expect(event.correlation?.graphId).to.equal("graph-321");
+    expect(event.correlation?.nodeId).to.equal("node-654");
+    expect(event.correlation?.childId).to.equal("child-987");
+  });
+});

--- a/tests/plan.run-reactive.test.ts
+++ b/tests/plan.run-reactive.test.ts
@@ -110,6 +110,8 @@ describe("plan_run_reactive tool", () => {
     const result = await execution;
 
     expect(result.status).to.equal("success");
+    expect(result.idempotent).to.equal(false);
+    expect(result.idempotency_key).to.equal(null);
     expect(result.loop_ticks).to.equal(1);
     expect(result.scheduler_ticks).to.be.greaterThanOrEqual(1);
     expect(result.invocations).to.have.length(1);
@@ -147,6 +149,8 @@ describe("plan_run_reactive tool", () => {
     const result = await execution;
 
     expect(result.status).to.equal("success");
+    expect(result.idempotent).to.equal(false);
+    expect(result.idempotency_key).to.equal(null);
     expect(result.invocations).to.have.length(1);
     expect(result.invocations[0]).to.include({ executed: false, output: null });
     expect(result.last_output).to.equal(null);

--- a/tests/tx.begin-apply-commit.test.ts
+++ b/tests/tx.begin-apply-commit.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import { GraphTransactionManager, GraphVersionConflictError } from "../src/graph/tx.js";
+import { GraphLockManager } from "../src/graph/locks.js";
+import { ResourceRegistry } from "../src/resources/registry.js";
+import {
+  handleTxBegin,
+  handleTxApply,
+  handleTxCommit,
+  handleTxRollback,
+  TxBeginInputSchema,
+  TxApplyInputSchema,
+  TxCommitInputSchema,
+  TxRollbackInputSchema,
+  type TxToolContext,
+} from "../src/tools/txTools.js";
+
+/**
+ * Builds a minimal but connected graph descriptor used across the transaction
+ * tests. Keeping it deterministic ensures preview versions remain stable.
+ */
+function createGraphDescriptor() {
+  return {
+    name: "workflow",
+    graph_id: "demo-graph",
+    graph_version: 1,
+    nodes: [
+      { id: "alpha", label: "Alpha" },
+      { id: "beta", label: "Beta" },
+    ],
+    edges: [
+      { from: "alpha", to: "beta" },
+    ],
+  };
+}
+
+describe("transaction tool handlers", () => {
+  let transactions: GraphTransactionManager;
+  let resources: ResourceRegistry;
+  let context: TxToolContext;
+  let locks: GraphLockManager;
+
+  beforeEach(() => {
+    transactions = new GraphTransactionManager();
+    resources = new ResourceRegistry();
+    locks = new GraphLockManager(() => Date.now());
+    context = { transactions, resources, locks };
+  });
+
+  it("opens, mutates and commits a transaction while recording resources", () => {
+    const graphDescriptor = createGraphDescriptor();
+    const beginInput = TxBeginInputSchema.parse({
+      graph_id: graphDescriptor.graph_id,
+      owner: "testsuite",
+      note: "initial import",
+      ttl_ms: 5_000,
+      graph: graphDescriptor,
+    });
+    const beginResult = handleTxBegin(context, beginInput);
+
+    expect(beginResult.graph.nodes).to.have.length(2);
+    expect(beginResult.owner).to.equal("testsuite");
+    expect(beginResult.expires_at).to.be.a("number");
+    expect(beginResult.idempotent).to.equal(false);
+    expect(beginResult.idempotency_key).to.equal(null);
+
+    const snapshotResource = resources.read(`sc://snapshots/${beginResult.graph_id}/${beginResult.tx_id}`);
+    expect(snapshotResource.kind).to.equal("snapshot");
+    const snapshotPayload = snapshotResource.payload as {
+      state: string;
+      owner: string | null;
+      note: string | null;
+      expiresAt: number | null;
+    };
+    expect(snapshotPayload.state).to.equal("pending");
+    expect(snapshotPayload.owner).to.equal("testsuite");
+    expect(snapshotPayload.note).to.equal("initial import");
+    expect(snapshotPayload.expiresAt).to.be.a("number");
+
+    const applyInput = TxApplyInputSchema.parse({
+      tx_id: beginResult.tx_id,
+      operations: [
+        { op: "add_node", node: { id: "gamma", label: "Gamma" } },
+        { op: "add_edge", edge: { from: "beta", to: "gamma" } },
+      ],
+    });
+    const applyResult = handleTxApply(context, applyInput);
+    expect(applyResult.changed).to.equal(true);
+    expect(applyResult.preview_version).to.equal(beginResult.base_version + 1);
+    expect(applyResult.applied.filter((entry) => entry.changed)).to.have.length(2);
+    expect(applyResult.graph.nodes).to.have.length(3);
+    expect(applyResult.graph.edges).to.have.length(2);
+
+    const commitInput = TxCommitInputSchema.parse({ tx_id: beginResult.tx_id });
+    const commitResult = handleTxCommit(context, commitInput);
+    expect(commitResult.version).to.equal(beginResult.base_version + 1);
+    expect(commitResult.graph.graph_version).to.equal(commitResult.version);
+
+    const graphResource = resources.read(`sc://graphs/${commitResult.graph_id}`);
+    expect(graphResource.kind).to.equal("graph");
+    const committedGraph = graphResource.payload.graph as { nodes: unknown[] };
+    expect(committedGraph.nodes).to.have.length(3);
+
+    const committedSnapshot = resources.read(`sc://snapshots/${commitResult.graph_id}/${commitResult.tx_id}`);
+    const committedPayload = committedSnapshot.payload as { state: string };
+    expect(committedPayload.state).to.equal("committed");
+  });
+
+  it("raises a version conflict when committing a stale transaction", () => {
+    const graphDescriptor = createGraphDescriptor();
+    const firstTx = handleTxBegin(
+      context,
+      TxBeginInputSchema.parse({ graph_id: graphDescriptor.graph_id, graph: graphDescriptor }),
+    );
+    const secondTx = handleTxBegin(
+      context,
+      TxBeginInputSchema.parse({ graph_id: graphDescriptor.graph_id, graph: graphDescriptor }),
+    );
+
+    expect(firstTx.idempotent).to.equal(false);
+    expect(secondTx.idempotent).to.equal(false);
+
+    const firstApply = handleTxApply(
+      context,
+      TxApplyInputSchema.parse({ tx_id: firstTx.tx_id, operations: [{ op: "remove_edge", from: "alpha", to: "beta" }] }),
+    );
+    expect(firstApply.preview_version).to.equal(firstTx.base_version + 1);
+    handleTxCommit(context, TxCommitInputSchema.parse({ tx_id: firstTx.tx_id }));
+
+    expect(() => handleTxCommit(context, TxCommitInputSchema.parse({ tx_id: secondTx.tx_id }))).to.throw(
+      GraphVersionConflictError,
+    );
+  });
+
+  it("rolls back a transaction and exposes the original snapshot", () => {
+    const graphDescriptor = createGraphDescriptor();
+    const beginResult = handleTxBegin(
+      context,
+      TxBeginInputSchema.parse({ graph_id: graphDescriptor.graph_id, graph: graphDescriptor, note: "rollback" }),
+    );
+
+    handleTxApply(
+      context,
+      TxApplyInputSchema.parse({ tx_id: beginResult.tx_id, operations: [{ op: "remove_node", id: "beta" }] }),
+    );
+
+    const rollbackResult = handleTxRollback(context, TxRollbackInputSchema.parse({ tx_id: beginResult.tx_id }));
+    expect(rollbackResult.snapshot.nodes).to.have.length(2);
+
+    const snapshotResource = resources.read(`sc://snapshots/${rollbackResult.graph_id}/${rollbackResult.tx_id}`);
+    const rolledPayload = snapshotResource.payload as { state: string };
+    expect(rolledPayload.state).to.equal("rolled_back");
+    expect(transactions.countActiveTransactions()).to.equal(0);
+  });
+});

--- a/tests/values.explain.integration.test.ts
+++ b/tests/values.explain.integration.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ValueGraph } from "../src/values/valueGraph.js";
+
+/**
+ * Integration-level coverage for the value guard explanation helper. The tests
+ * verify that violations are enriched with correlation metadata and human
+ * readable hints so MCP clients can present actionable diagnostics.
+ */
+describe("values guard explanations", () => {
+  it("produces actionable hints and correlation metadata", () => {
+    const graph = new ValueGraph();
+    graph.set({
+      defaultThreshold: 0.6,
+      values: [
+        { id: "privacy", weight: 1, tolerance: 0.25, label: "Privacy" },
+        { id: "compliance", weight: 0.8, tolerance: 0.5, label: "Compliance" },
+      ],
+      relationships: [
+        { from: "privacy", to: "compliance", kind: "supports", weight: 0.6 },
+      ],
+    });
+
+    const explanation = graph.explain({
+      id: "plan-risk",
+      label: "Risky data export",
+      impacts: [
+        {
+          value: "privacy",
+          impact: "risk",
+          severity: 0.9,
+          rationale: "shares raw customer data",
+          source: "task:export",
+          nodeId: "task-export",
+        },
+      ],
+    });
+
+    expect(explanation.decision.allowed).to.equal(false);
+    expect(explanation.decision.violations).to.have.lengthOf(2);
+    expect(explanation.violations).to.have.lengthOf(explanation.decision.violations.length);
+
+    const privacy = explanation.violations.find((entry) => entry.value === "privacy");
+    expect(privacy).to.not.equal(undefined);
+    expect(privacy?.nodeId).to.equal("task-export");
+    expect(privacy?.primaryContributor?.amount).to.be.closeTo(0.9, 1e-6);
+    expect(privacy?.hint).to.include("Direct risk impact");
+    expect(privacy?.hint).to.include("shares raw customer data");
+
+    const compliance = explanation.violations.find((entry) => entry.value === "compliance");
+    expect(compliance).to.not.equal(undefined);
+    expect(compliance?.primaryContributor?.propagated).to.equal(true);
+    expect(compliance?.primaryContributor?.via).to.equal("supports");
+    expect(compliance?.hint).to.include("Risk propagated from value 'privacy'");
+    expect(compliance?.hint).to.include("via supports");
+    expect(compliance?.hint).to.include("plan node 'task-export'");
+  });
+
+  it("guides operators when a plan references an unknown value", () => {
+    const graph = new ValueGraph();
+    graph.set({
+      defaultThreshold: 0.6,
+      values: [{ id: "safety", weight: 1, tolerance: 0.3 }],
+    });
+
+    const explanation = graph.explain({
+      id: "plan-unknown",
+      label: "Plan referencing undefined value",
+      impacts: [
+        {
+          value: "undefined",
+          impact: "risk",
+          severity: 0.5,
+          rationale: "touches unspecified principle",
+        },
+      ],
+    });
+
+    const violation = explanation.violations.find((entry) => entry.value === "undefined");
+    expect(violation).to.not.equal(undefined);
+    expect(violation?.nodeId).to.equal(null);
+    expect(violation?.hint).to.include("Declare the missing value");
+    expect(explanation.decision.allowed).to.equal(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated graph_batch_mutate helper with transactional commits, idempotency support, and server wiring
- expose child_batch_create with rollback-aware bookkeeping, created counts, and docs plus stig_batch with atomic pheromone updates
- expand the bulk integration tests and MCP documentation to cover graph/child/stig batches and updated README guidance

## Testing
- npm run build
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df55f60448832f89a144a62178fd6b