### PR TITLE
Add paused plan lifecycle coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,14 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
   * [x] Consensus : décisions agrégées → `EventBus` (run/op/job + métadonnées)
 * [ ] **Modifier** `src/executor/*`, `src/coord/*`, `src/agents/*`
 
-  * [ ] Publier évènements standardisés avec `opId/runId`
+  * [ ] Publier évènements standardisés avec `opId/runId` *(Contract-Net : corrélations propagées dans `contractNet` + `bridgeContractNetEvents`, reste à aligner exécuteur/agents)*
+    * [x] Autoscaler publie `AUTOSCALER` avec corrélations child/run/op/job (itération 119)
+    * [x] Autoscaler et passerelle child runtime réutilisent `extractCorrelationHints` et préservent les null explicites tout en gardant les identifiants natifs (itération 121)
+    * [x] `child_collect` publie des événements `COGNITIVE` corrélés (metaCritic + selfReflect) via `buildChildCognitiveEvents` (itération 122)
+    * [x] `child_prompt`/`child_chat`/`child_reply`/`child_kill` et outils associés publient désormais des événements `PROMPT`/`PENDING`/`REPLY`/`INFO`/`KILL` corrélés en fusionnant les métadonnées `ChildrenIndex` avec les hints extraits (itération 123)
+  * [x] Extraire les corrélations des incidents du superviseur afin que les événements `supervisor_*` exposent `runId/opId/childId` quand disponibles
+  * [x] Acheminer les corrélations fournies par les outils plan via `PlanEventEmitter` et `pushEvent` (itération 117)
+  * [x] Empêcher les resolvers Contract-Net d'effacer les corrélations natives lorsqu'ils retournent des `undefined` (itération 113)
 * [x] **Modifier** `src/server.ts`
 
   * [x] tool `events_subscribe({cats?, runId?})` (stream SSE/jsonlines)
@@ -184,14 +191,14 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 ### 3.1 Lifecycle uniforme
 
-* [ ] **Créer** `src/executor/planLifecycle.ts`
+* [x] **Créer** `src/executor/planLifecycle.ts`
 
-  * [ ] États : `running|paused|done|failed`, progression %, last event seq
-* [ ] **Modifier** `src/server.ts`
+  * [x] États : `running|paused|done|failed`, progression %, last event seq
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] tools `plan_status({runId})`, `plan_pause({runId})`, `plan_resume({runId})`
-  * [ ] `plan_dry_run({graphId|btJson})` → compile, applique `values_explain`, `rewrite` **en preview**
-* [ ] **Tests** : `tests/plan.lifecycle.test.ts`, `tests/plan.dry-run.test.ts`
+  * [x] tools `plan_status({runId})`, `plan_pause({runId})`, `plan_resume({runId})`
+  * [x] `plan_dry_run({graphId|btJson})` → compile, applique `values_explain`, `rewrite` **en preview**
+  * [x] **Tests** : `tests/plan.lifecycle.test.ts`, `tests/plan.dry-run.test.ts`
 
 ### 3.2 Child operations
 
@@ -311,13 +318,13 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 ### 6.1 Logs corrélés & tail
 
-* [ ] **Créer** `src/monitor/log.ts`
+* [x] **Créer** `src/monitor/log.ts`
 
-  * [ ] Log JSONL avec `runId|opId|graphId|childId|seq` ; rotation
-* [ ] **Modifier** `src/server.ts`
+  * [x] Log JSONL avec `runId|opId|graphId|childId|seq` ; rotation
+* [x] **Modifier** `src/server.ts`
 
-  * [ ] tool `logs_tail({stream:"server"|"run"|"child", id?, limit?, fromSeq?})`
-* [ ] **Tests** : `tests/logs.tail.filters.test.ts` (filtres, fromSeq)
+  * [x] tool `logs_tail({stream:"server"|"run"|"child", id?, limit?, fromSeq?})`
+* [x] **Tests** : `tests/logs.tail.filters.test.ts` (filtres, fromSeq)
 
 ### 6.2 Dashboard overlays
 
@@ -644,3 +651,119 @@ Si tu veux, je peux te générer à la demande les **squelettes TypeScript** exa
 - ✅ Mis à jour `README.md` et `docs/mcp-api.md` pour détailler les nouveaux schémas (`StigBatchInput`, `GraphBatchMutateInput`, `ChildBatchCreateInput`) et clarifier les champs `created`/`changed`.
 - ✅ Étendu `tests/bulk.bb-graph-child-stig.test.ts` avec les scénarios de version attendue, no-op, comptage `created` et rollback enfants ; exécuté la suite complète (`npm run build`, `npm run lint`, `npm test`).
 - 🔜 Couvrir l'émission des événements bus/corrélations pour les outils bulk côté serveur et ajouter un test d'intégration MCP end-to-end.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 112)
+- ✅ Propagé les identifiants de corrélation (run/op/job) dans le Contract-Net (`contractNet.announce`, snapshots, évènements bus) et dans l'outillage `cnp_announce`.
+- ✅ Mis à jour `bridgeContractNetEvents` pour fusionner automatiquement les corrélations natives avec les résolveurs optionnels.
+- ✅ Étendu la couverture (`tests/events.bridges.test.ts`, `tests/e2e.contract-net.consensus.test.ts`) pour vérifier la présence des métadonnées et la sérialisation côté tool ; exécuté `npm ci`, `npm test`.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 113)
+- ✅ Durci `bridgeContractNetEvents` afin que les résolveurs ne puissent plus écraser les corrélations natives avec des valeurs `undefined`, en factorisant `mergeCorrelationHints` côté source et dist (`src/events/bridges.ts`, `dist/events/bridges.js`).
+- ✅ Ajouté un test de régression vérifiant que les auto-bids conservent `runId/opId` même lorsque le resolver renvoie `undefined` (`tests/events.bridges.test.ts`).
+- ✅ Exécuté la suite complète (`npm ci`, `npm test`), puis nettoyé les artefacts temporaires (`children/`, `node_modules/`).
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 114)
+- ✅ Extrait les utilitaires de corrélation dans `src/events/correlation.ts` et synchronisé la version dist pour réutiliser `mergeCorrelationHints` sans duplication.
+- ✅ Aligné `bridgeContractNetEvents`, le superviseur enfant et la suite de tests sur le nouveau module partagé, en ajoutant une couverture unitaire dédiée (`tests/events.correlation.test.ts`).
+- 🔜 Étendre l'utilisation du module de corrélation aux autres passerelles (executor/agents) afin de finaliser la checklist "Event bus unifié & corrélation".
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 115)
+- ✅ Préservé les indices de corrélation natifs du `ChildSupervisor` en fusionnant les résolveurs via `mergeCorrelationHints` pour éviter qu'un `undefined` efface `childId/runId/opId`.
+- ✅ Ajouté un scénario `tests/child.supervisor.test.ts` garantissant que les journaux enfants conservent les identifiants quand le résolveur est clairsemé.
+- ✅ Propager la fusion sûre des corrélations vers les autres passerelles (`executor/*`, `agents/*`) afin de clôturer la tâche "Event bus unifié & corrélation".
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 116)
+- ✅ Harmonisé les passerelles d'événements annulés/enfants/consensus/values avec `mergeCorrelationHints` pour empêcher les résolveurs clairsemés de purger `runId/opId/jobId`.
+- ✅ Ajouté des régressions ciblées (`tests/events.bridges.test.ts`) couvrant les résolveurs qui retournent `undefined` ou `null` et vérifié que les identifiants natifs subsistent.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test`.
+- 🔜 Auditer les autres émetteurs d'événements (plan/executor/agents restants) pour confirmer l'absence de fuites `undefined` et préparer l'exposition côté tools MCP (`events_subscribe`, cancel/bulk).
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 117)
+- ✅ Propagé les corrélations fournies par les outils plan vers le bus unifié via `PlanEventEmitter` et `pushEvent`, en fusionnant les hints externes avec ceux extraits des payloads.
+- ✅ Étendu `tests/plan.bt.events.test.ts` pour vérifier que les événements Behaviour Tree et réactifs exposent systématiquement les identifiants de corrélation.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test` (après `npm ci`) et nettoyé `node_modules/` et `children/` avant commit.
+- 🔜 Finaliser l'alignement des autres émetteurs (`src/executor/*`, `src/agents/*`) afin que chaque événement plan/superviseur publie `runId/opId` sans dépendre exclusivement du payload.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 118)
+- ✅ Ajouté `inferSupervisorIncidentCorrelation` pour dériver run/op/job/child depuis le contexte des incidents et alimenter `pushEvent` côté serveur.
+- ✅ Créé `tests/agents.supervisor.correlation.test.ts` couvrant la normalisation camelCase/snake_case, les tableaux unitaires et la fusion non destructive des corrélations embarquées.
+- ✅ Exécuté `npm test` (lint/build à planifier avec les prochaines itérations pour l'alignement complet des émetteurs restants).
+- 🔜 Étendre la propagation des corrélations au reste des actions superviseur/autoscaler et boucler l'item "Modifier src/executor/*, src/agents/*".
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 119)
+- ✅ Instrumenté l'autoscaler pour publier des événements `AUTOSCALER` via `pushEvent`, en fusionnant les corrélations issues des métadonnées enfants et des gabarits de spawn.
+- ✅ Ajouté `tests/agents.autoscaler.correlation.test.ts` pour couvrir la retraite nominale, l'escalade forcée et l'échec du kill tout en vérifiant la préservation des hints run/op/job/graph/node.
+- ✅ Étendu `EventStore` afin d'accepter la catégorie `AUTOSCALER` et branché le serveur sur le nouvel émetteur ; exécuté `npm run lint`, `npm run build`, `npm test`.
+- 🔜 Poursuivre l'alignement des autres agents/exécuteurs (scheduler, metaCritic, etc.) afin de finaliser la case "Publier évènements standardisés avec opId/runId".
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 120)
+- ✅ Étendu `events/correlation` avec `extractCorrelationHints` puis refactorisé `inferSupervisorIncidentCorrelation` et `ChildSupervisor` pour dériver automatiquement run/op/job/graph/node/child depuis les métadonnées runtime et index, supprimant la dépendance aux résolveurs ad-hoc.
+- ✅ Ajouté des tests ciblés (`tests/events.correlation.test.ts`, `tests/child.supervisor.test.ts`) validant l'extraction (snake/camel case, blocs imbriqués, métadonnées enfants) et la propagation des hints sur le bus `child`.
+- ✅ Regénéré les artefacts dist (`npm run build`), linté (`npm run lint`) et exécuté la suite complète (`npm test`) pour garantir l'absence de régressions.
+- 🔜 Finaliser la case "Publier événements standardisés avec opId/runId" côté scheduler/agents restants (metaCritic/selfReflect, boucle réactive) en capitalisant sur `extractCorrelationHints` lorsque les métadonnées sont disponibles.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 121)
+- ✅ Étendu `extractCorrelationHints` pour préserver les overrides explicites à `null` tout en normalisant les tableaux ambigus et fusionné l'autoscaler sur cette implémentation commune.
+- ✅ Aligné `src/agents/autoscaler.ts` et `bridgeChildRuntimeEvents` sur le nouveau helper, garantissant que les métadonnées runtime/index et les templates de spawn conservent les identifiants sans effacer volontairement les `null`.
+- ✅ Renforcé la couverture (`tests/events.correlation.test.ts`, `tests/agents.autoscaler.correlation.test.ts`, `tests/events.bridges.test.ts`) afin de couvrir les scénarios `null`/manifest extras/scale up ; exécuté `npm run lint`, `npm run build`, `npm test`.
+- 🔜 Poursuivre l'audit des émetteurs restants (`src/executor/*`, autres agents) pour éliminer les duplications d'inférence et préparer la clôture de la checklist "Publier événements standardisés avec opId/runId".
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 122)
+- ✅ Introduit `buildChildCognitiveEvents` et la catégorie `COGNITIVE` pour formaliser les revues metaCritic/selfReflect avec corrélations normalisées.
+- ✅ Instrumenté `child_collect` afin d'émettre les événements de revue/réflexion corrélés via `pushEvent`, en s'appuyant sur les métadonnées `ChildrenIndex` et les nouveaux helpers.
+- ✅ Ajouté les régressions `tests/events.cognitive.test.ts` pour valider la structure des payloads et la propagation des hints `runId/opId/graphId/nodeId`.
+- 🔜 Aligner le reste des agents/exécuteurs (scheduler, metaCritic follow-ups, boucle réactive) pour clôturer la tâche "Publier événements standardisés avec opId/runId" et vérifier l'impact sur le streaming `events_subscribe`.
+
+### 2025-10-04 – Agent `gpt-5-codex` (iteration 123)
+- ✅ Ajouté `buildChildCorrelationHints` et sa couverture dédiée afin de normaliser l'agrégation des métadonnées enfants (job/run/op/graph/node) sans écraser les overrides explicites.
+- ✅ Instrumenté `pushEvent` côté serveur (`child_prompt`, `child_chat`, `child_push_reply/partial`, `child_rename/reset`, TTL et `kill`) pour fusionner les hints `ChildrenIndex`/graph avant publication des événements `PROMPT`/`PENDING`/`REPLY`/`INFO`/`KILL`.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test` pour valider l'ensemble de la suite après durcissement des corrélations enfants.
+- 🔜 Étendre l'alignement aux autres émetteurs serveur/agents (agrégations plan/status, superviseur metaCritic) afin de terminer la checklist "Publier événements standardisés avec opId/runId".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 124)
+- ✅ Introduit `buildJobCorrelationHints` pour agréger les métadonnées job/enfants et exposer `runId/opId/graphId/nodeId` sans répéter la logique d'extraction.
+- ✅ Aligné les événements serveur `HEARTBEAT`/`STATUS`/`AGGREGATE`/`KILL` sur le nouveau résolveur de corrélation afin que les publications job-scopées propagent les identifiants `runId/opId` dérivés des enfants.
+- ✅ Étendu `tests/events.correlation.test.ts` pour couvrir la construction des hints job et s'assurer que les overrides explicites à `null` restent respectés ; exécuté `npm run lint`, `npm run build`, `npm test`.
+- 🔜 Harmoniser les autres émetteurs job/plan (agrégations supplémentaires, metaCritic/superviseur) pour clôturer l'item "Publier événements standardisés avec opId/runId" et vérifier l'impact côté streaming `events_subscribe`.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 125)
+- ✅ Durci `buildJobCorrelationHints` en ignorant les identifiants job contradictoires, en gelant les overrides explicites à `null` pour les champs run/op/graph/node et en gardant l'autorité aux hints fournis par l'appelant serveur.
+- ✅ Étendu `tests/events.correlation.test.ts` avec des scénarios `sources` vides, conflits non nuls et overrides mixtes pour prouver la nouvelle sémantique, puis régénéré `dist/events/correlation.js` et `dist/server.js` via `npm run build`.
+- ✅ Nettoyé l'arbre de travail (`rm -rf node_modules children` avant install), réinstallé avec `npm ci`, exécuté `npm run lint`, `npm run build`, `npm test` et restauré un état propre sans artefacts non suivis.
+- 🔜 Vérifier le reste des émetteurs job-plan (metaCritic, streams bulk/status additionnels) et ajouter une couverture `events_subscribe` pour `status`/`aggregate`/`heartbeat`; mesurer l'impact perf du resolver heartbeat sur de longues séries.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 126)
+- ✅ Factorisé `emitHeartbeatTick` et ajouté `stopHeartbeat` pour déclencher/arrêter les battements manuellement tout en exportant `childSupervisor` afin de préparer des scénarios de tests déterministes.
+- ✅ Ajouté le test d'intégration `tests/events.subscribe.job-correlation.test.ts` qui vérifie que `events_subscribe` renvoie bien les événements `HEARTBEAT`/`STATUS`/`AGGREGATE` corrélés (`runId/opId/graphId/nodeId`) après des invocations réelles des outils.
+- 🔜 Étendre la couverture aux flux d'événements child/job restants (ex. `logs_tail`, `plan_run_reactive`) et auditer les timers heartbeat pour supporter des cadences configurables côté orchestrateur.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 127)
+- ✅ Ajouté le scénario d'intégration `tests/events.subscribe.child-correlation.test.ts` pour vérifier que les outils `child_prompt` et `child_push_partial` publient des événements `PROMPT`/`PENDING`/`REPLY_PART`/`REPLY` corrélés (`runId/opId/graphId/nodeId/childId`).
+- ✅ Confirmé que le streaming `events_subscribe` filtré par `child_id` restitue la corrélation complète après configuration du bus MCP.
+- 🔜 Couvrir `logs_tail` et les flux plan (`plan_run_reactive`, fan-out) côté `events_subscribe`, puis poursuivre l'audit des émetteurs `src/executor/*` pour clôturer la case "Publier événements standardisés avec opId/runId".
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 128)
+- ✅ Ajouté le test d'intégration `tests/events.subscribe.plan-correlation.test.ts` pour confirmer que `plan_run_bt` et `plan_run_reactive` publient des événements `BT_RUN` corrélés via `events_subscribe`.
+- ✅ Couvert `plan_fanout` sur le bus MCP en vérifiant les événements `PLAN` corrélés et en nettoyant les clones factices après exécution.
+- 🔜 Implémenter l'outil `logs_tail` puis ajouter la couverture `events_subscribe` associée afin de finaliser l'observabilité des logs.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 129)
+- ✅ Créé `src/monitor/log.ts` pour journaliser en JSONL les flux serveur/run/enfant avec corrélation `runId/opId/graphId/childId` et rotation.
+- ✅ Instrumenté `src/server.ts` afin d'enregistrer les événements dans le journal corrélé, exposé le tool MCP `logs_tail` et propagé les erreurs sans bloquer l'orchestrateur.
+- ✅ Ajouté `tests/logs.tail.filters.test.ts` pour couvrir les filtres `from_seq`, la validation d'identifiants et les entrées serveur par défaut.
+- 🔜 Étendre la couverture aux flux `events_subscribe` restants (logs tail + dashboards) et observer l'impact perf de la persistance JSONL sur des séries longues.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 130)
+- ✅ Normalisé `plan_dry_run` pour accepter des graphes hiérarchiques ou normalisés, générer des hints `reroute-avoid` automatiques et consigner les métriques appliquées (règles invoquées, nœuds/labels évités).
+- ✅ Ajouté des tests unitaires couvrant les prévisualisations de réécriture (split parallèle, inline subgraph, reroute) et enrichi `tests/plan.lifecycle.test.ts` avec la reprise après complétion et les erreurs `pause` sans contrôles.
+- ✅ Étendu la couverture intégration `plan_status/pause/resume` pour vérifier l'erreur `E-PLAN-COMPLETED` et documenté le comportement dans le journal MCP.
+- ✅ Permis aux appels `plan_dry_run` de fournir explicitement des listes `reroute_avoid` et noté le besoin de compléter la couverture autour des relances `plan_pause`/`resume` sur exécutions BT multi-nœuds.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 131)
+- ✅ Accepté un bloc `reroute_avoid` explicite dans `plan_dry_run`, fusionné avec les heuristiques et restitué les listes dans la réponse.
+- ✅ Étendu `tests/plan.dry-run.test.ts` avec un scénario pour les hints manuels et vérifié que les métriques reflètent les listes combinées.
+- 🔜 Ajouter une couverture `plan_pause`/`resume` multi-nœuds et étendre les tests `events_subscribe` pour les plans relancés.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 132)
+- ✅ Ajouté un scénario multi-nœuds dans `tests/plan.lifecycle.test.ts` pour couvrir `plan_pause`/`plan_resume` avec un arbre en séquence et vérifier l'exécution complète après reprise.
+- ✅ Étendu `tests/events.subscribe.plan-correlation.test.ts` afin de valider le streaming des événements `BT_RUN` (start/node/complete) après une pause puis reprise d'un plan réactif corrélé.
+- 🔜 Prolonger la couverture `events_subscribe` aux flux `PLAN`/`BT_RUN` lors de reprises multiples (pause/résume répétés) et auditer les snapshots `plan_status` pour les plans annulés afin de préparer les scénarios E2E restants.

--- a/dist/agents/autoscaler.js
+++ b/dist/agents/autoscaler.js
@@ -1,3 +1,34 @@
+import { extractCorrelationHints, mergeCorrelationHints, } from "../events/correlation.js";
+/**
+ * Builds correlation hints from a child snapshot already registered in the index.
+ * The helper keeps explicit `null` overrides while defaulting to the known
+ * `childId` when metadata does not surface one.
+ */
+function inferChildRecordCorrelation(child) {
+    if (!child) {
+        return {};
+    }
+    const hints = extractCorrelationHints(child.metadata);
+    if (hints.childId == null) {
+        hints.childId = child.childId;
+    }
+    return hints;
+}
+/** Derives correlation hints from a spawn template used before the child exists. */
+function inferCreateChildCorrelation(template) {
+    if (!template) {
+        return {};
+    }
+    const hints = extractCorrelationHints(template);
+    mergeCorrelationHints(hints, extractCorrelationHints(template.metadata));
+    mergeCorrelationHints(hints, extractCorrelationHints(template.manifestExtras));
+    if (hints.childId === undefined &&
+        typeof template.childId === "string" &&
+        template.childId.trim().length > 0) {
+        hints.childId = template.childId.trim();
+    }
+    return hints;
+}
 const DEFAULT_CONFIG = {
     minChildren: 0,
     maxChildren: 4,
@@ -25,6 +56,7 @@ export class Autoscaler {
     thresholds;
     spawnTemplate;
     retireGracefulTimeoutMs;
+    emitEvent;
     config;
     backlog = 0;
     samples = [];
@@ -38,6 +70,7 @@ export class Autoscaler {
         this.thresholds = { ...DEFAULT_THRESHOLDS, ...(options.thresholds ?? {}) };
         this.spawnTemplate = options.spawnTemplate;
         this.retireGracefulTimeoutMs = Math.max(100, options.retireGracefulTimeoutMs ?? 500);
+        this.emitEvent = options.emitEvent;
         this.config = { ...DEFAULT_CONFIG, ...(options.config ?? {}) };
         this.config = this.normaliseConfig(this.config);
     }
@@ -100,6 +133,30 @@ export class Autoscaler {
             averageLatencyMs,
             failureRate,
         };
+    }
+    /** Publishes a structured autoscaler event when an action occurs. */
+    publishEvent(event) {
+        if (!this.emitEvent) {
+            return;
+        }
+        const correlation = {};
+        if (event.childId) {
+            correlation.childId = event.childId;
+        }
+        mergeCorrelationHints(correlation, event.correlation);
+        if (event.childId && correlation.childId == null) {
+            correlation.childId = event.childId;
+        }
+        const payload = { ...event.payload };
+        if (event.childId && payload.child_id === undefined) {
+            payload.child_id = event.childId;
+        }
+        this.emitEvent({
+            level: event.level,
+            childId: event.childId,
+            payload,
+            correlation,
+        });
     }
     /** Implements the {@link LoopReconciler} contract. */
     async reconcile(context) {
@@ -174,6 +231,11 @@ export class Autoscaler {
     }
     async scaleUp(reason) {
         this.scalingInFlight = true;
+        const templateCorrelation = inferCreateChildCorrelation(this.spawnTemplate ?? null);
+        const templateChildId = typeof templateCorrelation.childId === "string" && templateCorrelation.childId.length > 0
+            ? templateCorrelation.childId
+            : undefined;
+        const knownChildren = new Set(this.supervisor.childrenIndex.list().map((child) => child.childId));
         try {
             await this.supervisor.createChild(this.spawnTemplate);
             this.lastScaleAt = this.now();
@@ -182,11 +244,43 @@ export class Autoscaler {
                 backlog: this.backlog,
                 samples: this.samples.length,
             });
+            const newChild = this.supervisor.childrenIndex
+                .list()
+                .find((snapshot) => !knownChildren.has(snapshot.childId));
+            const correlation = newChild
+                ? inferChildRecordCorrelation(newChild)
+                : {};
+            mergeCorrelationHints(correlation, templateCorrelation);
+            const childId = newChild?.childId ?? templateChildId;
+            this.publishEvent({
+                level: "info",
+                childId,
+                payload: {
+                    msg: "scale_up",
+                    reason,
+                    backlog: this.backlog,
+                    samples: this.samples.length,
+                },
+                correlation,
+            });
         }
         catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
             this.logger?.error("autoscaler_scale_up_failed", {
                 reason,
-                message: error instanceof Error ? error.message : String(error),
+                message,
+            });
+            this.publishEvent({
+                level: "error",
+                childId: templateChildId,
+                payload: {
+                    msg: "scale_up_failed",
+                    reason,
+                    backlog: this.backlog,
+                    samples: this.samples.length,
+                    message,
+                },
+                correlation: templateCorrelation,
             });
         }
         finally {
@@ -198,27 +292,73 @@ export class Autoscaler {
         if (!candidate) {
             return;
         }
+        const correlation = inferChildRecordCorrelation(candidate);
+        const basePayload = {
+            reason: "relaxation",
+            backlog: this.backlog,
+            samples: this.samples.length,
+        };
         this.scalingInFlight = true;
         try {
             await this.supervisor.cancel(candidate.childId, { timeoutMs: this.retireGracefulTimeoutMs });
             this.lastScaleAt = this.now();
             this.logger?.info("autoscaler_scale_down", { child_id: candidate.childId });
+            this.publishEvent({
+                level: "info",
+                childId: candidate.childId,
+                payload: {
+                    ...basePayload,
+                    msg: "scale_down",
+                },
+                correlation,
+            });
         }
         catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
             this.logger?.warn?.("autoscaler_scale_down_cancel_failed", {
                 child_id: candidate.childId,
-                message: error instanceof Error ? error.message : String(error),
+                message,
+            });
+            this.publishEvent({
+                level: "warn",
+                childId: candidate.childId,
+                payload: {
+                    ...basePayload,
+                    msg: "scale_down_cancel_failed",
+                    message,
+                },
+                correlation,
             });
             if (this.supervisor.kill) {
                 try {
                     await this.supervisor.kill(candidate.childId, { timeoutMs: 200 });
                     this.lastScaleAt = this.now();
                     this.logger?.info("autoscaler_scale_down_forced", { child_id: candidate.childId });
+                    this.publishEvent({
+                        level: "warn",
+                        childId: candidate.childId,
+                        payload: {
+                            ...basePayload,
+                            msg: "scale_down_forced",
+                        },
+                        correlation,
+                    });
                 }
                 catch (killError) {
+                    const killMessage = killError instanceof Error ? killError.message : String(killError);
                     this.logger?.error("autoscaler_scale_down_failed", {
                         child_id: candidate.childId,
-                        message: killError instanceof Error ? killError.message : String(killError),
+                        message: killMessage,
+                    });
+                    this.publishEvent({
+                        level: "error",
+                        childId: candidate.childId,
+                        payload: {
+                            ...basePayload,
+                            msg: "scale_down_failed",
+                            message: killMessage,
+                        },
+                        correlation,
                     });
                 }
             }

--- a/dist/agents/supervisor.js
+++ b/dist/agents/supervisor.js
@@ -1,3 +1,4 @@
+import { extractCorrelationHints } from "../events/correlation.js";
 /**
  * Supervisor observing scheduler progress, loop alerts and child inactivity to
  * initiate mitigating actions. The component implements {@link LoopReconciler}
@@ -218,4 +219,13 @@ export class OrchestratorSupervisor {
             }
         }
     }
+}
+/**
+ * Extracts correlation hints from a supervisor incident so downstream
+ * orchestrator events can expose run/op identifiers when they are included in
+ * the incident context. The helper accepts both camelCase and snake_case
+ * fields and tolerates arrays when a single identifier is available.
+ */
+export function inferSupervisorIncidentCorrelation(incident) {
+    return extractCorrelationHints(incident.context);
 }

--- a/dist/events/cognitive.js
+++ b/dist/events/cognitive.js
@@ -1,0 +1,103 @@
+import { cloneCorrelationHints, extractCorrelationHints, mergeCorrelationHints, } from "./correlation.js";
+/**
+ * Normalises the provided correlation sources and synthesises a single record
+ * that contains the identifiers expected by the unified event bus.
+ */
+function buildCorrelationHints(options) {
+    const hints = {};
+    mergeCorrelationHints(hints, { childId: options.childId });
+    if (options.jobId !== undefined) {
+        mergeCorrelationHints(hints, { jobId: options.jobId ?? null });
+    }
+    for (const source of options.sources ?? []) {
+        if (!source) {
+            continue;
+        }
+        mergeCorrelationHints(hints, extractCorrelationHints(source));
+    }
+    return hints;
+}
+/**
+ * Build structured events describing the meta-review (and optional self
+ * reflection) performed after a `child_collect` invocation. The helper keeps
+ * payloads compact yet informative so downstream MCP clients can surface
+ * actionable telemetry without reimplementing the orchestrator logic.
+ */
+export function buildChildCognitiveEvents(options) {
+    const baseCorrelation = buildCorrelationHints({
+        childId: options.childId,
+        jobId: options.jobId,
+        sources: options.correlationSources,
+    });
+    const sharedEnvelope = {
+        kind: "COGNITIVE",
+        level: "info",
+        childId: options.childId,
+        jobId: options.jobId ?? null,
+    };
+    const basePayloadFields = {
+        child_id: options.childId,
+        job_id: options.jobId ?? null,
+        run_id: baseCorrelation.runId ?? null,
+        op_id: baseCorrelation.opId ?? null,
+        graph_id: baseCorrelation.graphId ?? null,
+        node_id: baseCorrelation.nodeId ?? null,
+    };
+    const reviewPayload = {
+        ...basePayloadFields,
+        msg: "child_meta_review",
+        summary: {
+            kind: options.summary.kind,
+            text: options.summary.text,
+            tags: [...options.summary.tags],
+        },
+        review: {
+            overall: options.review.overall,
+            verdict: options.review.verdict,
+            feedback: [...options.review.feedback],
+            suggestions: [...options.review.suggestions],
+            breakdown: options.review.breakdown.map((entry) => ({ ...entry })),
+        },
+        metrics: {
+            artifacts: options.artifactCount,
+            messages: options.messageCount,
+        },
+        quality_assessment: options.quality
+            ? {
+                kind: options.quality.kind,
+                score: options.quality.score,
+                rubric: { ...options.quality.rubric },
+                metrics: { ...options.quality.metrics },
+                gate: { ...options.quality.gate },
+            }
+            : null,
+    };
+    const reviewEvent = {
+        ...sharedEnvelope,
+        payload: reviewPayload,
+        correlation: cloneCorrelationHints(baseCorrelation),
+    };
+    let reflectionEvent = null;
+    if (options.reflection) {
+        const reflectionPayload = {
+            ...basePayloadFields,
+            msg: "child_reflection",
+            summary: {
+                kind: options.summary.kind,
+                text: options.summary.text,
+                tags: [...options.summary.tags],
+            },
+            reflection: {
+                insights: [...options.reflection.insights],
+                next_steps: [...options.reflection.nextSteps],
+                risks: [...options.reflection.risks],
+            },
+        };
+        reflectionEvent = {
+            ...sharedEnvelope,
+            payload: reflectionPayload,
+            correlation: cloneCorrelationHints(baseCorrelation),
+        };
+    }
+    return { review: reviewEvent, reflection: reflectionEvent };
+}

--- a/dist/events/correlation.js
+++ b/dist/events/correlation.js
@@ -1,0 +1,261 @@
+/**
+ * Merge correlation hints into the provided target without overriding existing
+ * values with `undefined`. The helper resolves the subtle case where optional
+ * resolvers omit identifiers which would otherwise erase the native correlation
+ * propagated through lifecycle events.
+ *
+ * @param target - Mutable record receiving the merged hints.
+ * @param source - Optional hints provided by emitters or resolvers.
+ */
+export function mergeCorrelationHints(target, source) {
+    if (!source) {
+        return;
+    }
+    for (const key of ["jobId", "runId", "opId", "graphId", "nodeId", "childId"]) {
+        const value = source[key];
+        if (value !== undefined) {
+            target[key] = value;
+        }
+    }
+}
+/**
+ * Clone correlation hints into a new plain object. Callers can rely on the
+ * helper when they need to publish snapshots without mutating the original
+ * record.
+ */
+export function cloneCorrelationHints(source) {
+    const target = {};
+    mergeCorrelationHints(target, source);
+    return target;
+}
+/** Normalise candidate values to non-empty strings when possible. */
+function normaliseCorrelationValue(value) {
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return String(value);
+    }
+    return null;
+}
+/**
+ * Extract correlation hints from arbitrary records, accepting both snake_case
+ * and camelCase identifiers. Nested `correlation` blocks (objects or single
+ * element arrays) are merged recursively, while ambiguous arrays are ignored
+ * to avoid guessing the intended identifier.
+ */
+export function extractCorrelationHints(source) {
+    const hints = {};
+    if (!source || typeof source !== "object") {
+        return hints;
+    }
+    const visited = new Set();
+    const queue = [];
+    const enqueue = (value) => {
+        if (!value || typeof value !== "object" || visited.has(value)) {
+            return;
+        }
+        visited.add(value);
+        if (Array.isArray(value)) {
+            const objects = value.filter((entry) => typeof entry === "object" && entry !== null);
+            if (objects.length === 1) {
+                queue.push(objects[0]);
+            }
+            return;
+        }
+        queue.push(value);
+    };
+    enqueue(source);
+    const readCandidate = (record, keys) => {
+        for (const key of keys) {
+            if (!Object.prototype.hasOwnProperty.call(record, key)) {
+                continue;
+            }
+            const value = record[key];
+            if (value === null) {
+                return null;
+            }
+            const candidate = normaliseCorrelationValue(value);
+            if (candidate) {
+                return candidate;
+            }
+        }
+        return undefined;
+    };
+    const readSingleFromArray = (record, keys) => {
+        for (const key of keys) {
+            if (!Object.prototype.hasOwnProperty.call(record, key)) {
+                continue;
+            }
+            const value = record[key];
+            if (value === null) {
+                return null;
+            }
+            if (Array.isArray(value)) {
+                const candidates = value
+                    .map((entry) => normaliseCorrelationValue(entry))
+                    .filter((entry) => typeof entry === "string" && entry.length > 0);
+                if (candidates.length === 1) {
+                    return candidates[0];
+                }
+            }
+        }
+        return undefined;
+    };
+    while (queue.length > 0) {
+        const record = queue.shift();
+        const runId = readCandidate(record, ["run_id", "runId"]);
+        if (runId !== undefined && hints.runId == null) {
+            hints.runId = runId;
+        }
+        const opId = readCandidate(record, ["op_id", "opId", "operation_id", "operationId"]);
+        if (opId !== undefined && hints.opId == null) {
+            hints.opId = opId;
+        }
+        const jobId = readCandidate(record, ["job_id", "jobId"]);
+        if (jobId !== undefined && hints.jobId == null) {
+            hints.jobId = jobId;
+        }
+        const graphId = readCandidate(record, ["graph_id", "graphId"]);
+        if (graphId !== undefined && hints.graphId == null) {
+            hints.graphId = graphId;
+        }
+        const nodeId = readCandidate(record, ["node_id", "nodeId"]);
+        if (nodeId !== undefined && hints.nodeId == null) {
+            hints.nodeId = nodeId;
+        }
+        const directChildId = readCandidate(record, ["child_id", "childId", "participant", "participant_id"]);
+        if (directChildId !== undefined && hints.childId == null) {
+            hints.childId = directChildId;
+        }
+        else if (hints.childId == null) {
+            const arrayChildId = readSingleFromArray(record, [
+                "child_ids",
+                "childIds",
+                "idle_children",
+                "participants",
+                "participant_ids",
+            ]);
+            if (arrayChildId !== undefined) {
+                hints.childId = arrayChildId;
+            }
+        }
+        const correlationCandidates = [
+            record.correlation,
+            record["correlation_hints"],
+            record["correlationHints"],
+        ];
+        for (const candidate of correlationCandidates) {
+            enqueue(candidate);
+        }
+    }
+    return hints;
+}
+/**
+ * Builds correlation hints for child-centric events by combining the runtime
+ * identifier with optional job identifiers and additional metadata records.
+ * The helper accepts heterogeneous sources (plain objects, nested correlation
+ * blocks, arrays with a single entry) and reuses {@link extractCorrelationHints}
+ * to keep the merge logic consistent with the rest of the event pipeline.
+ */
+export function buildChildCorrelationHints(options) {
+    const hints = {};
+    mergeCorrelationHints(hints, { childId: options.childId });
+    if (options.jobId !== undefined) {
+        if (options.jobId === null) {
+            mergeCorrelationHints(hints, { jobId: null });
+        }
+        else if (typeof options.jobId === "string") {
+            const trimmed = options.jobId.trim();
+            mergeCorrelationHints(hints, { jobId: trimmed.length > 0 ? trimmed : null });
+        }
+    }
+    for (const source of options.sources ?? []) {
+        if (!source) {
+            continue;
+        }
+        mergeCorrelationHints(hints, extractCorrelationHints(source));
+    }
+    return hints;
+}
+/**
+ * Builds correlation hints for job-centric events by combining the job identifier
+ * with optional auxiliary metadata. The helper mirrors
+ * {@link buildChildCorrelationHints} so callers can derive `runId`/`opId`
+ * information from job-related records (children snapshots, supervisor
+ * metadata, payloads) without reimplementing the merge semantics.
+ */
+export function buildJobCorrelationHints(options) {
+    const hints = {};
+    const explicitNulls = new Set();
+    const applyHints = (source) => {
+        if (!source) {
+            return;
+        }
+        for (const key of ["jobId", "runId", "opId", "graphId", "nodeId", "childId"]) {
+            const value = source[key];
+            if (value === undefined) {
+                continue;
+            }
+            if (value === null) {
+                hints[key] = null;
+                explicitNulls.add(key);
+                continue;
+            }
+            if (!explicitNulls.has(key)) {
+                hints[key] = value;
+            }
+        }
+    };
+    let resolvedJobId;
+    let resolvedFrom;
+    if (options.jobId !== undefined) {
+        if (options.jobId === null) {
+            resolvedJobId = null;
+            resolvedFrom = "base";
+            applyHints({ jobId: null });
+        }
+        else {
+            const normalised = normaliseCorrelationValue(options.jobId);
+            if (normalised !== null) {
+                resolvedJobId = normalised;
+                resolvedFrom = "base";
+                applyHints({ jobId: normalised });
+            }
+            else {
+                resolvedJobId = null;
+                resolvedFrom = "base";
+                applyHints({ jobId: null });
+            }
+        }
+    }
+    for (const source of options.sources ?? []) {
+        if (!source) {
+            continue;
+        }
+        const extracted = extractCorrelationHints(source);
+        const { jobId, ...rest } = extracted;
+        if (jobId !== undefined) {
+            if (jobId === null) {
+                resolvedJobId = null;
+                resolvedFrom = resolvedFrom ?? "source";
+                applyHints({ jobId: null });
+            }
+            else if (resolvedJobId === undefined) {
+                resolvedJobId = jobId;
+                resolvedFrom = "source";
+                applyHints({ jobId });
+            }
+            else if (resolvedJobId !== null && resolvedJobId !== jobId) {
+                if (resolvedFrom !== "base") {
+                    resolvedJobId = null;
+                    resolvedFrom = "source";
+                    applyHints({ jobId: null });
+                }
+            }
+        }
+        applyHints(rest);
+    }
+    return hints;
+}

--- a/dist/executor/planLifecycle.js
+++ b/dist/executor/planLifecycle.js
@@ -1,0 +1,345 @@
+/**
+ * Base error raised when lifecycle operations fail. Errors carry a stable code
+ * so MCP tool wrappers can surface consistent diagnostics to clients.
+ */
+export class PlanLifecycleError extends Error {
+    code;
+    hint;
+    details;
+    constructor(message, code, hint, details) {
+        super(message);
+        this.name = "PlanLifecycleError";
+        this.code = code;
+        this.hint = hint;
+        this.details = details;
+    }
+}
+/** Error thrown when callers reference an unknown plan run. */
+export class PlanRunNotFoundError extends PlanLifecycleError {
+    constructor(runId) {
+        super(`unknown plan run ${runId}`, "E-PLAN-NOT-FOUND", "plan_run", { runId });
+        this.name = "PlanRunNotFoundError";
+    }
+}
+/** Error thrown when pause/resume is requested on a run that does not support it. */
+export class PlanLifecycleUnsupportedError extends PlanLifecycleError {
+    constructor(runId, operation) {
+        super(`plan run ${runId} does not support ${operation}`, operation === "pause" ? "E-PLAN-PAUSE-UNSUPPORTED" : "E-PLAN-RESUME-UNSUPPORTED", "plan_run_reactive", { runId, operation });
+        this.name = "PlanLifecycleUnsupportedError";
+    }
+}
+/** Error thrown when lifecycle operations conflict with the current state. */
+export class PlanLifecycleInvalidStateError extends PlanLifecycleError {
+    constructor(runId, expected, actual) {
+        super(`plan run ${runId} is ${actual} but expected ${expected}`, "E-PLAN-INVALID-STATE", "plan_status", { runId, expected, actual });
+        this.name = "PlanLifecycleInvalidStateError";
+    }
+}
+/** Error raised when callers interact with a run that already completed. */
+export class PlanLifecycleCompletedError extends PlanLifecycleError {
+    constructor(runId) {
+        super(`plan run ${runId} already completed`, "E-PLAN-COMPLETED", "plan_status", { runId });
+        this.name = "PlanLifecycleCompletedError";
+    }
+}
+/** Error raised when lifecycle tooling is disabled in the runtime features. */
+export class PlanLifecycleFeatureDisabledError extends PlanLifecycleError {
+    constructor() {
+        super("plan lifecycle tooling disabled", "E-PLAN-LIFECYCLE-DISABLED", "enable_plan_lifecycle");
+        this.name = "PlanLifecycleFeatureDisabledError";
+    }
+}
+function cloneSnapshot(snapshot) {
+    return structuredClone(snapshot);
+}
+function clonePayload(payload) {
+    return structuredClone(payload);
+}
+function sanitiseCorrelation(hints) {
+    return {
+        run_id: hints?.runId ?? null,
+        op_id: hints?.opId ?? null,
+        job_id: hints?.jobId ?? null,
+        graph_id: hints?.graphId ?? null,
+        node_id: hints?.nodeId ?? null,
+        child_id: hints?.childId ?? null,
+    };
+}
+function clampProgress(value) {
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+    if (value < 0) {
+        return 0;
+    }
+    if (value > 100) {
+        return 100;
+    }
+    return value;
+}
+function roundProgress(value) {
+    return Math.round(value * 100) / 100;
+}
+/**
+ * In-memory registry mirroring the lifecycle of Behaviour Tree executions. The
+ * registry keeps lightweight snapshots so MCP tools can expose plan status,
+ * pause, and resume semantics without duplicating bookkeeping logic in tests or
+ * server handlers.
+ */
+export class PlanLifecycleRegistry {
+    clock;
+    entries = new Map();
+    constructor(options = {}) {
+        this.clock = options.clock ?? (() => Date.now());
+    }
+    /** Remove every tracked run. Mainly used by tests to reset state between scenarios. */
+    clear() {
+        this.entries.clear();
+    }
+    /** Register a new run so subsequent events can update its snapshot. */
+    registerRun(options) {
+        const existing = this.entries.get(options.runId);
+        if (existing) {
+            throw new PlanLifecycleError(`plan run ${options.runId} already tracked`, "E-PLAN-ALREADY-TRACKED", "plan_status", { runId: options.runId, state: existing.snapshot.state });
+        }
+        const now = this.clock();
+        const snapshot = {
+            run_id: options.runId,
+            op_id: options.opId,
+            mode: options.mode,
+            state: "running",
+            progress: 0,
+            last_event_seq: 0,
+            started_at: now,
+            updated_at: now,
+            finished_at: null,
+            paused_at: null,
+            dry_run: options.dryRun ?? false,
+            correlation: sanitiseCorrelation(options.correlation ?? null),
+            supports_pause: false,
+            supports_resume: false,
+            last_event: null,
+            failure: null,
+        };
+        const entry = {
+            snapshot,
+            controls: {},
+            metrics: {
+                estimatedWork: options.estimatedWork ?? null,
+                visitedNodes: new Set(),
+                lastTickCount: 0,
+                lastSchedulerTicks: 0,
+                lastLoopTicks: 0,
+                lastPendingAfter: 0,
+            },
+        };
+        this.entries.set(options.runId, entry);
+        return cloneSnapshot(snapshot);
+    }
+    /** Attach pause/resume controls to a registered run. */
+    attachControls(runId, controls) {
+        const entry = this.entries.get(runId);
+        if (!entry) {
+            throw new PlanRunNotFoundError(runId);
+        }
+        entry.controls = { ...controls };
+        entry.snapshot.supports_pause = typeof controls.pause === "function";
+        entry.snapshot.supports_resume = typeof controls.resume === "function";
+        entry.snapshot.updated_at = this.clock();
+        return cloneSnapshot(entry.snapshot);
+    }
+    /** Release pause/resume controls once a run completed. */
+    releaseControls(runId) {
+        const entry = this.entries.get(runId);
+        if (!entry) {
+            return;
+        }
+        entry.controls = {};
+        entry.snapshot.supports_pause = false;
+        entry.snapshot.supports_resume = false;
+    }
+    /** Record a lifecycle event and update the associated snapshot. */
+    recordEvent(runId, event) {
+        const entry = this.entries.get(runId);
+        if (!entry) {
+            throw new PlanRunNotFoundError(runId);
+        }
+        const now = event.timestamp ?? this.clock();
+        entry.snapshot.last_event_seq += 1;
+        entry.snapshot.last_event = {
+            phase: event.phase,
+            payload: clonePayload(event.payload),
+            at: now,
+            seq: entry.snapshot.last_event_seq,
+        };
+        entry.snapshot.updated_at = now;
+        switch (event.phase) {
+            case "start":
+            case "tick":
+            case "loop":
+            case "node": {
+                if (entry.snapshot.state !== "running") {
+                    entry.snapshot.state = "running";
+                }
+                entry.snapshot.paused_at = null;
+                break;
+            }
+            case "complete": {
+                entry.snapshot.state = "done";
+                entry.snapshot.finished_at = now;
+                entry.snapshot.failure = null;
+                entry.snapshot.progress = 100;
+                this.releaseControls(runId);
+                break;
+            }
+            case "error":
+            case "cancel": {
+                entry.snapshot.state = "failed";
+                entry.snapshot.finished_at = now;
+                entry.snapshot.failure = {
+                    status: typeof event.payload.status === "string" ? event.payload.status : null,
+                    reason: typeof event.payload.reason === "string" ? event.payload.reason : null,
+                };
+                entry.snapshot.progress = 100;
+                this.releaseControls(runId);
+                break;
+            }
+            default:
+                break;
+        }
+        this.updateProgress(entry, event);
+        return cloneSnapshot(entry.snapshot);
+    }
+    /** Pause a running plan run and surface the updated snapshot. */
+    async pause(runId) {
+        const entry = this.entries.get(runId);
+        if (!entry) {
+            throw new PlanRunNotFoundError(runId);
+        }
+        if (entry.snapshot.state === "done" || entry.snapshot.state === "failed") {
+            throw new PlanLifecycleCompletedError(runId);
+        }
+        if (entry.snapshot.state === "paused") {
+            return cloneSnapshot(entry.snapshot);
+        }
+        if (typeof entry.controls.pause !== "function") {
+            throw new PlanLifecycleUnsupportedError(runId, "pause");
+        }
+        await entry.controls.pause();
+        const now = this.clock();
+        entry.snapshot.state = "paused";
+        entry.snapshot.paused_at = now;
+        entry.snapshot.updated_at = now;
+        entry.snapshot.last_event_seq += 1;
+        entry.snapshot.last_event = {
+            phase: "pause",
+            payload: { manual: true },
+            at: now,
+            seq: entry.snapshot.last_event_seq,
+        };
+        return cloneSnapshot(entry.snapshot);
+    }
+    /** Resume a paused run and surface the latest snapshot. */
+    async resume(runId) {
+        const entry = this.entries.get(runId);
+        if (!entry) {
+            throw new PlanRunNotFoundError(runId);
+        }
+        if (entry.snapshot.state === "done" || entry.snapshot.state === "failed") {
+            throw new PlanLifecycleCompletedError(runId);
+        }
+        if (entry.snapshot.state !== "paused") {
+            throw new PlanLifecycleInvalidStateError(runId, "paused", entry.snapshot.state);
+        }
+        if (typeof entry.controls.resume !== "function") {
+            throw new PlanLifecycleUnsupportedError(runId, "resume");
+        }
+        await entry.controls.resume();
+        const now = this.clock();
+        entry.snapshot.state = "running";
+        entry.snapshot.paused_at = null;
+        entry.snapshot.updated_at = now;
+        entry.snapshot.last_event_seq += 1;
+        entry.snapshot.last_event = {
+            phase: "resume",
+            payload: { manual: true },
+            at: now,
+            seq: entry.snapshot.last_event_seq,
+        };
+        return cloneSnapshot(entry.snapshot);
+    }
+    /** Return a snapshot describing the current lifecycle of the requested run. */
+    getSnapshot(runId) {
+        const entry = this.entries.get(runId);
+        if (!entry) {
+            throw new PlanRunNotFoundError(runId);
+        }
+        return cloneSnapshot(entry.snapshot);
+    }
+    updateProgress(entry, event) {
+        switch (event.phase) {
+            case "tick": {
+                const ticks = this.extractNumber(event.payload.ticks ?? event.payload.scheduler_ticks);
+                if (ticks !== null) {
+                    entry.metrics.lastTickCount = Math.max(entry.metrics.lastTickCount, ticks);
+                    entry.metrics.lastSchedulerTicks = Math.max(entry.metrics.lastSchedulerTicks, ticks);
+                }
+                const pending = this.extractNumber(event.payload.pending_after);
+                if (pending !== null) {
+                    entry.metrics.lastPendingAfter = Math.max(0, pending);
+                }
+                break;
+            }
+            case "loop": {
+                const executed = this.extractNumber(event.payload.executed_ticks);
+                if (executed !== null) {
+                    entry.metrics.lastLoopTicks = Math.max(entry.metrics.lastLoopTicks, executed);
+                }
+                break;
+            }
+            case "node": {
+                const nodeId = typeof event.payload.node_id === "string" ? event.payload.node_id : null;
+                const status = typeof event.payload.status === "string" ? event.payload.status : null;
+                if (nodeId && status && status !== "running") {
+                    entry.metrics.visitedNodes.add(nodeId);
+                }
+                break;
+            }
+            default:
+                break;
+        }
+        if (entry.snapshot.state === "done" || entry.snapshot.state === "failed") {
+            entry.snapshot.progress = 100;
+            return;
+        }
+        const ratios = [];
+        if (entry.metrics.estimatedWork && entry.metrics.estimatedWork > 0) {
+            ratios.push(entry.metrics.visitedNodes.size / entry.metrics.estimatedWork);
+        }
+        if (entry.metrics.lastTickCount > 0 || entry.metrics.lastSchedulerTicks > 0) {
+            const ticks = Math.max(entry.metrics.lastTickCount, entry.metrics.lastSchedulerTicks);
+            const denominator = ticks + entry.metrics.lastPendingAfter + 1;
+            ratios.push(ticks / denominator);
+        }
+        if (entry.metrics.lastLoopTicks > 0) {
+            const denominator = entry.metrics.lastLoopTicks + entry.metrics.lastPendingAfter + 1;
+            ratios.push(entry.metrics.lastLoopTicks / denominator);
+        }
+        if (ratios.length === 0) {
+            return;
+        }
+        const ratio = Math.max(...ratios);
+        const bounded = Math.min(0.99, Math.max(0, ratio));
+        const progress = clampProgress(roundProgress(bounded * 100));
+        entry.snapshot.progress = Math.max(entry.snapshot.progress, progress);
+    }
+    extractNumber(value) {
+        if (typeof value !== "number") {
+            return null;
+        }
+        if (!Number.isFinite(value)) {
+            return null;
+        }
+        return value;
+    }
+}

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -27,11 +27,14 @@ export class StructuredLogger {
      * `./tmp/orchestrator.log` work even when the `tmp/` folder is missing.
      */
     logDirectoryReady = false;
+    /** Optional listener invoked with the structured entry. */
+    entryListener;
     constructor(options = {}) {
         this.logFile = options.logFile ?? undefined;
         this.maxFileSizeBytes = options.maxFileSizeBytes ?? DEFAULT_MAX_FILE_SIZE;
         this.maxFileCount = Math.max(1, options.maxFileCount ?? DEFAULT_MAX_FILE_COUNT);
         this.redactSecrets = options.redactSecrets ? [...options.redactSecrets] : [];
+        this.entryListener = options.onEntry;
     }
     info(message, payload) {
         this.log("info", message, payload);
@@ -94,6 +97,9 @@ export class StructuredLogger {
         };
         const line = `${JSON.stringify(entry)}\n`;
         process.stdout.write(line);
+        if (this.entryListener) {
+            this.entryListener(structuredClone(entry));
+        }
         if (!this.logFile) {
             return;
         }

--- a/dist/monitor/log.js
+++ b/dist/monitor/log.js
@@ -1,0 +1,213 @@
+import { appendFile, mkdir, rename, rm, stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+/** Error raised when a log operation fails. */
+export class LogJournalError extends Error {
+    code;
+    constructor(message, code = "E-LOG-JOURNAL") {
+        super(message);
+        this.code = code;
+        this.name = "LogJournalError";
+    }
+}
+/** Constants controlling memory usage and rotation defaults. */
+const DEFAULT_MAX_ENTRIES = 500;
+const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MiB keeps artefacts small.
+const DEFAULT_MAX_FILE_COUNT = 5;
+/** Ensures a string bucket identifier is safe to use within file paths. */
+function sanitiseBucketId(raw) {
+    const trimmed = raw.trim();
+    if (!trimmed.length) {
+        return "default";
+    }
+    const safe = trimmed.replace(/[^a-zA-Z0-9_-]/g, "-");
+    return safe.slice(0, 120) || "default";
+}
+/** Resolve the base directory for a given stream. */
+function resolveStreamDir(rootDir, stream) {
+    switch (stream) {
+        case "server":
+            return join(rootDir, "server");
+        case "run":
+            return join(rootDir, "runs");
+        case "child":
+            return join(rootDir, "children");
+        default:
+            return rootDir;
+    }
+}
+/** Creates the JSONL file path for a bucket. */
+function resolveBucketPath(rootDir, stream, bucketId) {
+    const baseDir = resolveStreamDir(rootDir, stream);
+    const safeId = sanitiseBucketId(bucketId);
+    return join(baseDir, `${safeId}.jsonl`);
+}
+/**
+ * Maintains correlated log entries for the orchestrator. Entries are preserved in memory for fast
+ * access and mirrored to JSONL artefacts with size-based rotation.
+ */
+export class LogJournal {
+    rootDir;
+    maxEntries;
+    maxFileSize;
+    maxFileCount;
+    buckets = new Map();
+    constructor(options) {
+        this.rootDir = resolve(options.rootDir);
+        this.maxEntries = Math.max(1, options.maxEntriesPerBucket ?? DEFAULT_MAX_ENTRIES);
+        this.maxFileSize = Math.max(64 * 1024, options.maxFileSizeBytes ?? DEFAULT_MAX_FILE_SIZE);
+        this.maxFileCount = Math.max(1, options.maxFileCount ?? DEFAULT_MAX_FILE_COUNT);
+    }
+    /** Clears all in-memory entries and resets sequence counters. */
+    reset() {
+        this.buckets.clear();
+    }
+    /**
+     * Records a new correlated entry. The write is synchronous from the caller perspective while file
+     * persistence is enqueued to guarantee ordering without blocking orchestrator hot paths.
+     */
+    record(input) {
+        const bucketId = input.bucketId?.trim() && input.bucketId.trim().length > 0 ? input.bucketId.trim() : "orchestrator";
+        const key = this.buildBucketKey(input.stream, bucketId);
+        const state = this.getOrCreateBucket(input.stream, bucketId, key);
+        const seq = input.seq && input.seq > state.lastSeq ? input.seq : state.lastSeq + 1;
+        state.lastSeq = Math.max(state.lastSeq, seq);
+        const ts = typeof input.ts === "number" && Number.isFinite(input.ts) ? Math.floor(input.ts) : Date.now();
+        const entry = {
+            seq,
+            ts,
+            stream: input.stream,
+            bucketId,
+            level: input.level,
+            message: input.message,
+            data: input.data,
+            jobId: input.jobId ?? null,
+            runId: input.runId ?? null,
+            opId: input.opId ?? null,
+            graphId: input.graphId ?? null,
+            nodeId: input.nodeId ?? null,
+            childId: input.childId ?? null,
+        };
+        state.entries.push(entry);
+        if (state.entries.length > this.maxEntries) {
+            state.entries.splice(0, state.entries.length - this.maxEntries);
+        }
+        state.writeQueue = state.writeQueue
+            .then(() => this.appendToFile(state, entry))
+            .catch(() => {
+            // Reset the queue so subsequent writes are not blocked by transient errors.
+            state.writeQueue = Promise.resolve();
+        });
+        this.buckets.set(key, state);
+        return entry;
+    }
+    /** Retrieves a slice of log entries ordered by their sequence number. */
+    tail(input) {
+        const bucketId = input.bucketId?.trim() && input.bucketId.trim().length > 0 ? input.bucketId.trim() : "orchestrator";
+        const key = this.buildBucketKey(input.stream, bucketId);
+        const state = this.buckets.get(key);
+        if (!state) {
+            return { entries: [], nextSeq: 0 };
+        }
+        const fromSeq = typeof input.fromSeq === "number" && input.fromSeq >= 0 ? input.fromSeq : 0;
+        const limit = typeof input.limit === "number" && input.limit > 0 ? Math.min(Math.floor(input.limit), this.maxEntries) : this.maxEntries;
+        const filtered = state.entries.filter((entry) => entry.seq > fromSeq);
+        const ordered = filtered.sort((a, b) => a.seq - b.seq).slice(0, limit);
+        const nextSeq = ordered.length ? ordered[ordered.length - 1].seq : state.lastSeq;
+        return { entries: ordered, nextSeq };
+    }
+    /** Waits for all pending file writes to complete. */
+    async flush() {
+        await Promise.all(Array.from(this.buckets.values(), (bucket) => bucket.writeQueue));
+    }
+    buildBucketKey(stream, bucketId) {
+        return `${stream}:${bucketId}`;
+    }
+    getOrCreateBucket(stream, bucketId, key) {
+        const existing = this.buckets.get(key);
+        if (existing) {
+            return existing;
+        }
+        const filePath = resolveBucketPath(this.rootDir, stream, bucketId);
+        return {
+            entries: [],
+            lastSeq: 0,
+            writeQueue: Promise.resolve(),
+            bytesWritten: 0,
+            writerReady: false,
+            filePath,
+        };
+    }
+    async appendToFile(state, entry) {
+        try {
+            if (!state.writerReady) {
+                await this.ensureWriter(state);
+            }
+            const line = `${JSON.stringify(entry)}\n`;
+            await this.rotateIfNeeded(state, Buffer.byteLength(line, "utf8"));
+            await appendFile(state.filePath, line, "utf8");
+            state.bytesWritten += Buffer.byteLength(line, "utf8");
+        }
+        catch (error) {
+            // On persistence failure, attempt to reset the bucket so future writes can retry.
+            state.writerReady = false;
+            state.bytesWritten = 0;
+            throw new LogJournalError(error instanceof Error ? error.message : `log_persist_failed:${String(error)}`, "E-LOG-WRITE");
+        }
+    }
+    async ensureWriter(state) {
+        const directory = dirname(state.filePath);
+        await mkdir(directory, { recursive: true });
+        try {
+            const stats = await stat(state.filePath);
+            state.bytesWritten = stats.size;
+        }
+        catch (error) {
+            if (error.code === "ENOENT") {
+                state.bytesWritten = 0;
+            }
+            else {
+                throw error;
+            }
+        }
+        state.writerReady = true;
+    }
+    async rotateIfNeeded(state, nextWriteBytes) {
+        if (state.bytesWritten + nextWriteBytes <= this.maxFileSize) {
+            return;
+        }
+        await this.rotateFiles(state.filePath);
+        state.bytesWritten = 0;
+    }
+    async rotateFiles(target) {
+        const directory = dirname(target);
+        await mkdir(directory, { recursive: true });
+        // Remove the oldest file if needed so rotation can proceed.
+        const oldest = `${target}.${this.maxFileCount}`;
+        try {
+            await rm(oldest, { force: true });
+        }
+        catch {
+            // Ignore removal errors: the file may not exist on the first rotations.
+        }
+        for (let index = this.maxFileCount - 1; index >= 1; index -= 1) {
+            const source = `${target}.${index}`;
+            const destination = `${target}.${index + 1}`;
+            try {
+                await rename(source, destination);
+            }
+            catch (error) {
+                if (error.code !== "ENOENT") {
+                    throw error;
+                }
+            }
+        }
+        try {
+            await rename(target, `${target}.1`);
+        }
+        catch (error) {
+            if (error.code !== "ENOENT") {
+                throw error;
+            }
+        }
+    }
+}

--- a/dist/tools/graphTools.js
+++ b/dist/tools/graphTools.js
@@ -1274,6 +1274,7 @@ function normaliseDescriptor(graph) {
     ensureGraphIdentity(descriptor, { preferId: graph.graph_id ?? null, preferVersion: graph.graph_version ?? null });
     return descriptor;
 }
+export { normaliseDescriptor as normaliseGraphDescriptor };
 function serialiseDescriptor(descriptor) {
     return {
         name: descriptor.name,

--- a/src/agents/autoscaler.ts
+++ b/src/agents/autoscaler.ts
@@ -2,6 +2,11 @@ import { StructuredLogger } from "../logger.js";
 import type { CreateChildOptions } from "../childSupervisor.js";
 import type { ChildRecordSnapshot } from "../state/childrenIndex.js";
 import type { LoopReconciler, LoopTickContext } from "../executor/loop.js";
+import {
+  extractCorrelationHints,
+  mergeCorrelationHints,
+  type EventCorrelationHints,
+} from "../events/correlation.js";
 
 /**
  * Subset of the {@link ChildSupervisor} API consumed by the autoscaler. Tests
@@ -55,6 +60,64 @@ export interface AutoscalerOptions {
   thresholds?: Partial<AutoscalerThresholds>;
   spawnTemplate?: CreateChildOptions;
   retireGracefulTimeoutMs?: number;
+  /** Optional sink receiving structured autoscaler events with correlation hints. */
+  emitEvent?: (event: AutoscalerEventInput) => void;
+}
+
+/** Severity levels emitted by the autoscaler when publishing lifecycle events. */
+export type AutoscalerEventLevel = "info" | "warn" | "error";
+
+/** Structured payload attached to autoscaler events. */
+export interface AutoscalerEventPayload extends Record<string, unknown> {
+  /** Short code describing the autoscaler action (e.g. `scale_up`). */
+  msg: string;
+}
+
+/** Envelope emitted whenever the autoscaler reports an action or anomaly. */
+export interface AutoscalerEventInput {
+  /** Severity attached to the event. */
+  level: AutoscalerEventLevel;
+  /** Optional child identifier involved in the action. */
+  childId?: string;
+  /** Structured payload describing the action and its context. */
+  payload: AutoscalerEventPayload;
+  /** Correlation hints (run/op/job/graph/node/child) forwarded to the unified bus. */
+  correlation?: EventCorrelationHints | null;
+}
+
+/**
+ * Builds correlation hints from a child snapshot already registered in the index.
+ * The helper keeps explicit `null` overrides while defaulting to the known
+ * `childId` when metadata does not surface one.
+ */
+function inferChildRecordCorrelation(child: ChildRecordSnapshot | null | undefined): EventCorrelationHints {
+  if (!child) {
+    return {};
+  }
+  const hints = extractCorrelationHints(child.metadata);
+  if (hints.childId == null) {
+    hints.childId = child.childId;
+  }
+  return hints;
+}
+
+/** Derives correlation hints from a spawn template used before the child exists. */
+function inferCreateChildCorrelation(template: CreateChildOptions | null | undefined): EventCorrelationHints {
+  if (!template) {
+    return {};
+  }
+  const hints = extractCorrelationHints(template);
+  mergeCorrelationHints(hints, extractCorrelationHints(template.metadata));
+  mergeCorrelationHints(hints, extractCorrelationHints(template.manifestExtras));
+
+  if (
+    hints.childId === undefined &&
+    typeof template.childId === "string" &&
+    template.childId.trim().length > 0
+  ) {
+    hints.childId = template.childId.trim();
+  }
+  return hints;
 }
 
 interface TaskSample {
@@ -91,6 +154,7 @@ export class Autoscaler implements LoopReconciler {
   private readonly thresholds: AutoscalerThresholds;
   private readonly spawnTemplate?: CreateChildOptions;
   private readonly retireGracefulTimeoutMs: number;
+  private readonly emitEvent?: (event: AutoscalerEventInput) => void;
 
   private config: AutoscalerConfig;
   private backlog = 0;
@@ -106,6 +170,7 @@ export class Autoscaler implements LoopReconciler {
     this.thresholds = { ...DEFAULT_THRESHOLDS, ...(options.thresholds ?? {}) };
     this.spawnTemplate = options.spawnTemplate;
     this.retireGracefulTimeoutMs = Math.max(100, options.retireGracefulTimeoutMs ?? 500);
+    this.emitEvent = options.emitEvent;
 
     this.config = { ...DEFAULT_CONFIG, ...(options.config ?? {}) };
     this.config = this.normaliseConfig(this.config);
@@ -176,6 +241,39 @@ export class Autoscaler implements LoopReconciler {
       averageLatencyMs,
       failureRate,
     };
+  }
+
+  /** Publishes a structured autoscaler event when an action occurs. */
+  private publishEvent(event: {
+    level: AutoscalerEventLevel;
+    childId?: string;
+    payload: AutoscalerEventPayload;
+    correlation?: EventCorrelationHints | null;
+  }): void {
+    if (!this.emitEvent) {
+      return;
+    }
+
+    const correlation: EventCorrelationHints = {};
+    if (event.childId) {
+      correlation.childId = event.childId;
+    }
+    mergeCorrelationHints(correlation, event.correlation);
+    if (event.childId && correlation.childId == null) {
+      correlation.childId = event.childId;
+    }
+
+    const payload: AutoscalerEventPayload = { ...event.payload };
+    if (event.childId && payload.child_id === undefined) {
+      payload.child_id = event.childId;
+    }
+
+    this.emitEvent({
+      level: event.level,
+      childId: event.childId,
+      payload,
+      correlation,
+    });
   }
 
   /** Implements the {@link LoopReconciler} contract. */
@@ -271,6 +369,12 @@ export class Autoscaler implements LoopReconciler {
 
   private async scaleUp(reason: string): Promise<void> {
     this.scalingInFlight = true;
+    const templateCorrelation = inferCreateChildCorrelation(this.spawnTemplate ?? null);
+    const templateChildId =
+      typeof templateCorrelation.childId === "string" && templateCorrelation.childId.length > 0
+        ? templateCorrelation.childId
+        : undefined;
+    const knownChildren = new Set(this.supervisor.childrenIndex.list().map((child) => child.childId));
     try {
       await this.supervisor.createChild(this.spawnTemplate);
       this.lastScaleAt = this.now();
@@ -279,10 +383,44 @@ export class Autoscaler implements LoopReconciler {
         backlog: this.backlog,
         samples: this.samples.length,
       });
+
+      const newChild = this.supervisor.childrenIndex
+        .list()
+        .find((snapshot) => !knownChildren.has(snapshot.childId));
+      const correlation: EventCorrelationHints = newChild
+        ? inferChildRecordCorrelation(newChild)
+        : {};
+      mergeCorrelationHints(correlation, templateCorrelation);
+      const childId = newChild?.childId ?? templateChildId;
+
+      this.publishEvent({
+        level: "info",
+        childId,
+        payload: {
+          msg: "scale_up",
+          reason,
+          backlog: this.backlog,
+          samples: this.samples.length,
+        },
+        correlation,
+      });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       this.logger?.error("autoscaler_scale_up_failed", {
         reason,
-        message: error instanceof Error ? error.message : String(error),
+        message,
+      });
+      this.publishEvent({
+        level: "error",
+        childId: templateChildId,
+        payload: {
+          msg: "scale_up_failed",
+          reason,
+          backlog: this.backlog,
+          samples: this.samples.length,
+          message,
+        },
+        correlation: templateCorrelation,
       });
     } finally {
       this.scalingInFlight = false;
@@ -295,25 +433,72 @@ export class Autoscaler implements LoopReconciler {
       return;
     }
 
+    const correlation = inferChildRecordCorrelation(candidate);
+    const basePayload = {
+      reason: "relaxation",
+      backlog: this.backlog,
+      samples: this.samples.length,
+    } as const;
+
     this.scalingInFlight = true;
     try {
       await this.supervisor.cancel(candidate.childId, { timeoutMs: this.retireGracefulTimeoutMs });
       this.lastScaleAt = this.now();
       this.logger?.info("autoscaler_scale_down", { child_id: candidate.childId });
+      this.publishEvent({
+        level: "info",
+        childId: candidate.childId,
+        payload: {
+          ...basePayload,
+          msg: "scale_down",
+        },
+        correlation,
+      });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       this.logger?.warn?.("autoscaler_scale_down_cancel_failed", {
         child_id: candidate.childId,
-        message: error instanceof Error ? error.message : String(error),
+        message,
+      });
+      this.publishEvent({
+        level: "warn",
+        childId: candidate.childId,
+        payload: {
+          ...basePayload,
+          msg: "scale_down_cancel_failed",
+          message,
+        },
+        correlation,
       });
       if (this.supervisor.kill) {
         try {
           await this.supervisor.kill(candidate.childId, { timeoutMs: 200 });
           this.lastScaleAt = this.now();
           this.logger?.info("autoscaler_scale_down_forced", { child_id: candidate.childId });
+          this.publishEvent({
+            level: "warn",
+            childId: candidate.childId,
+            payload: {
+              ...basePayload,
+              msg: "scale_down_forced",
+            },
+            correlation,
+          });
         } catch (killError) {
+          const killMessage = killError instanceof Error ? killError.message : String(killError);
           this.logger?.error("autoscaler_scale_down_failed", {
             child_id: candidate.childId,
-            message: killError instanceof Error ? killError.message : String(killError),
+            message: killMessage,
+          });
+          this.publishEvent({
+            level: "error",
+            childId: candidate.childId,
+            payload: {
+              ...basePayload,
+              msg: "scale_down_failed",
+              message: killMessage,
+            },
+            correlation,
           });
         }
       }

--- a/src/agents/supervisor.ts
+++ b/src/agents/supervisor.ts
@@ -2,6 +2,7 @@ import { StructuredLogger } from "../logger.js";
 import type { ChildRecordSnapshot } from "../state/childrenIndex.js";
 import type { LoopReconciler, LoopTickContext } from "../executor/loop.js";
 import type { LoopAlert } from "../guard/loopDetector.js";
+import { extractCorrelationHints, mergeCorrelationHints, type EventCorrelationHints } from "../events/correlation.js";
 
 /**
  * Minimal subset of the {@link ChildSupervisor} consumed by the supervisor.
@@ -309,4 +310,14 @@ export class OrchestratorSupervisor implements LoopReconciler {
       }
     }
   }
+}
+
+/**
+ * Extracts correlation hints from a supervisor incident so downstream
+ * orchestrator events can expose run/op identifiers when they are included in
+ * the incident context. The helper accepts both camelCase and snake_case
+ * fields and tolerates arrays when a single identifier is available.
+ */
+export function inferSupervisorIncidentCorrelation(incident: SupervisorIncident): EventCorrelationHints {
+  return extractCorrelationHints(incident.context);
 }

--- a/src/eventStore.ts
+++ b/src/eventStore.ts
@@ -14,7 +14,9 @@ export type EventKind =
   | "INFO"
   | "WARN"
   | "ERROR"
-  | "BT_RUN";
+  | "BT_RUN"
+  | "AUTOSCALER"
+  | "COGNITIVE";
 
 export type EventLevel = "info" | "warn" | "error";
 export type EventSource = "orchestrator" | "child" | "system";

--- a/src/events/cognitive.ts
+++ b/src/events/cognitive.ts
@@ -1,0 +1,178 @@
+import type { ReviewKind, ReviewResult } from "../agents/metaCritic.js";
+import type { ReflectionResult } from "../agents/selfReflect.js";
+import type { EventKind, EventLevel } from "../eventStore.js";
+
+import {
+  cloneCorrelationHints,
+  extractCorrelationHints,
+  mergeCorrelationHints,
+  type EventCorrelationHints,
+} from "./correlation.js";
+
+/**
+ * Snapshot describing the quality gate computation associated with a child
+ * collection. The structure mirrors the enriched object produced by the
+ * orchestrator when the meta critic scores an output.
+ */
+export interface QualityAssessmentSnapshot {
+  kind: ReviewKind;
+  score: number;
+  rubric: Record<string, number>;
+  metrics: Record<string, number>;
+  gate: { enabled: boolean; threshold: number; needs_revision: boolean };
+}
+
+/**
+ * Input required to build structured cognitive events for a child collection.
+ */
+export interface ChildCognitiveEventOptions {
+  /** Identifier of the child that produced the artefacts. */
+  childId: string;
+  /** Optional job identifier used when the child is associated with a plan run. */
+  jobId?: string | null;
+  /** Textual summary synthesised from the collected outputs. */
+  summary: { text: string; tags: string[]; kind: ReviewKind };
+  /** Review result returned by the meta critic heuristics. */
+  review: ReviewResult;
+  /** Optional reflection produced by the self-reflection heuristics. */
+  reflection?: ReflectionResult | null;
+  /** Optional quality assessment computed from the summary/review. */
+  quality?: QualityAssessmentSnapshot | null;
+  /** Number of artefacts returned by the collection. */
+  artifactCount: number;
+  /** Number of stdout/stderr messages returned by the collection. */
+  messageCount: number;
+  /** Additional records inspected to derive correlation metadata. */
+  correlationSources?: Array<unknown | null | undefined>;
+}
+
+/** Structured payload returned for a cognitive event ready to be published. */
+export interface CognitiveEventRecord {
+  kind: Extract<EventKind, "COGNITIVE">;
+  level: EventLevel;
+  childId: string;
+  jobId?: string | null;
+  payload: Record<string, unknown>;
+  correlation: EventCorrelationHints;
+}
+
+/** Pair of cognitive events derived from a single child collection. */
+export interface ChildCognitiveEvents {
+  review: CognitiveEventRecord;
+  reflection: CognitiveEventRecord | null;
+}
+
+/**
+ * Normalises the provided correlation sources and synthesises a single record
+ * that contains the identifiers expected by the unified event bus.
+ */
+function buildCorrelationHints(options: {
+  childId: string;
+  jobId?: string | null;
+  sources?: Array<unknown | null | undefined>;
+}): EventCorrelationHints {
+  const hints: EventCorrelationHints = {};
+  mergeCorrelationHints(hints, { childId: options.childId });
+  if (options.jobId !== undefined) {
+    mergeCorrelationHints(hints, { jobId: options.jobId ?? null });
+  }
+  for (const source of options.sources ?? []) {
+    if (!source) {
+      continue;
+    }
+    mergeCorrelationHints(hints, extractCorrelationHints(source));
+  }
+  return hints;
+}
+
+/**
+ * Build structured events describing the meta-review (and optional self
+ * reflection) performed after a `child_collect` invocation. The helper keeps
+ * payloads compact yet informative so downstream MCP clients can surface
+ * actionable telemetry without reimplementing the orchestrator logic.
+ */
+export function buildChildCognitiveEvents(options: ChildCognitiveEventOptions): ChildCognitiveEvents {
+  const baseCorrelation = buildCorrelationHints({
+    childId: options.childId,
+    jobId: options.jobId,
+    sources: options.correlationSources,
+  });
+
+  const sharedEnvelope = {
+    kind: "COGNITIVE" as const,
+    level: "info" as const satisfies EventLevel,
+    childId: options.childId,
+    jobId: options.jobId ?? null,
+  } satisfies Pick<CognitiveEventRecord, "kind" | "level" | "childId" | "jobId">;
+
+  const basePayloadFields = {
+    child_id: options.childId,
+    job_id: options.jobId ?? null,
+    run_id: baseCorrelation.runId ?? null,
+    op_id: baseCorrelation.opId ?? null,
+    graph_id: baseCorrelation.graphId ?? null,
+    node_id: baseCorrelation.nodeId ?? null,
+  } as const;
+
+  const reviewPayload: Record<string, unknown> = {
+    ...basePayloadFields,
+    msg: "child_meta_review",
+    summary: {
+      kind: options.summary.kind,
+      text: options.summary.text,
+      tags: [...options.summary.tags],
+    },
+    review: {
+      overall: options.review.overall,
+      verdict: options.review.verdict,
+      feedback: [...options.review.feedback],
+      suggestions: [...options.review.suggestions],
+      breakdown: options.review.breakdown.map((entry) => ({ ...entry })),
+    },
+    metrics: {
+      artifacts: options.artifactCount,
+      messages: options.messageCount,
+    },
+    quality_assessment: options.quality
+      ? {
+          kind: options.quality.kind,
+          score: options.quality.score,
+          rubric: { ...options.quality.rubric },
+          metrics: { ...options.quality.metrics },
+          gate: { ...options.quality.gate },
+        }
+      : null,
+  };
+
+  const reviewEvent: CognitiveEventRecord = {
+    ...sharedEnvelope,
+    payload: reviewPayload,
+    correlation: cloneCorrelationHints(baseCorrelation),
+  };
+
+  let reflectionEvent: CognitiveEventRecord | null = null;
+  if (options.reflection) {
+    const reflectionPayload: Record<string, unknown> = {
+      ...basePayloadFields,
+      msg: "child_reflection",
+      summary: {
+        kind: options.summary.kind,
+        text: options.summary.text,
+        tags: [...options.summary.tags],
+      },
+      reflection: {
+        insights: [...options.reflection.insights],
+        next_steps: [...options.reflection.nextSteps],
+        risks: [...options.reflection.risks],
+      },
+    };
+    reflectionEvent = {
+      ...sharedEnvelope,
+      payload: reflectionPayload,
+      correlation: cloneCorrelationHints(baseCorrelation),
+    };
+  }
+
+  return { review: reviewEvent, reflection: reflectionEvent };
+}
+

--- a/src/events/correlation.ts
+++ b/src/events/correlation.ts
@@ -1,0 +1,327 @@
+/**
+ * Utilities shared across the event bridges to safely merge correlation hints.
+ * The helpers ensure optional resolvers cannot erase native identifiers when
+ * they omit fields (returning `undefined`) while still allowing overrides with
+ * explicit `null` or string values.
+ */
+export interface EventCorrelationHints {
+  jobId?: string | null;
+  runId?: string | null;
+  opId?: string | null;
+  graphId?: string | null;
+  nodeId?: string | null;
+  childId?: string | null;
+}
+
+/**
+ * Shape accepted when merging correlation hints into a target envelope. Using a
+ * separate alias makes the intent explicit when helpers receive hints from
+ * legacy emitters that may surface sparse records.
+ */
+export type CorrelationLike =
+  | Partial<Record<keyof EventCorrelationHints, string | null | undefined>>
+  | null
+  | undefined;
+
+/**
+ * Merge correlation hints into the provided target without overriding existing
+ * values with `undefined`. The helper resolves the subtle case where optional
+ * resolvers omit identifiers which would otherwise erase the native correlation
+ * propagated through lifecycle events.
+ *
+ * @param target - Mutable record receiving the merged hints.
+ * @param source - Optional hints provided by emitters or resolvers.
+ */
+export function mergeCorrelationHints(target: EventCorrelationHints, source: CorrelationLike): void {
+  if (!source) {
+    return;
+  }
+  for (const key of ["jobId", "runId", "opId", "graphId", "nodeId", "childId"] as const) {
+    const value = source[key];
+    if (value !== undefined) {
+      target[key] = value;
+    }
+  }
+}
+
+/**
+ * Clone correlation hints into a new plain object. Callers can rely on the
+ * helper when they need to publish snapshots without mutating the original
+ * record.
+ */
+export function cloneCorrelationHints(source: CorrelationLike): EventCorrelationHints {
+  const target: EventCorrelationHints = {};
+  mergeCorrelationHints(target, source);
+  return target;
+}
+
+/** Normalise candidate values to non-empty strings when possible. */
+function normaliseCorrelationValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return null;
+}
+
+/**
+ * Extract correlation hints from arbitrary records, accepting both snake_case
+ * and camelCase identifiers. Nested `correlation` blocks (objects or single
+ * element arrays) are merged recursively, while ambiguous arrays are ignored
+ * to avoid guessing the intended identifier.
+ */
+export function extractCorrelationHints(source: unknown): EventCorrelationHints {
+  const hints: EventCorrelationHints = {};
+  if (!source || typeof source !== "object") {
+    return hints;
+  }
+
+  const visited = new Set<unknown>();
+  const queue: Record<string, unknown>[] = [];
+
+  const enqueue = (value: unknown) => {
+    if (!value || typeof value !== "object" || visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+    if (Array.isArray(value)) {
+      const objects = value.filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null);
+      if (objects.length === 1) {
+        queue.push(objects[0]!);
+      }
+      return;
+    }
+    queue.push(value as Record<string, unknown>);
+  };
+
+  enqueue(source);
+
+  const readCandidate = (
+    record: Record<string, unknown>,
+    keys: readonly string[],
+  ): string | null | undefined => {
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(record, key)) {
+        continue;
+      }
+      const value = record[key];
+      if (value === null) {
+        return null;
+      }
+      const candidate = normaliseCorrelationValue(value);
+      if (candidate) {
+        return candidate;
+      }
+    }
+    return undefined;
+  };
+
+  const readSingleFromArray = (
+    record: Record<string, unknown>,
+    keys: readonly string[],
+  ): string | null | undefined => {
+    for (const key of keys) {
+      if (!Object.prototype.hasOwnProperty.call(record, key)) {
+        continue;
+      }
+      const value = record[key];
+      if (value === null) {
+        return null;
+      }
+      if (Array.isArray(value)) {
+        const candidates = value
+          .map((entry) => normaliseCorrelationValue(entry))
+          .filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+        if (candidates.length === 1) {
+          return candidates[0]!;
+        }
+      }
+    }
+    return undefined;
+  };
+
+  while (queue.length > 0) {
+    const record = queue.shift()!;
+
+    const runId = readCandidate(record, ["run_id", "runId"]);
+    if (runId !== undefined && hints.runId == null) {
+      hints.runId = runId;
+    }
+
+    const opId = readCandidate(record, ["op_id", "opId", "operation_id", "operationId"]);
+    if (opId !== undefined && hints.opId == null) {
+      hints.opId = opId;
+    }
+
+    const jobId = readCandidate(record, ["job_id", "jobId"]);
+    if (jobId !== undefined && hints.jobId == null) {
+      hints.jobId = jobId;
+    }
+
+    const graphId = readCandidate(record, ["graph_id", "graphId"]);
+    if (graphId !== undefined && hints.graphId == null) {
+      hints.graphId = graphId;
+    }
+
+    const nodeId = readCandidate(record, ["node_id", "nodeId"]);
+    if (nodeId !== undefined && hints.nodeId == null) {
+      hints.nodeId = nodeId;
+    }
+
+    const directChildId = readCandidate(record, ["child_id", "childId", "participant", "participant_id"]);
+    if (directChildId !== undefined && hints.childId == null) {
+      hints.childId = directChildId;
+    } else if (hints.childId == null) {
+      const arrayChildId = readSingleFromArray(record, [
+        "child_ids",
+        "childIds",
+        "idle_children",
+        "participants",
+        "participant_ids",
+      ]);
+      if (arrayChildId !== undefined) {
+        hints.childId = arrayChildId;
+      }
+    }
+
+    const correlationCandidates = [
+      record.correlation,
+      (record as Record<string, unknown>)["correlation_hints"],
+      (record as Record<string, unknown>)["correlationHints"],
+    ];
+    for (const candidate of correlationCandidates) {
+      enqueue(candidate);
+    }
+  }
+
+  return hints;
+}
+
+/**
+ * Builds correlation hints for child-centric events by combining the runtime
+ * identifier with optional job identifiers and additional metadata records.
+ * The helper accepts heterogeneous sources (plain objects, nested correlation
+ * blocks, arrays with a single entry) and reuses {@link extractCorrelationHints}
+ * to keep the merge logic consistent with the rest of the event pipeline.
+ */
+export function buildChildCorrelationHints(options: {
+  /** Child identifier associated with the event. */
+  childId: string;
+  /** Optional job identifier inferred from the orchestrator state. */
+  jobId?: string | null | undefined;
+  /** Additional records inspected to derive correlation hints (metadata, payloads…). */
+  sources?: Array<unknown | null | undefined>;
+}): EventCorrelationHints {
+  const hints: EventCorrelationHints = {};
+  mergeCorrelationHints(hints, { childId: options.childId });
+
+  if (options.jobId !== undefined) {
+    if (options.jobId === null) {
+      mergeCorrelationHints(hints, { jobId: null });
+    } else if (typeof options.jobId === "string") {
+      const trimmed = options.jobId.trim();
+      mergeCorrelationHints(hints, { jobId: trimmed.length > 0 ? trimmed : null });
+    }
+  }
+
+  for (const source of options.sources ?? []) {
+    if (!source) {
+      continue;
+    }
+    mergeCorrelationHints(hints, extractCorrelationHints(source));
+  }
+
+  return hints;
+}
+
+/**
+ * Builds correlation hints for job-centric events by combining the job identifier
+ * with optional auxiliary metadata. The helper mirrors
+ * {@link buildChildCorrelationHints} so callers can derive `runId`/`opId`
+ * information from job-related records (children snapshots, supervisor
+ * metadata, payloads) without reimplementing the merge semantics.
+ */
+export function buildJobCorrelationHints(options: {
+  /** Job identifier associated with the event. */
+  jobId?: string | null | undefined;
+  /** Additional records inspected to derive correlation hints. */
+  sources?: Array<unknown | null | undefined>;
+}): EventCorrelationHints {
+  const hints: EventCorrelationHints = {};
+
+  const explicitNulls = new Set<keyof EventCorrelationHints>();
+  const applyHints = (source: CorrelationLike) => {
+    if (!source) {
+      return;
+    }
+    for (const key of ["jobId", "runId", "opId", "graphId", "nodeId", "childId"] as const) {
+      const value = source[key];
+      if (value === undefined) {
+        continue;
+      }
+      if (value === null) {
+        hints[key] = null;
+        explicitNulls.add(key);
+        continue;
+      }
+      if (!explicitNulls.has(key)) {
+        hints[key] = value;
+      }
+    }
+  };
+
+  let resolvedJobId: string | null | undefined;
+  let resolvedFrom: "base" | "source" | undefined;
+
+  if (options.jobId !== undefined) {
+    if (options.jobId === null) {
+      resolvedJobId = null;
+      resolvedFrom = "base";
+      applyHints({ jobId: null });
+    } else {
+      const normalised = normaliseCorrelationValue(options.jobId);
+      if (normalised !== null) {
+        resolvedJobId = normalised;
+        resolvedFrom = "base";
+        applyHints({ jobId: normalised });
+      } else {
+        resolvedJobId = null;
+        resolvedFrom = "base";
+        applyHints({ jobId: null });
+      }
+    }
+  }
+
+  for (const source of options.sources ?? []) {
+    if (!source) {
+      continue;
+    }
+    const extracted = extractCorrelationHints(source);
+    const { jobId, ...rest } = extracted;
+
+    if (jobId !== undefined) {
+      if (jobId === null) {
+        resolvedJobId = null;
+        resolvedFrom = resolvedFrom ?? "source";
+        applyHints({ jobId: null });
+      } else if (resolvedJobId === undefined) {
+        resolvedJobId = jobId;
+        resolvedFrom = "source";
+        applyHints({ jobId });
+      } else if (resolvedJobId !== null && resolvedJobId !== jobId) {
+        if (resolvedFrom !== "base") {
+          resolvedJobId = null;
+          resolvedFrom = "source";
+          applyHints({ jobId: null });
+        }
+      }
+    }
+
+    applyHints(rest);
+  }
+
+  return hints;
+}

--- a/src/executor/planLifecycle.ts
+++ b/src/executor/planLifecycle.ts
@@ -1,0 +1,495 @@
+import type { EventCorrelationHints } from "../events/correlation.js";
+
+/**
+ * Phases emitted by plan lifecycle publishers. They mirror the event payloads
+ * produced by the plan execution helpers so the registry can update progress
+ * and state atomically when events are recorded.
+ */
+export type PlanLifecyclePhase =
+  | "start"
+  | "tick"
+  | "loop"
+  | "node"
+  | "complete"
+  | "error"
+  | "cancel";
+
+/** Modes supported by the lifecycle registry. */
+export type PlanLifecycleMode = "bt" | "reactive";
+
+/** States exposed by the lifecycle registry. */
+export type PlanLifecycleState = "running" | "paused" | "done" | "failed";
+
+/**
+ * Snapshot returned to callers observing the lifecycle of a plan run. The
+ * structure is intentionally serialisable so MCP tools can return it directly
+ * as structured content.
+ */
+export interface PlanLifecycleSnapshot extends Record<string, unknown> {
+  run_id: string;
+  op_id: string;
+  mode: PlanLifecycleMode;
+  state: PlanLifecycleState;
+  progress: number;
+  last_event_seq: number;
+  started_at: number;
+  updated_at: number;
+  finished_at: number | null;
+  paused_at: number | null;
+  dry_run: boolean;
+  correlation: {
+    run_id: string | null;
+    op_id: string | null;
+    job_id: string | null;
+    graph_id: string | null;
+    node_id: string | null;
+    child_id: string | null;
+  };
+  supports_pause: boolean;
+  supports_resume: boolean;
+  last_event: {
+    phase: PlanLifecyclePhase | "pause" | "resume";
+    payload: Record<string, unknown>;
+    at: number;
+    seq: number;
+  } | null;
+  failure: {
+    status: string | null;
+    reason: string | null;
+  } | null;
+}
+
+/**
+ * Event recorded by the lifecycle registry. The payload mirrors the shape of
+ * orchestration events so progress heuristics can rely on tick counters and
+ * node identifiers published by the execution helpers.
+ */
+export interface PlanLifecycleEvent {
+  phase: PlanLifecyclePhase;
+  payload: Record<string, unknown>;
+  timestamp?: number;
+}
+
+/** Control hooks installed by execution helpers to pause or resume a run. */
+export interface PlanLifecycleControls {
+  pause?: () => boolean | Promise<boolean>;
+  resume?: () => boolean | Promise<boolean>;
+}
+
+/** Options accepted by the lifecycle registry constructor. */
+export interface PlanLifecycleRegistryOptions {
+  clock?: () => number;
+}
+
+/**
+ * Base error raised when lifecycle operations fail. Errors carry a stable code
+ * so MCP tool wrappers can surface consistent diagnostics to clients.
+ */
+export class PlanLifecycleError extends Error {
+  public readonly code: string;
+  public readonly hint?: string;
+  public readonly details?: unknown;
+
+  constructor(message: string, code: string, hint?: string, details?: unknown) {
+    super(message);
+    this.name = "PlanLifecycleError";
+    this.code = code;
+    this.hint = hint;
+    this.details = details;
+  }
+}
+
+/** Error thrown when callers reference an unknown plan run. */
+export class PlanRunNotFoundError extends PlanLifecycleError {
+  constructor(runId: string) {
+    super(`unknown plan run ${runId}`, "E-PLAN-NOT-FOUND", "plan_run", { runId });
+    this.name = "PlanRunNotFoundError";
+  }
+}
+
+/** Error thrown when pause/resume is requested on a run that does not support it. */
+export class PlanLifecycleUnsupportedError extends PlanLifecycleError {
+  constructor(runId: string, operation: "pause" | "resume") {
+    super(
+      `plan run ${runId} does not support ${operation}`,
+      operation === "pause" ? "E-PLAN-PAUSE-UNSUPPORTED" : "E-PLAN-RESUME-UNSUPPORTED",
+      "plan_run_reactive",
+      { runId, operation },
+    );
+    this.name = "PlanLifecycleUnsupportedError";
+  }
+}
+
+/** Error thrown when lifecycle operations conflict with the current state. */
+export class PlanLifecycleInvalidStateError extends PlanLifecycleError {
+  constructor(runId: string, expected: PlanLifecycleState, actual: PlanLifecycleState) {
+    super(
+      `plan run ${runId} is ${actual} but expected ${expected}`,
+      "E-PLAN-INVALID-STATE",
+      "plan_status",
+      { runId, expected, actual },
+    );
+    this.name = "PlanLifecycleInvalidStateError";
+  }
+}
+
+/** Error raised when callers interact with a run that already completed. */
+export class PlanLifecycleCompletedError extends PlanLifecycleError {
+  constructor(runId: string) {
+    super(`plan run ${runId} already completed`, "E-PLAN-COMPLETED", "plan_status", { runId });
+    this.name = "PlanLifecycleCompletedError";
+  }
+}
+
+/** Error raised when lifecycle tooling is disabled in the runtime features. */
+export class PlanLifecycleFeatureDisabledError extends PlanLifecycleError {
+  constructor() {
+    super("plan lifecycle tooling disabled", "E-PLAN-LIFECYCLE-DISABLED", "enable_plan_lifecycle");
+    this.name = "PlanLifecycleFeatureDisabledError";
+  }
+}
+
+interface PlanLifecycleMetrics {
+  estimatedWork: number | null;
+  visitedNodes: Set<string>;
+  lastTickCount: number;
+  lastSchedulerTicks: number;
+  lastLoopTicks: number;
+  lastPendingAfter: number;
+}
+
+interface PlanLifecycleEntry {
+  snapshot: PlanLifecycleSnapshot;
+  controls: PlanLifecycleControls;
+  metrics: PlanLifecycleMetrics;
+}
+
+function cloneSnapshot(snapshot: PlanLifecycleSnapshot): PlanLifecycleSnapshot {
+  return structuredClone(snapshot);
+}
+
+function clonePayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return structuredClone(payload) as Record<string, unknown>;
+}
+
+function sanitiseCorrelation(hints: EventCorrelationHints | null | undefined) {
+  return {
+    run_id: hints?.runId ?? null,
+    op_id: hints?.opId ?? null,
+    job_id: hints?.jobId ?? null,
+    graph_id: hints?.graphId ?? null,
+    node_id: hints?.nodeId ?? null,
+    child_id: hints?.childId ?? null,
+  };
+}
+
+function clampProgress(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  if (value > 100) {
+    return 100;
+  }
+  return value;
+}
+
+function roundProgress(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * In-memory registry mirroring the lifecycle of Behaviour Tree executions. The
+ * registry keeps lightweight snapshots so MCP tools can expose plan status,
+ * pause, and resume semantics without duplicating bookkeeping logic in tests or
+ * server handlers.
+ */
+export class PlanLifecycleRegistry {
+  private readonly clock: () => number;
+  private readonly entries = new Map<string, PlanLifecycleEntry>();
+
+  constructor(options: PlanLifecycleRegistryOptions = {}) {
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  /** Remove every tracked run. Mainly used by tests to reset state between scenarios. */
+  public clear(): void {
+    this.entries.clear();
+  }
+
+  /** Register a new run so subsequent events can update its snapshot. */
+  public registerRun(options: {
+    runId: string;
+    opId: string;
+    mode: PlanLifecycleMode;
+    dryRun?: boolean;
+    correlation?: EventCorrelationHints | null;
+    estimatedWork?: number | null;
+  }): PlanLifecycleSnapshot {
+    const existing = this.entries.get(options.runId);
+    if (existing) {
+      throw new PlanLifecycleError(
+        `plan run ${options.runId} already tracked`,
+        "E-PLAN-ALREADY-TRACKED",
+        "plan_status",
+        { runId: options.runId, state: existing.snapshot.state },
+      );
+    }
+    const now = this.clock();
+    const snapshot: PlanLifecycleSnapshot = {
+      run_id: options.runId,
+      op_id: options.opId,
+      mode: options.mode,
+      state: "running",
+      progress: 0,
+      last_event_seq: 0,
+      started_at: now,
+      updated_at: now,
+      finished_at: null,
+      paused_at: null,
+      dry_run: options.dryRun ?? false,
+      correlation: sanitiseCorrelation(options.correlation ?? null),
+      supports_pause: false,
+      supports_resume: false,
+      last_event: null,
+      failure: null,
+    };
+    const entry: PlanLifecycleEntry = {
+      snapshot,
+      controls: {},
+      metrics: {
+        estimatedWork: options.estimatedWork ?? null,
+        visitedNodes: new Set<string>(),
+        lastTickCount: 0,
+        lastSchedulerTicks: 0,
+        lastLoopTicks: 0,
+        lastPendingAfter: 0,
+      },
+    };
+    this.entries.set(options.runId, entry);
+    return cloneSnapshot(snapshot);
+  }
+
+  /** Attach pause/resume controls to a registered run. */
+  public attachControls(runId: string, controls: PlanLifecycleControls): PlanLifecycleSnapshot {
+    const entry = this.entries.get(runId);
+    if (!entry) {
+      throw new PlanRunNotFoundError(runId);
+    }
+    entry.controls = { ...controls };
+    entry.snapshot.supports_pause = typeof controls.pause === "function";
+    entry.snapshot.supports_resume = typeof controls.resume === "function";
+    entry.snapshot.updated_at = this.clock();
+    return cloneSnapshot(entry.snapshot);
+  }
+
+  /** Release pause/resume controls once a run completed. */
+  public releaseControls(runId: string): void {
+    const entry = this.entries.get(runId);
+    if (!entry) {
+      return;
+    }
+    entry.controls = {};
+    entry.snapshot.supports_pause = false;
+    entry.snapshot.supports_resume = false;
+  }
+
+  /** Record a lifecycle event and update the associated snapshot. */
+  public recordEvent(runId: string, event: PlanLifecycleEvent): PlanLifecycleSnapshot {
+    const entry = this.entries.get(runId);
+    if (!entry) {
+      throw new PlanRunNotFoundError(runId);
+    }
+    const now = event.timestamp ?? this.clock();
+    entry.snapshot.last_event_seq += 1;
+    entry.snapshot.last_event = {
+      phase: event.phase,
+      payload: clonePayload(event.payload),
+      at: now,
+      seq: entry.snapshot.last_event_seq,
+    };
+    entry.snapshot.updated_at = now;
+
+    switch (event.phase) {
+      case "start":
+      case "tick":
+      case "loop":
+      case "node": {
+        if (entry.snapshot.state !== "running") {
+          entry.snapshot.state = "running";
+        }
+        entry.snapshot.paused_at = null;
+        break;
+      }
+      case "complete": {
+        entry.snapshot.state = "done";
+        entry.snapshot.finished_at = now;
+        entry.snapshot.failure = null;
+        entry.snapshot.progress = 100;
+        this.releaseControls(runId);
+        break;
+      }
+      case "error":
+      case "cancel": {
+        entry.snapshot.state = "failed";
+        entry.snapshot.finished_at = now;
+        entry.snapshot.failure = {
+          status: typeof event.payload.status === "string" ? event.payload.status : null,
+          reason: typeof event.payload.reason === "string" ? event.payload.reason : null,
+        };
+        entry.snapshot.progress = 100;
+        this.releaseControls(runId);
+        break;
+      }
+      default:
+        break;
+    }
+
+    this.updateProgress(entry, event);
+    return cloneSnapshot(entry.snapshot);
+  }
+
+  /** Pause a running plan run and surface the updated snapshot. */
+  public async pause(runId: string): Promise<PlanLifecycleSnapshot> {
+    const entry = this.entries.get(runId);
+    if (!entry) {
+      throw new PlanRunNotFoundError(runId);
+    }
+    if (entry.snapshot.state === "done" || entry.snapshot.state === "failed") {
+      throw new PlanLifecycleCompletedError(runId);
+    }
+    if (entry.snapshot.state === "paused") {
+      return cloneSnapshot(entry.snapshot);
+    }
+    if (typeof entry.controls.pause !== "function") {
+      throw new PlanLifecycleUnsupportedError(runId, "pause");
+    }
+    await entry.controls.pause();
+    const now = this.clock();
+    entry.snapshot.state = "paused";
+    entry.snapshot.paused_at = now;
+    entry.snapshot.updated_at = now;
+    entry.snapshot.last_event_seq += 1;
+    entry.snapshot.last_event = {
+      phase: "pause",
+      payload: { manual: true },
+      at: now,
+      seq: entry.snapshot.last_event_seq,
+    };
+    return cloneSnapshot(entry.snapshot);
+  }
+
+  /** Resume a paused run and surface the latest snapshot. */
+  public async resume(runId: string): Promise<PlanLifecycleSnapshot> {
+    const entry = this.entries.get(runId);
+    if (!entry) {
+      throw new PlanRunNotFoundError(runId);
+    }
+    if (entry.snapshot.state === "done" || entry.snapshot.state === "failed") {
+      throw new PlanLifecycleCompletedError(runId);
+    }
+    if (entry.snapshot.state !== "paused") {
+      throw new PlanLifecycleInvalidStateError(runId, "paused", entry.snapshot.state);
+    }
+    if (typeof entry.controls.resume !== "function") {
+      throw new PlanLifecycleUnsupportedError(runId, "resume");
+    }
+    await entry.controls.resume();
+    const now = this.clock();
+    entry.snapshot.state = "running";
+    entry.snapshot.paused_at = null;
+    entry.snapshot.updated_at = now;
+    entry.snapshot.last_event_seq += 1;
+    entry.snapshot.last_event = {
+      phase: "resume",
+      payload: { manual: true },
+      at: now,
+      seq: entry.snapshot.last_event_seq,
+    };
+    return cloneSnapshot(entry.snapshot);
+  }
+
+  /** Return a snapshot describing the current lifecycle of the requested run. */
+  public getSnapshot(runId: string): PlanLifecycleSnapshot {
+    const entry = this.entries.get(runId);
+    if (!entry) {
+      throw new PlanRunNotFoundError(runId);
+    }
+    return cloneSnapshot(entry.snapshot);
+  }
+
+  private updateProgress(entry: PlanLifecycleEntry, event: PlanLifecycleEvent): void {
+    switch (event.phase) {
+      case "tick": {
+        const ticks = this.extractNumber(event.payload.ticks ?? event.payload.scheduler_ticks);
+        if (ticks !== null) {
+          entry.metrics.lastTickCount = Math.max(entry.metrics.lastTickCount, ticks);
+          entry.metrics.lastSchedulerTicks = Math.max(entry.metrics.lastSchedulerTicks, ticks);
+        }
+        const pending = this.extractNumber(event.payload.pending_after);
+        if (pending !== null) {
+          entry.metrics.lastPendingAfter = Math.max(0, pending);
+        }
+        break;
+      }
+      case "loop": {
+        const executed = this.extractNumber(event.payload.executed_ticks);
+        if (executed !== null) {
+          entry.metrics.lastLoopTicks = Math.max(entry.metrics.lastLoopTicks, executed);
+        }
+        break;
+      }
+      case "node": {
+        const nodeId = typeof event.payload.node_id === "string" ? event.payload.node_id : null;
+        const status = typeof event.payload.status === "string" ? event.payload.status : null;
+        if (nodeId && status && status !== "running") {
+          entry.metrics.visitedNodes.add(nodeId);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    if (entry.snapshot.state === "done" || entry.snapshot.state === "failed") {
+      entry.snapshot.progress = 100;
+      return;
+    }
+
+    const ratios: number[] = [];
+    if (entry.metrics.estimatedWork && entry.metrics.estimatedWork > 0) {
+      ratios.push(entry.metrics.visitedNodes.size / entry.metrics.estimatedWork);
+    }
+    if (entry.metrics.lastTickCount > 0 || entry.metrics.lastSchedulerTicks > 0) {
+      const ticks = Math.max(entry.metrics.lastTickCount, entry.metrics.lastSchedulerTicks);
+      const denominator = ticks + entry.metrics.lastPendingAfter + 1;
+      ratios.push(ticks / denominator);
+    }
+    if (entry.metrics.lastLoopTicks > 0) {
+      const denominator = entry.metrics.lastLoopTicks + entry.metrics.lastPendingAfter + 1;
+      ratios.push(entry.metrics.lastLoopTicks / denominator);
+    }
+
+    if (ratios.length === 0) {
+      return;
+    }
+
+    const ratio = Math.max(...ratios);
+    const bounded = Math.min(0.99, Math.max(0, ratio));
+    const progress = clampProgress(roundProgress(bounded * 100));
+    entry.snapshot.progress = Math.max(entry.snapshot.progress, progress);
+  }
+
+  private extractNumber(value: unknown): number | null {
+    if (typeof value !== "number") {
+      return null;
+    }
+    if (!Number.isFinite(value)) {
+      return null;
+    }
+    return value;
+  }
+}
+

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -35,6 +35,8 @@ export interface LoggerOptions {
    * sensitive prompts stay confidential in persisted artefacts.
    */
   readonly redactSecrets?: Array<string | RegExp>;
+  /** Optional listener invoked every time an entry is emitted. */
+  readonly onEntry?: (entry: LogEntry) => void;
 }
 
 /** Phases covered by the cognitive logging helpers. */
@@ -77,12 +79,15 @@ export class StructuredLogger {
    * `./tmp/orchestrator.log` work even when the `tmp/` folder is missing.
    */
   private logDirectoryReady = false;
+  /** Optional listener invoked with the structured entry. */
+  private readonly entryListener?: (entry: LogEntry) => void;
 
   constructor(options: LoggerOptions = {}) {
     this.logFile = options.logFile ?? undefined;
     this.maxFileSizeBytes = options.maxFileSizeBytes ?? DEFAULT_MAX_FILE_SIZE;
     this.maxFileCount = Math.max(1, options.maxFileCount ?? DEFAULT_MAX_FILE_COUNT);
     this.redactSecrets = options.redactSecrets ? [...options.redactSecrets] : [];
+    this.entryListener = options.onEntry;
   }
 
   info(message: string, payload?: unknown): void {
@@ -153,6 +158,9 @@ export class StructuredLogger {
     };
     const line = `${JSON.stringify(entry)}\n`;
     process.stdout.write(line);
+    if (this.entryListener) {
+      this.entryListener(structuredClone(entry));
+    }
     if (!this.logFile) {
       return;
     }

--- a/src/monitor/log.ts
+++ b/src/monitor/log.ts
@@ -1,0 +1,318 @@
+import { appendFile, mkdir, rename, rm, stat } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+/** Streams supported by the log journal. */
+export type LogStream = "server" | "run" | "child";
+
+/**
+ * Options accepted when instantiating the {@link LogJournal}. They control how many entries are
+ * retained in memory and how JSONL persistence is rotated on disk.
+ */
+export interface LogJournalOptions {
+  /** Root directory where JSONL artefacts are persisted. */
+  readonly rootDir: string;
+  /** Maximum number of entries preserved in memory for a given bucket. */
+  readonly maxEntriesPerBucket?: number;
+  /** Maximum size in bytes of a JSONL file before rotation occurs. */
+  readonly maxFileSizeBytes?: number;
+  /** Number of rotated files kept per bucket. */
+  readonly maxFileCount?: number;
+}
+
+/** Base shape shared by all correlated log entries. */
+export interface BaseCorrelatedLogEntry {
+  /** Monotonic sequence used for paging. */
+  seq: number;
+  /** Timestamp expressed in epoch milliseconds. */
+  ts: number;
+  /** Stream category the entry belongs to. */
+  stream: LogStream;
+  /** Identifier of the underlying bucket (run id, child id or fixed name). */
+  bucketId: string;
+  /** Severity level surfaced by the orchestrator. */
+  level: string;
+  /** Human readable message. */
+  message: string;
+  /** Optional structured payload carried alongside the message. */
+  data?: unknown;
+  /** Optional job identifier associated with the log entry. */
+  jobId?: string | null;
+  /** Optional run identifier. */
+  runId?: string | null;
+  /** Optional operation identifier. */
+  opId?: string | null;
+  /** Optional graph identifier. */
+  graphId?: string | null;
+  /** Optional node identifier. */
+  nodeId?: string | null;
+  /** Optional child identifier. */
+  childId?: string | null;
+}
+
+/** Entry shape persisted in memory and on disk. */
+export interface CorrelatedLogEntry extends BaseCorrelatedLogEntry {}
+
+/** Input accepted when recording a new log entry. */
+export interface LogRecordInput {
+  stream: LogStream;
+  bucketId?: string | null;
+  ts?: number;
+  seq?: number;
+  level: string;
+  message: string;
+  data?: unknown;
+  jobId?: string | null;
+  runId?: string | null;
+  opId?: string | null;
+  graphId?: string | null;
+  nodeId?: string | null;
+  childId?: string | null;
+}
+
+/** Result returned by {@link LogJournal.tail}. */
+export interface LogTailResult {
+  entries: CorrelatedLogEntry[];
+  nextSeq: number;
+}
+
+/** Error raised when a log operation fails. */
+export class LogJournalError extends Error {
+  constructor(message: string, readonly code: string = "E-LOG-JOURNAL") {
+    super(message);
+    this.name = "LogJournalError";
+  }
+}
+
+/** Internal state tracked for a log bucket. */
+interface LogBucketState {
+  entries: CorrelatedLogEntry[];
+  lastSeq: number;
+  writeQueue: Promise<void>;
+  bytesWritten: number;
+  writerReady: boolean;
+  readonly filePath: string;
+}
+
+/** Constants controlling memory usage and rotation defaults. */
+const DEFAULT_MAX_ENTRIES = 500;
+const DEFAULT_MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MiB keeps artefacts small.
+const DEFAULT_MAX_FILE_COUNT = 5;
+
+/** Ensures a string bucket identifier is safe to use within file paths. */
+function sanitiseBucketId(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.length) {
+    return "default";
+  }
+  const safe = trimmed.replace(/[^a-zA-Z0-9_-]/g, "-");
+  return safe.slice(0, 120) || "default";
+}
+
+/** Resolve the base directory for a given stream. */
+function resolveStreamDir(rootDir: string, stream: LogStream): string {
+  switch (stream) {
+    case "server":
+      return join(rootDir, "server");
+    case "run":
+      return join(rootDir, "runs");
+    case "child":
+      return join(rootDir, "children");
+    default:
+      return rootDir;
+  }
+}
+
+/** Creates the JSONL file path for a bucket. */
+function resolveBucketPath(rootDir: string, stream: LogStream, bucketId: string): string {
+  const baseDir = resolveStreamDir(rootDir, stream);
+  const safeId = sanitiseBucketId(bucketId);
+  return join(baseDir, `${safeId}.jsonl`);
+}
+
+/**
+ * Maintains correlated log entries for the orchestrator. Entries are preserved in memory for fast
+ * access and mirrored to JSONL artefacts with size-based rotation.
+ */
+export class LogJournal {
+  private readonly rootDir: string;
+  private readonly maxEntries: number;
+  private readonly maxFileSize: number;
+  private readonly maxFileCount: number;
+  private readonly buckets = new Map<string, LogBucketState>();
+
+  constructor(options: LogJournalOptions) {
+    this.rootDir = resolve(options.rootDir);
+    this.maxEntries = Math.max(1, options.maxEntriesPerBucket ?? DEFAULT_MAX_ENTRIES);
+    this.maxFileSize = Math.max(64 * 1024, options.maxFileSizeBytes ?? DEFAULT_MAX_FILE_SIZE);
+    this.maxFileCount = Math.max(1, options.maxFileCount ?? DEFAULT_MAX_FILE_COUNT);
+  }
+
+  /** Clears all in-memory entries and resets sequence counters. */
+  reset(): void {
+    this.buckets.clear();
+  }
+
+  /**
+   * Records a new correlated entry. The write is synchronous from the caller perspective while file
+   * persistence is enqueued to guarantee ordering without blocking orchestrator hot paths.
+   */
+  record(input: LogRecordInput): CorrelatedLogEntry {
+    const bucketId = input.bucketId?.trim() && input.bucketId.trim().length > 0 ? input.bucketId.trim() : "orchestrator";
+    const key = this.buildBucketKey(input.stream, bucketId);
+    const state = this.getOrCreateBucket(input.stream, bucketId, key);
+
+    const seq = input.seq && input.seq > state.lastSeq ? input.seq : state.lastSeq + 1;
+    state.lastSeq = Math.max(state.lastSeq, seq);
+
+    const ts = typeof input.ts === "number" && Number.isFinite(input.ts) ? Math.floor(input.ts) : Date.now();
+    const entry: CorrelatedLogEntry = {
+      seq,
+      ts,
+      stream: input.stream,
+      bucketId,
+      level: input.level,
+      message: input.message,
+      data: input.data,
+      jobId: input.jobId ?? null,
+      runId: input.runId ?? null,
+      opId: input.opId ?? null,
+      graphId: input.graphId ?? null,
+      nodeId: input.nodeId ?? null,
+      childId: input.childId ?? null,
+    };
+
+    state.entries.push(entry);
+    if (state.entries.length > this.maxEntries) {
+      state.entries.splice(0, state.entries.length - this.maxEntries);
+    }
+
+    state.writeQueue = state.writeQueue
+      .then(() => this.appendToFile(state, entry))
+      .catch(() => {
+        // Reset the queue so subsequent writes are not blocked by transient errors.
+        state.writeQueue = Promise.resolve();
+      });
+
+    this.buckets.set(key, state);
+    return entry;
+  }
+
+  /** Retrieves a slice of log entries ordered by their sequence number. */
+  tail(input: { stream: LogStream; bucketId?: string | null; fromSeq?: number; limit?: number }): LogTailResult {
+    const bucketId = input.bucketId?.trim() && input.bucketId.trim().length > 0 ? input.bucketId.trim() : "orchestrator";
+    const key = this.buildBucketKey(input.stream, bucketId);
+    const state = this.buckets.get(key);
+    if (!state) {
+      return { entries: [], nextSeq: 0 };
+    }
+
+    const fromSeq = typeof input.fromSeq === "number" && input.fromSeq >= 0 ? input.fromSeq : 0;
+    const limit = typeof input.limit === "number" && input.limit > 0 ? Math.min(Math.floor(input.limit), this.maxEntries) : this.maxEntries;
+
+    const filtered = state.entries.filter((entry) => entry.seq > fromSeq);
+    const ordered = filtered.sort((a, b) => a.seq - b.seq).slice(0, limit);
+    const nextSeq = ordered.length ? ordered[ordered.length - 1].seq : state.lastSeq;
+    return { entries: ordered, nextSeq };
+  }
+
+  /** Waits for all pending file writes to complete. */
+  async flush(): Promise<void> {
+    await Promise.all(Array.from(this.buckets.values(), (bucket) => bucket.writeQueue));
+  }
+
+  private buildBucketKey(stream: LogStream, bucketId: string): string {
+    return `${stream}:${bucketId}`;
+  }
+
+  private getOrCreateBucket(stream: LogStream, bucketId: string, key: string): LogBucketState {
+    const existing = this.buckets.get(key);
+    if (existing) {
+      return existing;
+    }
+    const filePath = resolveBucketPath(this.rootDir, stream, bucketId);
+    return {
+      entries: [],
+      lastSeq: 0,
+      writeQueue: Promise.resolve(),
+      bytesWritten: 0,
+      writerReady: false,
+      filePath,
+    };
+  }
+
+  private async appendToFile(state: LogBucketState, entry: CorrelatedLogEntry): Promise<void> {
+    try {
+      if (!state.writerReady) {
+        await this.ensureWriter(state);
+      }
+      const line = `${JSON.stringify(entry)}\n`;
+      await this.rotateIfNeeded(state, Buffer.byteLength(line, "utf8"));
+      await appendFile(state.filePath, line, "utf8");
+      state.bytesWritten += Buffer.byteLength(line, "utf8");
+    } catch (error) {
+      // On persistence failure, attempt to reset the bucket so future writes can retry.
+      state.writerReady = false;
+      state.bytesWritten = 0;
+      throw new LogJournalError(
+        error instanceof Error ? error.message : `log_persist_failed:${String(error)}`,
+        "E-LOG-WRITE",
+      );
+    }
+  }
+
+  private async ensureWriter(state: LogBucketState): Promise<void> {
+    const directory = dirname(state.filePath);
+    await mkdir(directory, { recursive: true });
+    try {
+      const stats = await stat(state.filePath);
+      state.bytesWritten = stats.size;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        state.bytesWritten = 0;
+      } else {
+        throw error;
+      }
+    }
+    state.writerReady = true;
+  }
+
+  private async rotateIfNeeded(state: LogBucketState, nextWriteBytes: number): Promise<void> {
+    if (state.bytesWritten + nextWriteBytes <= this.maxFileSize) {
+      return;
+    }
+    await this.rotateFiles(state.filePath);
+    state.bytesWritten = 0;
+  }
+
+  private async rotateFiles(target: string): Promise<void> {
+    const directory = dirname(target);
+    await mkdir(directory, { recursive: true });
+    // Remove the oldest file if needed so rotation can proceed.
+    const oldest = `${target}.${this.maxFileCount}`;
+    try {
+      await rm(oldest, { force: true });
+    } catch {
+      // Ignore removal errors: the file may not exist on the first rotations.
+    }
+
+    for (let index = this.maxFileCount - 1; index >= 1; index -= 1) {
+      const source = `${target}.${index}`;
+      const destination = `${target}.${index + 1}`;
+      try {
+        await rename(source, destination);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+      }
+    }
+
+    try {
+      await rename(target, `${target}.1`);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,12 +5,19 @@ import { randomUUID } from "crypto";
 import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { resolve as resolvePath, dirname as pathDirname, basename as pathBasename } from "node:path";
 import { pathToFileURL } from "url";
-import { GraphState } from "./graphState.js";
+import { GraphState, type ChildSnapshot, type JobSnapshot } from "./graphState.js";
 import { GraphTransactionManager, GraphTransactionError, GraphVersionConflictError } from "./graph/tx.js";
 import { GraphLockManager } from "./graph/locks.js";
-import { LoggerOptions, StructuredLogger } from "./logger.js";
+import { LoggerOptions, StructuredLogger, type LogEntry } from "./logger.js";
 import { EventStore, OrchestratorEvent } from "./eventStore.js";
 import { EventBus, type EventLevel as BusEventLevel } from "./events/bus.js";
+import {
+  buildChildCorrelationHints,
+  buildJobCorrelationHints,
+  mergeCorrelationHints,
+  type EventCorrelationHints,
+} from "./events/correlation.js";
+import { buildChildCognitiveEvents, type QualityAssessmentSnapshot } from "./events/cognitive.js";
 import {
   bridgeBlackboardEvents,
   bridgeCancellationEvents,
@@ -21,6 +28,7 @@ import {
 } from "./events/bridges.js";
 import { startHttpServer } from "./httpServer.js";
 import { startDashboardServer } from "./monitor/dashboard.js";
+import { LogJournal, type LogStream } from "./monitor/log.js";
 import { BehaviorTreeStatusRegistry } from "./monitor/btStatusRegistry.js";
 import { MessageRecord, Role } from "./types.js";
 import {
@@ -33,7 +41,7 @@ import { ChildSupervisor, type ChildLogEventSnapshot } from "./childSupervisor.j
 import { ChildRecordSnapshot, UnknownChildError } from "./state/childrenIndex.js";
 import { ChildCollectedOutputs, ChildRuntimeStatus } from "./childRuntime.js";
 import { Autoscaler } from "./agents/autoscaler.js";
-import { OrchestratorSupervisor } from "./agents/supervisor.js";
+import { OrchestratorSupervisor, inferSupervisorIncidentCorrelation } from "./agents/supervisor.js";
 import { MetaCritic, ReviewKind, ReviewResult } from "./agents/metaCritic.js";
 import { reflect, ReflectionResult } from "./agents/selfReflect.js";
 import { scoreCode, scorePlan, scoreText, ScoreCodeInput, ScorePlanInput, ScoreTextInput } from "./quality/scoring.js";
@@ -49,6 +57,7 @@ import { ValueGraph } from "./values/valueGraph.js";
 import type { ValueFilterDecision } from "./values/valueGraph.js";
 import { ResourceRegistry, ResourceRegistryError } from "./resources/registry.js";
 import { IdempotencyRegistry } from "./infra/idempotency.js";
+import { PlanLifecycleRegistry } from "./executor/planLifecycle.js";
 import {
   ChildCancelInputShape,
   ChildCancelInputSchema,
@@ -106,6 +115,12 @@ import {
   PlanReduceInputShape,
   PlanDryRunInputSchema,
   PlanDryRunInputShape,
+  PlanStatusInputSchema,
+  PlanStatusInputShape,
+  PlanPauseInputSchema,
+  PlanPauseInputShape,
+  PlanResumeInputSchema,
+  PlanResumeInputShape,
   PlanToolContext,
   handlePlanFanout,
   handlePlanJoin,
@@ -114,6 +129,9 @@ import {
   handlePlanRunReactive,
   handlePlanReduce,
   handlePlanDryRun,
+  handlePlanStatus,
+  handlePlanPause,
+  handlePlanResume,
   ValueGuardRejectionError,
 } from "./tools/planTools.js";
 import {
@@ -353,6 +371,17 @@ const valueGraph = new ValueGraph();
 const valueGuardRegistry = new Map<string, ValueFilterDecision>();
 /** Registry exposing live Behaviour Tree node statuses to dashboards. */
 const btStatusRegistry = new BehaviorTreeStatusRegistry();
+/** Registry tracking plan lifecycle state for pause/resume tooling. */
+const planLifecycle = new PlanLifecycleRegistry();
+/** Directory storing JSONL artefacts for correlated log tails. */
+const LOG_JOURNAL_ROOT = resolvePath(process.cwd(), "runs", "logs");
+/** Shared journal preserving orchestrator, run and child logs for MCP tools. */
+const logJournal = new LogJournal({
+  rootDir: LOG_JOURNAL_ROOT,
+  maxEntriesPerBucket: 1000,
+  maxFileSizeBytes: 4 * 1024 * 1024,
+  maxFileCount: 5,
+});
 
 /** Default feature toggles used before CLI/flags are parsed. */
 const DEFAULT_FEATURE_TOGGLES: FeatureToggles = {
@@ -549,8 +578,52 @@ const baseLoggerOptions: LoggerOptions = {
   redactSecrets: parseRedactEnv(process.env.MCP_LOG_REDACT),
 };
 
+function recordServerLogEntry(entry: LogEntry): void {
+  let timestamp = Date.parse(entry.timestamp);
+  if (!Number.isFinite(timestamp)) {
+    timestamp = Date.now();
+  }
+  const payload = entry.payload ?? null;
+  const runId = extractRunId(payload);
+  const opId = extractOpId(payload);
+  const graphId = extractGraphId(payload);
+  const nodeId = extractNodeId(payload);
+  const childId = extractChildId(payload);
+  const jobId = extractJobId(payload);
+
+  try {
+    logJournal.record({
+      stream: "server",
+      bucketId: "orchestrator",
+      ts: timestamp,
+      level: entry.level,
+      message: entry.message,
+      data: payload ?? null,
+      jobId,
+      runId,
+      opId,
+      graphId,
+      nodeId,
+      childId,
+    });
+  } catch (error) {
+    try {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `${JSON.stringify({ ts: new Date().toISOString(), level: "error", message: "log_journal_record_failed", detail })}\n`,
+      );
+    } catch {
+      // Ignore secondary failures: logging should never crash orchestrator hot paths.
+    }
+  }
+}
+
+function instantiateLogger(options: LoggerOptions): StructuredLogger {
+  return new StructuredLogger({ ...options, onEntry: recordServerLogEntry });
+}
+
 let activeLoggerOptions: LoggerOptions = { ...baseLoggerOptions };
-let logger = new StructuredLogger(activeLoggerOptions);
+let logger = instantiateLogger(activeLoggerOptions);
 const eventStore = new EventStore({ maxHistory: 5000, logger });
 const eventBus = new EventBus({ historyLimit: 5000 });
 
@@ -643,10 +716,47 @@ const childSupervisor = new ChildSupervisor({
       raw: entry.raw ?? null,
       parsed: entry.parsed ?? null,
     });
+    try {
+      logJournal.record({
+        stream: "child",
+        bucketId: entry.childId ?? childId,
+        ts: entry.ts,
+        level: resolveChildLogLevel(entry.stream),
+        message: entry.message,
+        data: {
+          raw: entry.raw ?? null,
+          parsed: entry.parsed ?? null,
+          stream: entry.stream,
+        },
+        jobId: entry.jobId ?? null,
+        runId: entry.runId ?? null,
+        opId: entry.opId ?? null,
+        graphId: entry.graphId ?? null,
+        nodeId: entry.nodeId ?? null,
+        childId: entry.childId ?? childId,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `${JSON.stringify({ ts: new Date().toISOString(), level: "error", message: "child_log_journal_failed", detail })}\n`,
+      );
+    }
   },
 });
 
-const autoscaler = new Autoscaler({ supervisor: childSupervisor, logger });
+const autoscaler = new Autoscaler({
+  supervisor: childSupervisor,
+  logger,
+  emitEvent: (event) => {
+    pushEvent({
+      kind: "AUTOSCALER",
+      level: event.level,
+      childId: event.childId,
+      payload: event.payload,
+      correlation: event.correlation ?? undefined,
+    });
+  },
+});
 
 const orchestratorSupervisor = new OrchestratorSupervisor({
   childManager: childSupervisor,
@@ -655,6 +765,7 @@ const orchestratorSupervisor = new OrchestratorSupervisor({
     emitAlert: async (incident) => {
       const level = incident.severity === "critical" ? "error" : "warn";
       const eventKind = level === "error" ? "ERROR" : "WARN";
+      const correlation = inferSupervisorIncidentCorrelation(incident);
       if (level === "error") {
         logger.error("supervisor_incident", {
           type: incident.type,
@@ -668,15 +779,30 @@ const orchestratorSupervisor = new OrchestratorSupervisor({
           context: incident.context,
         });
       }
-      pushEvent({ kind: eventKind, level, payload: { type: "supervisor_incident", incident } });
+      pushEvent({
+        kind: eventKind,
+        level,
+        payload: { type: "supervisor_incident", incident },
+        correlation,
+      });
     },
     requestRewrite: async (incident) => {
       logger.warn("supervisor_request_rewrite", incident.context);
-      pushEvent({ kind: "INFO", level: "warn", payload: { type: "supervisor_request_rewrite", incident } });
+      pushEvent({
+        kind: "INFO",
+        level: "warn",
+        payload: { type: "supervisor_request_rewrite", incident },
+        correlation: inferSupervisorIncidentCorrelation(incident),
+      });
     },
     requestRedispatch: async (incident) => {
       logger.warn("supervisor_request_redispatch", incident.context);
-      pushEvent({ kind: "INFO", level: "warn", payload: { type: "supervisor_request_redispatch", incident } });
+      pushEvent({
+        kind: "INFO",
+        level: "warn",
+        payload: { type: "supervisor_request_redispatch", incident },
+        correlation: inferSupervisorIncidentCorrelation(incident),
+      });
     },
   },
 });
@@ -1126,6 +1252,7 @@ function getPlanToolContext(): PlanToolContext {
         jobId: event.jobId,
         childId: event.childId,
         payload: event.payload,
+        correlation: event.correlation ?? undefined,
       });
     },
     stigmergy,
@@ -1138,6 +1265,7 @@ function getPlanToolContext(): PlanToolContext {
     loopDetector,
     autoscaler: runtimeFeatures.enableAutoscaler ? autoscaler : undefined,
     btStatusRegistry,
+    planLifecycle: runtimeFeatures.enablePlanLifecycle ? planLifecycle : undefined,
     idempotency: runtimeFeatures.enableIdempotency ? idempotencyRegistry : undefined,
   };
 }
@@ -1579,6 +1707,62 @@ function ensureTransactionsEnabled(toolName: string) {
 const now = () => Date.now();
 const j = (o: unknown) => JSON.stringify(o, null, 2);
 
+function extractStringProperty(payload: unknown, key: string): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const candidate = payload as Record<string, unknown>;
+  const raw = candidate[key];
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function extractRunId(payload: unknown): string | null {
+  return extractStringProperty(payload, "run_id");
+}
+
+function extractOpId(payload: unknown): string | null {
+  return extractStringProperty(payload, "op_id") ?? extractStringProperty(payload, "operation_id");
+}
+
+function extractGraphId(payload: unknown): string | null {
+  return extractStringProperty(payload, "graph_id") ?? null;
+}
+
+function extractNodeId(payload: unknown): string | null {
+  return extractStringProperty(payload, "node_id") ?? null;
+}
+
+function extractChildId(payload: unknown): string | null {
+  return extractStringProperty(payload, "child_id") ?? null;
+}
+
+function extractJobId(payload: unknown): string | null {
+  return extractStringProperty(payload, "job_id") ?? null;
+}
+
+function deriveEventMessage(kind: string, payload: unknown): string {
+  const msg = extractStringProperty(payload, "msg");
+  if (msg) {
+    return msg;
+  }
+  return kind.toLowerCase();
+}
+
+function resolveChildLogLevel(stream: "stdout" | "stderr" | "meta"): string {
+  switch (stream) {
+    case "stderr":
+      return "error";
+    case "meta":
+      return "debug";
+    default:
+      return "info";
+  }
+}
+
 const OpCancelInputSchema = z
   .object({
     op_id: z.string().min(1),
@@ -1646,6 +1830,16 @@ const EventSubscribeInputSchema = z
   .strict();
 const EventSubscribeInputShape = EventSubscribeInputSchema.shape;
 
+const LogsTailInputSchema = z
+  .object({
+    stream: z.enum(["server", "run", "child"]).default("server"),
+    id: z.string().trim().min(1).optional(),
+    from_seq: z.number().int().min(0).optional(),
+    limit: z.number().int().positive().max(500).optional(),
+  })
+  .strict();
+const LogsTailInputShape = LogsTailInputSchema.shape;
+
 /**
  * Input schema guarding the `graph_subgraph_extract` tool. The strict contract
  * rejects stray properties so export destinations remain predictable.
@@ -1663,46 +1857,9 @@ const GraphSubgraphExtractInputShape = GraphSubgraphExtractInputSchema.shape;
 
 type GraphSubgraphExtractInput = z.infer<typeof GraphSubgraphExtractInputSchema>;
 
-function extractStringProperty(payload: unknown, key: string): string | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-  const candidate = payload as Record<string, unknown>;
-  const raw = candidate[key];
-  if (typeof raw !== "string") {
-    return null;
-  }
-  const trimmed = raw.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function extractRunId(payload: unknown): string | null {
-  return extractStringProperty(payload, "run_id");
-}
-
-function extractOpId(payload: unknown): string | null {
-  return extractStringProperty(payload, "op_id") ?? extractStringProperty(payload, "operation_id");
-}
-
-function extractGraphId(payload: unknown): string | null {
-  return extractStringProperty(payload, "graph_id") ?? null;
-}
-
-function extractNodeId(payload: unknown): string | null {
-  return extractStringProperty(payload, "node_id") ?? null;
-}
-
-function deriveEventMessage(kind: string, payload: unknown): string {
-  const msg = extractStringProperty(payload, "msg");
-  if (msg) {
-    return msg;
-  }
-  return kind.toLowerCase();
-}
-
 function pushEvent(
   event: Omit<OrchestratorEvent, "seq" | "ts" | "source" | "level"> &
-    Partial<Pick<OrchestratorEvent, "source" | "level">>
+    Partial<Pick<OrchestratorEvent, "source" | "level">> & { correlation?: EventCorrelationHints | null }
 ): OrchestratorEvent {
   const emitted = eventStore.emit({
     kind: event.kind,
@@ -1720,20 +1877,52 @@ function pushEvent(
     jobId: emitted.jobId,
     childId: emitted.childId
   });
-  const runId = extractRunId(event.payload);
-  const opId = extractOpId(event.payload);
-  const graphId = extractGraphId(event.payload);
-  const nodeId = extractNodeId(event.payload);
+
+  const hints: EventCorrelationHints = {};
+  mergeCorrelationHints(hints, event.correlation ?? undefined);
+  if (event.jobId !== undefined) {
+    mergeCorrelationHints(hints, { jobId: event.jobId ?? null });
+  }
+  if (event.childId !== undefined) {
+    mergeCorrelationHints(hints, { childId: event.childId ?? null });
+  }
+
+  const payloadHints: EventCorrelationHints = {};
+  const payloadRunId = extractRunId(event.payload);
+  if (typeof payloadRunId === "string") {
+    payloadHints.runId = payloadRunId;
+  }
+  const payloadOpId = extractOpId(event.payload);
+  if (typeof payloadOpId === "string") {
+    payloadHints.opId = payloadOpId;
+  }
+  const payloadGraphId = extractGraphId(event.payload);
+  if (typeof payloadGraphId === "string") {
+    payloadHints.graphId = payloadGraphId;
+  }
+  const payloadNodeId = extractNodeId(event.payload);
+  if (typeof payloadNodeId === "string") {
+    payloadHints.nodeId = payloadNodeId;
+  }
+  mergeCorrelationHints(hints, payloadHints);
+
+  const runId = hints.runId ?? null;
+  const opId = hints.opId ?? null;
+  const graphId = hints.graphId ?? null;
+  const nodeId = hints.nodeId ?? null;
+  const jobId = hints.jobId ?? null;
+  const childId = hints.childId ?? null;
   const message = deriveEventMessage(event.kind, event.payload);
+
   eventBus.publish({
     cat: event.kind,
     level: (event.level ?? emitted.level) as BusEventLevel,
-    jobId: event.jobId ?? null,
+    jobId,
     runId,
     opId,
     graphId,
     nodeId,
-    childId: event.childId ?? null,
+    childId,
     msg: message,
     data: event.payload,
   });
@@ -1743,14 +1932,36 @@ function pushEvent(
       ts: emitted.ts,
       kind: emitted.kind,
       level: emitted.level,
-      jobId: emitted.jobId,
+      jobId,
       runId,
       opId,
       graphId,
       nodeId,
-      childId: emitted.childId,
+      childId,
       payload: emitted.payload,
     });
+    try {
+      logJournal.record({
+        stream: "run",
+        bucketId: runId,
+        seq: emitted.seq,
+        ts: emitted.ts,
+        level: event.level ?? emitted.level,
+        message,
+        data: event.payload ?? null,
+        jobId,
+        runId,
+        opId,
+        graphId,
+        nodeId,
+        childId,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      process.stderr.write(
+        `${JSON.stringify({ ts: new Date().toISOString(), level: "error", message: "run_log_journal_failed", detail })}\n`,
+      );
+    }
   }
   return emitted;
 }
@@ -1790,13 +2001,42 @@ function buildLiveEvents(input: { job_id?: string; child_id?: string; limit?: nu
 
 // Heartbeat
 let HEARTBEAT_TIMER: NodeJS.Timeout | null = null;
+
+/**
+ * Publish a heartbeat event for every job currently marked as running. The helper keeps the
+ * correlation logic reusable so deterministic tests can trigger heartbeats without waiting for
+ * the scheduler interval to elapse.
+ */
+function emitHeartbeatTick(): void {
+  for (const job of graphState.listJobsByState("running")) {
+    const correlation = resolveJobEventCorrelation(job.id, { job });
+    pushEvent({
+      kind: "HEARTBEAT",
+      jobId: correlation.jobId ?? job.id,
+      payload: { msg: "alive" },
+      correlation,
+    });
+  }
+}
+
+/**
+ * Start the periodic heartbeat publisher when the orchestrator schedules background jobs. The
+ * interval delegates to {@link emitHeartbeatTick} so the logic remains testable.
+ */
 function startHeartbeat() {
   if (HEARTBEAT_TIMER) return;
   HEARTBEAT_TIMER = setInterval(() => {
-    for (const job of graphState.listJobsByState("running")) {
-      pushEvent({ kind: "HEARTBEAT", jobId: job.id, payload: { msg: "alive" } });
-    }
+    emitHeartbeatTick();
   }, 2000);
+}
+
+/** Stop the heartbeat interval to avoid leaking timers when shutting down tests or transports. */
+function stopHeartbeat(): void {
+  if (!HEARTBEAT_TIMER) {
+    return;
+  }
+  clearInterval(HEARTBEAT_TIMER);
+  HEARTBEAT_TIMER = null;
 }
 
 // ---------------------------
@@ -1823,14 +2063,87 @@ function findJobIdByChild(childId: string): string | undefined {
   return graphState.findJobIdByChild(childId);
 }
 
+/**
+ * Synthesises correlation hints for child-centric events by combining the
+ * orchestrator state (graph snapshot + supervisor metadata) with optional
+ * additional sources.
+ */
+function resolveChildEventCorrelation(
+  childId: string,
+  options: { child?: ChildSnapshot | null; extraSources?: Array<unknown | null | undefined> } = {},
+): EventCorrelationHints {
+  const childSnapshot = options.child ?? graphState.getChild(childId) ?? null;
+  const jobCandidate = childSnapshot?.jobId ?? findJobIdByChild(childId) ?? null;
+  const metadata = childSupervisor.childrenIndex.getChild(childId)?.metadata;
+  const sources: Array<unknown | null | undefined> = [];
+  if (metadata) {
+    sources.push(metadata);
+  }
+  if (options.extraSources) {
+    sources.push(...options.extraSources);
+  }
+  return buildChildCorrelationHints({
+    childId,
+    jobId: jobCandidate,
+    sources,
+  });
+}
+
+/**
+ * Synthesises correlation hints for job-centric events by combining the
+ * orchestrator state with supervisor metadata. The helper inspects the job
+ * snapshot, associated children and any additional sources so job-scoped
+ * events can inherit `runId`/`opId` hints derived from their participants.
+ */
+function resolveJobEventCorrelation(
+  jobId: string,
+  options: { job?: JobSnapshot | null; extraSources?: Array<unknown | null | undefined> } = {},
+): EventCorrelationHints {
+  const jobSnapshot = options.job ?? graphState.getJob(jobId) ?? null;
+  const sources: Array<unknown | null | undefined> = [];
+
+  if (jobSnapshot) {
+    sources.push({
+      job_id: jobSnapshot.id,
+      state: jobSnapshot.state,
+      child_ids: jobSnapshot.childIds,
+    });
+
+    for (const childId of jobSnapshot.childIds) {
+      const child = graphState.getChild(childId);
+      if (child) {
+        sources.push(child);
+      }
+      const indexSnapshot = childSupervisor.childrenIndex.getChild(childId);
+      if (indexSnapshot) {
+        sources.push(indexSnapshot.metadata);
+      }
+    }
+  }
+
+  if (options.extraSources) {
+    sources.push(...options.extraSources);
+  }
+
+  return buildJobCorrelationHints({ jobId, sources });
+}
+
 function pruneExpired() {
   const t = now();
   for (const child of graphState.listChildSnapshots()) {
     if (child.ttlAt && t > child.ttlAt && child.state !== "killed") {
       graphState.clearPendingForChild(child.id);
       graphState.patchChild(child.id, { state: "killed", waitingFor: null, pendingId: null, ttlAt: null });
-      const jobId = child.jobId ?? findJobIdByChild(child.id);
-      pushEvent({ kind: "KILL", jobId, childId: child.id, level: "warn", payload: { reason: "ttl" } });
+      const correlation = resolveChildEventCorrelation(child.id, { child });
+      const jobId = correlation.jobId ?? undefined;
+      pushEvent({
+        kind: "KILL",
+        jobId,
+        childId: correlation.childId ?? child.id,
+        level: "warn",
+        payload: { reason: "ttl" },
+        correlation,
+      });
     }
   }
   const expiredEntries = blackboard.evictExpired();
@@ -2437,6 +2750,86 @@ server.registerTool(
           {
             type: "text" as const,
             text: j({ error: "E-EVT-INVALID", message, hint: "invalid_filters" }),
+          },
+        ],
+      };
+    }
+  },
+);
+
+server.registerTool(
+  "logs_tail",
+  {
+    title: "Logs tail",
+    description: "Diffuse un extrait corrélé des journaux orchestrateur, runs et enfants.",
+    inputSchema: LogsTailInputShape,
+  },
+  async (input: unknown) => {
+    try {
+      const parsed = LogsTailInputSchema.parse(input ?? {});
+      const stream = (parsed.stream ?? "server") as LogStream;
+      const bucketId = parsed.id?.trim();
+
+      if ((stream === "run" || stream === "child") && (!bucketId || bucketId.length === 0)) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: j({
+                error: "E-LOGS-MISSING_ID",
+                message: "id is required when tailing run or child streams",
+                stream,
+              }),
+            },
+          ],
+        };
+      }
+
+      const targetBucket = bucketId ?? "orchestrator";
+      const result = logJournal.tail({
+        stream,
+        bucketId: targetBucket,
+        fromSeq: parsed.from_seq,
+        limit: parsed.limit,
+      });
+
+      const entries = result.entries.map((entry) => ({
+        seq: entry.seq,
+        ts: entry.ts,
+        stream: entry.stream,
+        bucket_id: entry.bucketId,
+        level: entry.level,
+        message: entry.message,
+        data: entry.data ?? null,
+        job_id: entry.jobId ?? null,
+        run_id: entry.runId ?? null,
+        op_id: entry.opId ?? null,
+        graph_id: entry.graphId ?? null,
+        node_id: entry.nodeId ?? null,
+        child_id: entry.childId ?? null,
+      }));
+
+      const structured = {
+        stream,
+        bucket_id: targetBucket,
+        entries,
+        next_seq: result.nextSeq,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: j({ tool: "logs_tail", result: structured }) }],
+        structuredContent: structured,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn("logs_tail_failed", { message });
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: j({ error: "E-LOGS-INVALID", message }),
           },
         ],
       };
@@ -4607,6 +5000,79 @@ server.registerTool(
 );
 
 server.registerTool(
+  "plan_status",
+  {
+    title: "Plan status",
+    description: "Expose l'état courant d'un run de plan (running/paused/done/failed).",
+    inputSchema: PlanStatusInputShape,
+  },
+  async (input) => {
+    try {
+      const parsed = PlanStatusInputSchema.parse(input);
+      logger.info("plan_status_requested", { run_id: parsed.run_id });
+      const result = handlePlanStatus(getPlanToolContext(), parsed);
+      logger.info("plan_status_resolved", {
+        run_id: result.run_id,
+        state: result.state,
+        progress: result.progress,
+      });
+      return {
+        content: [{ type: "text" as const, text: j({ tool: "plan_status", result }) }],
+        structuredContent: result,
+      };
+    } catch (error) {
+      return planToolError("plan_status", error, {}, "E-PLAN-STATUS");
+    }
+  },
+);
+
+server.registerTool(
+  "plan_pause",
+  {
+    title: "Plan pause",
+    description: "Met en pause un run de plan actif via le lifecycle registry.",
+    inputSchema: PlanPauseInputShape,
+  },
+  async (input) => {
+    try {
+      const parsed = PlanPauseInputSchema.parse(input);
+      logger.info("plan_pause_requested", { run_id: parsed.run_id });
+      const result = await handlePlanPause(getPlanToolContext(), parsed);
+      logger.info("plan_pause_applied", { run_id: result.run_id, state: result.state });
+      return {
+        content: [{ type: "text" as const, text: j({ tool: "plan_pause", result }) }],
+        structuredContent: result,
+      };
+    } catch (error) {
+      return planToolError("plan_pause", error, {}, "E-PLAN-PAUSE");
+    }
+  },
+);
+
+server.registerTool(
+  "plan_resume",
+  {
+    title: "Plan resume",
+    description: "Reprend un run de plan précédemment mis en pause.",
+    inputSchema: PlanResumeInputShape,
+  },
+  async (input) => {
+    try {
+      const parsed = PlanResumeInputSchema.parse(input);
+      logger.info("plan_resume_requested", { run_id: parsed.run_id });
+      const result = await handlePlanResume(getPlanToolContext(), parsed);
+      logger.info("plan_resume_applied", { run_id: result.run_id, state: result.state });
+      return {
+        content: [{ type: "text" as const, text: j({ tool: "plan_resume", result }) }],
+        structuredContent: result,
+      };
+    } catch (error) {
+      return planToolError("plan_resume", error, {}, "E-PLAN-RESUME");
+    }
+  },
+);
+
+server.registerTool(
   "op_cancel",
   {
     title: "Operation cancel",
@@ -5015,7 +5481,14 @@ server.registerTool(
 
         started++;
 
-        pushEvent({ kind: "START", jobId: job_id, childId: child.id, payload: { name: child.name } });
+        const correlation = resolveChildEventCorrelation(child.id, { child });
+        pushEvent({
+          kind: "START",
+          jobId: correlation.jobId ?? undefined,
+          childId: correlation.childId ?? child.id,
+          payload: { name: child.name },
+          correlation,
+        });
 
       }
 
@@ -5327,17 +5800,14 @@ server.registerTool(
       }
 
       const qualityComputation = computeQualityAssessment(summary.kind, summary.text, review);
-      let qualityAssessment:
-        | (QualityAssessmentComputation & {
-            kind: ReviewKind;
-            gate: { enabled: boolean; threshold: number; needs_revision: boolean };
-          })
-        | null = null;
+      let qualityAssessment: QualityAssessmentSnapshot | null = null;
       if (qualityComputation) {
         const needsRevision = qualityGateEnabled && qualityComputation.score < qualityGateThreshold;
         qualityAssessment = {
-          ...qualityComputation,
           kind: summary.kind,
+          score: qualityComputation.score,
+          rubric: { ...qualityComputation.rubric },
+          metrics: { ...qualityComputation.metrics },
           gate: {
             enabled: qualityGateEnabled,
             threshold: qualityGateThreshold,
@@ -5348,16 +5818,17 @@ server.registerTool(
           actor: "quality-scorer",
           phase: "score",
           childId: parsed.child_id,
-          score: qualityComputation.score / 100,
+          score: qualityAssessment.score / 100,
           content: `quality-${summary.kind}`,
           metadata: {
             threshold: qualityGateThreshold,
             needs_revision: needsRevision,
-            rubric: qualityComputation.rubric,
+            rubric: qualityAssessment.rubric,
           },
         });
       }
       const childSnapshot = childSupervisor.childrenIndex.getChild(parsed.child_id);
+      const jobId = findJobIdByChild(parsed.child_id) ?? null;
       const metadataTags = extractMetadataTags(childSnapshot?.metadata);
       const tags = new Set<string>([...summary.tags, ...metadataTags, parsed.child_id]);
       const goals = extractMetadataGoals(childSnapshot?.metadata);
@@ -5377,6 +5848,38 @@ server.registerTool(
           rubric: qualityAssessment.rubric,
           gate: qualityAssessment.gate,
         };
+      }
+
+      const cognitiveEvents = buildChildCognitiveEvents({
+        childId: parsed.child_id,
+        jobId,
+        summary,
+        review,
+        reflection: reflectionSummary,
+        quality: qualityAssessment,
+        artifactCount: result.outputs.artifacts.length,
+        messageCount: result.outputs.messages.length,
+        correlationSources: [childSnapshot?.metadata, result.outputs, result],
+      });
+
+      pushEvent({
+        kind: cognitiveEvents.review.kind,
+        level: cognitiveEvents.review.level,
+        jobId: cognitiveEvents.review.jobId ?? undefined,
+        childId: cognitiveEvents.review.childId,
+        payload: cognitiveEvents.review.payload,
+        correlation: cognitiveEvents.review.correlation,
+      });
+
+      if (cognitiveEvents.reflection) {
+        pushEvent({
+          kind: cognitiveEvents.reflection.kind,
+          level: cognitiveEvents.reflection.level,
+          jobId: cognitiveEvents.reflection.jobId ?? undefined,
+          childId: cognitiveEvents.reflection.childId,
+          payload: cognitiveEvents.reflection.payload,
+          correlation: cognitiveEvents.reflection.correlation,
+        });
       }
 
       const episode = memoryStore.recordEpisode({
@@ -5559,11 +6062,25 @@ server.registerTool(
 
 
 
-    const jobId = child.jobId ?? findJobIdByChild(child_id);
+    const correlation = resolveChildEventCorrelation(child_id, { child });
+    const jobId = correlation.jobId ?? undefined;
 
-    pushEvent({ kind: "PROMPT", jobId, childId: child_id, source: "orchestrator", payload: { appended: messages.length } });
+    pushEvent({
+      kind: "PROMPT",
+      jobId,
+      childId: correlation.childId ?? child_id,
+      source: "orchestrator",
+      payload: { appended: messages.length },
+      correlation,
+    });
 
-    pushEvent({ kind: "PENDING", jobId, childId: child_id, payload: { pendingId } });
+    pushEvent({
+      kind: "PENDING",
+      jobId,
+      childId: correlation.childId ?? child_id,
+      payload: { pendingId },
+      correlation,
+    });
 
 
 
@@ -5608,9 +6125,17 @@ server.registerTool(
       graphState.appendMessage(child.id, { role: "assistant", content: text, ts: now(), actor: "child" });
     }
 
-    const jobId = child.jobId ?? findJobIdByChild(child.id);
+    const correlation = resolveChildEventCorrelation(child.id, { child });
+    const jobId = correlation.jobId ?? undefined;
 
-    pushEvent({ kind: "REPLY_PART", jobId, childId: child.id, source: "child", payload: { len: text.length } });
+    pushEvent({
+      kind: "REPLY_PART",
+      jobId,
+      childId: correlation.childId ?? child.id,
+      source: "child",
+      payload: { len: text.length },
+      correlation,
+    });
 
 
 
@@ -5620,7 +6145,14 @@ server.registerTool(
 
       graphState.patchChild(child.id, { state: "waiting", waitingFor: null, pendingId: null });
 
-      pushEvent({ kind: "REPLY", jobId, childId: child.id, source: "child", payload: { final: true } });
+      pushEvent({
+        kind: "REPLY",
+        jobId,
+        childId: correlation.childId ?? child.id,
+        source: "child",
+        payload: { final: true },
+        correlation,
+      });
 
     }
 
@@ -5668,9 +6200,17 @@ server.registerTool(
 
 
 
-    const jobId = child.jobId ?? findJobIdByChild(child.id);
+    const correlation = resolveChildEventCorrelation(child.id, { child });
+    const jobId = correlation.jobId ?? undefined;
 
-    pushEvent({ kind: "REPLY", jobId, childId: child.id, source: "child", payload: { length: content.length, final: true } });
+    pushEvent({
+      kind: "REPLY",
+      jobId,
+      childId: correlation.childId ?? child.id,
+      source: "child",
+      payload: { length: content.length, final: true },
+      correlation,
+    });
 
 
 
@@ -5718,11 +6258,25 @@ server.registerTool(
 
 
 
-    const jobId = child.jobId ?? findJobIdByChild(child_id);
+    const correlation = resolveChildEventCorrelation(child_id, { child });
+    const jobId = correlation.jobId ?? undefined;
 
-    pushEvent({ kind: "PROMPT", jobId, childId: child_id, source: "orchestrator", payload: { oneShot: true } });
+    pushEvent({
+      kind: "PROMPT",
+      jobId,
+      childId: correlation.childId ?? child_id,
+      source: "orchestrator",
+      payload: { oneShot: true },
+      correlation,
+    });
 
-    pushEvent({ kind: "PENDING", jobId, childId: child_id, payload: { pendingId } });
+    pushEvent({
+      kind: "PENDING",
+      jobId,
+      childId: correlation.childId ?? child_id,
+      payload: { pendingId },
+      correlation,
+    });
 
 
 
@@ -5838,7 +6392,14 @@ server.registerTool(
 
     graphState.patchChild(child.id, { name: input.name });
 
-    pushEvent({ kind: "INFO", childId: child.id, jobId: child.jobId ?? findJobIdByChild(child.id), payload: { rename: { from: oldName, to: input.name } } });
+    const correlation = resolveChildEventCorrelation(child.id, { child });
+    pushEvent({
+      kind: "INFO",
+      childId: correlation.childId ?? child.id,
+      jobId: correlation.jobId ?? undefined,
+      payload: { rename: { from: oldName, to: input.name } },
+      correlation,
+    });
 
     return { content: [{ type: "text", text: j({ ok: true, child_id: child.id, name: input.name }) }] };
 
@@ -5866,7 +6427,14 @@ server.registerTool(
 
     graphState.resetChild(child.id, { keepSystem: !!input.keep_system, timestamp: now() });
 
-    pushEvent({ kind: "INFO", childId: child.id, jobId: child.jobId ?? findJobIdByChild(child.id), payload: { reset: { keep_system: !!input.keep_system } } });
+    const correlation = resolveChildEventCorrelation(child.id, { child });
+    pushEvent({
+      kind: "INFO",
+      childId: correlation.childId ?? child.id,
+      jobId: correlation.jobId ?? undefined,
+      payload: { reset: { keep_system: !!input.keep_system } },
+      correlation,
+    });
 
     return { content: [{ type: "text", text: j({ ok: true, child_id: child.id }) }] };
 
@@ -5919,8 +6487,14 @@ server.registerTool(
       }));
 
       const payload = { job_id, state: job.state, children };
+      const correlation = resolveJobEventCorrelation(job.id, { job, extraSources: [payload] });
 
-      pushEvent({ kind: "STATUS", jobId: job.id, payload });
+      pushEvent({
+        kind: "STATUS",
+        jobId: correlation.jobId ?? job.id,
+        payload,
+        correlation,
+      });
 
       return { content: [{ type: "text", text: j(payload) }] };
 
@@ -6068,7 +6642,14 @@ server.registerTool(
 
     graphState.patchJob(job_id, { state: "done" });
 
-    pushEvent({ kind: "AGGREGATE", jobId: job.id, payload: { strategy: strategy ?? "concat", requested: strategyRaw ?? null } });
+    const correlation = resolveJobEventCorrelation(job.id, { job });
+
+    pushEvent({
+      kind: "AGGREGATE",
+      jobId: correlation.jobId ?? job.id,
+      payload: { strategy: strategy ?? "concat", requested: strategyRaw ?? null },
+      correlation,
+    });
 
 
 
@@ -6108,9 +6689,16 @@ server.registerTool(
 
       graphState.patchChild(child_id, { state: "killed", waitingFor: null, pendingId: null });
 
-      const jobId = child.jobId ?? findJobIdByChild(child_id);
+      const correlation = resolveChildEventCorrelation(child_id, { child });
 
-      pushEvent({ kind: "KILL", jobId, childId: child_id, level: "warn", payload: { scope: "child" } });
+      pushEvent({
+        kind: "KILL",
+        jobId: correlation.jobId ?? undefined,
+        childId: correlation.childId ?? child_id,
+        level: "warn",
+        payload: { scope: "child" },
+        correlation,
+      });
 
       return { content: [{ type: "text", text: j({ ok: true, child_id }) }] };
 
@@ -6133,8 +6721,15 @@ server.registerTool(
       }
 
       graphState.patchJob(job_id, { state: "killed" });
+      const correlation = resolveJobEventCorrelation(job_id, { job });
 
-      pushEvent({ kind: "KILL", jobId: job_id, level: "warn", payload: { scope: "job" } });
+      pushEvent({
+        kind: "KILL",
+        jobId: correlation.jobId ?? job_id,
+        level: "warn",
+        payload: { scope: "job" },
+        correlation,
+      });
 
       return { content: [{ type: "text", text: j({ ok: true, job_id }) }] };
 
@@ -6172,7 +6767,7 @@ if (isMain) {
 
   if (options.logFile) {
     activeLoggerOptions = { ...activeLoggerOptions, logFile: options.logFile };
-    logger = new StructuredLogger(activeLoggerOptions);
+    logger = instantiateLogger(activeLoggerOptions);
     eventStore.setLogger(logger);
     logger.info("logger_configured", {
       log_file: options.logFile,
@@ -6278,10 +6873,14 @@ if (isMain) {
 export {
   server,
   graphState,
+  childSupervisor,
+  logJournal,
   DEFAULT_CHILD_RUNTIME,
   buildLiveEvents,
   setDefaultChildRuntime,
   GraphSubgraphExtractInputSchema,
   GraphSubgraphExtractInputShape,
+  emitHeartbeatTick,
+  stopHeartbeat,
 };
 

--- a/src/tools/graphTools.ts
+++ b/src/tools/graphTools.ts
@@ -1774,6 +1774,8 @@ function normaliseDescriptor(graph: z.infer<typeof GraphDescriptorSchema>): Norm
   return descriptor;
 }
 
+export { normaliseDescriptor as normaliseGraphDescriptor };
+
 function serialiseDescriptor(descriptor: NormalisedGraph): GraphDescriptorPayload {
   return {
     name: descriptor.name,

--- a/tests/agents.autoscaler.correlation.test.ts
+++ b/tests/agents.autoscaler.correlation.test.ts
@@ -1,0 +1,296 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  Autoscaler,
+  type AutoscalerEventInput,
+  type AutoscalerSupervisor,
+} from "../src/agents/autoscaler.js";
+import { ChildrenIndex } from "../src/state/childrenIndex.js";
+import type { LoopTickContext } from "../src/executor/loop.js";
+import type { CreateChildOptions } from "../src/childSupervisor.js";
+
+/** Deterministic clock mirroring the `Date.now` contract. */
+class ManualClock {
+  private value = 0;
+
+  now(): number {
+    return this.value;
+  }
+
+  advance(ms: number): void {
+    this.value += ms;
+  }
+}
+
+/** Builds a minimal loop context compatible with the autoscaler reconciler. */
+function buildContext(clock: ManualClock, tickIndex = 0): LoopTickContext {
+  const controller = new AbortController();
+  return {
+    startedAt: clock.now(),
+    now: () => clock.now(),
+    tickIndex,
+    signal: controller.signal,
+    budget: undefined,
+  };
+}
+
+interface SupervisorBehaviour {
+  cancelFails?: boolean;
+  killFails?: boolean;
+}
+
+/**
+ * Supervisor double exposing child snapshots and configurable failure modes so tests
+ * can exercise the autoscaler correlation paths deterministically.
+ */
+class CorrelatedSupervisor implements AutoscalerSupervisor {
+  public readonly childrenIndex = new ChildrenIndex();
+
+  constructor(private readonly clock: ManualClock, private readonly behaviour: SupervisorBehaviour = {}) {}
+
+  async createChild(options?: CreateChildOptions): Promise<unknown> {
+    const childId =
+      typeof options?.childId === "string" && options.childId.trim().length > 0
+        ? options.childId.trim()
+        : `child-${this.childrenIndex.list().length + 1}`;
+    this.registerChild(childId, options?.metadata ?? {});
+    return { childId };
+  }
+
+  async cancel(childId: string): Promise<unknown> {
+    if (this.behaviour.cancelFails) {
+      throw new Error("cancel_failed");
+    }
+    const removed = this.childrenIndex.removeChild(childId);
+    if (!removed) {
+      throw new Error(`unknown child ${childId}`);
+    }
+    return null;
+  }
+
+  async kill(childId: string): Promise<unknown> {
+    if (this.behaviour.killFails) {
+      throw new Error("kill_failed");
+    }
+    const removed = this.childrenIndex.removeChild(childId);
+    if (!removed) {
+      throw new Error(`unknown child ${childId}`);
+    }
+    return null;
+  }
+
+  registerChild(childId: string, metadata: Record<string, unknown>): void {
+    this.childrenIndex.registerChild({
+      childId,
+      pid: 100 + this.childrenIndex.list().length,
+      workdir: `/tmp/${childId}`,
+      startedAt: this.clock.now(),
+      state: "idle",
+      metadata,
+    });
+  }
+}
+
+/** Validates correlation hints when the autoscaler retires an idle child gracefully. */
+describe("agents autoscaler correlation", () => {
+  it("emits correlation hints when scaling down an idle child", async () => {
+    const clock = new ManualClock();
+    const supervisor = new CorrelatedSupervisor(clock);
+    const childId = "child-alpha";
+    supervisor.registerChild(childId, {
+      job_id: "job-777",
+      run_id: "run-123",
+      op_id: "op-456",
+      graph_id: "graph-graph",
+      node_id: "node-node",
+    });
+
+    const events: AutoscalerEventInput[] = [];
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 0, maxChildren: 1, cooldownMs: 0 },
+      emitEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    await autoscaler.reconcile(buildContext(clock));
+
+    expect(events).to.have.lengthOf(1);
+    const [event] = events;
+    expect(event.payload.msg).to.equal("scale_down");
+    expect(event.childId).to.equal(childId);
+    expect(event.payload.child_id).to.equal(childId);
+
+    const correlation = event.correlation ?? {};
+    expect(correlation.childId).to.equal(childId);
+    expect(correlation.runId).to.equal("run-123");
+    expect(correlation.opId).to.equal("op-456");
+    expect(correlation.jobId).to.equal("job-777");
+    expect(correlation.graphId).to.equal("graph-graph");
+    expect(correlation.nodeId).to.equal("node-node");
+  });
+
+  it("keeps explicit null correlation overrides from child metadata", async () => {
+    const clock = new ManualClock();
+    const supervisor = new CorrelatedSupervisor(clock);
+    const childId = "child-null";
+    supervisor.registerChild(childId, {
+      run_id: null,
+      op_id: null,
+      job_id: null,
+      graph_id: null,
+      node_id: null,
+    });
+
+    const events: AutoscalerEventInput[] = [];
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 0, maxChildren: 1, cooldownMs: 0 },
+      emitEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    await autoscaler.reconcile(buildContext(clock));
+
+    expect(events).to.have.lengthOf(1);
+    const [event] = events;
+    expect(event.payload.msg).to.equal("scale_down");
+    const correlation = event.correlation ?? {};
+    expect(correlation.childId).to.equal(childId);
+    expect(correlation.runId).to.equal(null);
+    expect(correlation.opId).to.equal(null);
+    expect(correlation.jobId).to.equal(null);
+    expect(correlation.graphId).to.equal(null);
+    expect(correlation.nodeId).to.equal(null);
+  });
+
+  it("preserves correlation when cancellation fallback terminates the child", async () => {
+    const clock = new ManualClock();
+    const supervisor = new CorrelatedSupervisor(clock, { cancelFails: true });
+    const childId = "child-beta";
+    supervisor.registerChild(childId, {
+      jobId: "job-camel",
+      runId: "run-camel",
+      opId: "op-camel",
+      graphId: "graph-camel",
+      nodeId: "node-camel",
+    });
+
+    const events: AutoscalerEventInput[] = [];
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 0, maxChildren: 1, cooldownMs: 0 },
+      emitEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    await autoscaler.reconcile(buildContext(clock, 1));
+
+    expect(events.map((event) => event.payload.msg)).to.deep.equal([
+      "scale_down_cancel_failed",
+      "scale_down_forced",
+    ]);
+
+    for (const event of events) {
+      expect(event.childId).to.equal(childId);
+      const correlation = event.correlation ?? {};
+      expect(correlation.childId).to.equal(childId);
+      expect(correlation.runId).to.equal("run-camel");
+      expect(correlation.opId).to.equal("op-camel");
+      expect(correlation.jobId).to.equal("job-camel");
+      expect(correlation.graphId).to.equal("graph-camel");
+      expect(correlation.nodeId).to.equal("node-camel");
+    }
+  });
+
+  it("includes correlation hints when forced termination fails", async () => {
+    const clock = new ManualClock();
+    const supervisor = new CorrelatedSupervisor(clock, { cancelFails: true, killFails: true });
+    const childId = "child-gamma";
+    supervisor.registerChild(childId, {
+      correlation: {
+        runId: "run-nested",
+        jobId: "job-nested",
+        opId: "op-nested",
+        graphId: "graph-nested",
+        nodeId: "node-nested",
+      },
+    });
+
+    const events: AutoscalerEventInput[] = [];
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 0, maxChildren: 1, cooldownMs: 0 },
+      emitEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    await autoscaler.reconcile(buildContext(clock, 2));
+
+    expect(events.map((event) => event.payload.msg)).to.deep.equal([
+      "scale_down_cancel_failed",
+      "scale_down_failed",
+    ]);
+
+    for (const event of events) {
+      expect(event.childId).to.equal(childId);
+      const correlation = event.correlation ?? {};
+      expect(correlation.childId).to.equal(childId);
+      expect(correlation.runId).to.equal("run-nested");
+      expect(correlation.opId).to.equal("op-nested");
+      expect(correlation.jobId).to.equal("job-nested");
+      expect(correlation.graphId).to.equal("graph-nested");
+      expect(correlation.nodeId).to.equal("node-nested");
+    }
+  });
+
+  it("derives correlation hints from spawn templates during scale up", async () => {
+    const clock = new ManualClock();
+    const supervisor = new CorrelatedSupervisor(clock);
+    const events: AutoscalerEventInput[] = [];
+    const autoscaler = new Autoscaler({
+      supervisor,
+      now: () => clock.now(),
+      config: { minChildren: 0, maxChildren: 2, cooldownMs: 0 },
+      spawnTemplate: {
+        childId: "template-child",
+        metadata: {
+          correlation: { run_id: "run-template" },
+          job_id: "job-template",
+        },
+        manifestExtras: {
+          op_id: "op-template",
+          graph_id: "graph-template",
+          node_id: "node-template",
+        },
+      },
+      emitEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    autoscaler.updateBacklog(10);
+    await autoscaler.reconcile(buildContext(clock, 5));
+
+    expect(events).to.have.lengthOf(1);
+    const [event] = events;
+    expect(event.payload.msg).to.equal("scale_up");
+    expect(event.childId).to.equal("template-child");
+    const correlation = event.correlation ?? {};
+    expect(correlation.childId).to.equal("template-child");
+    expect(correlation.runId).to.equal("run-template");
+    expect(correlation.jobId).to.equal("job-template");
+    expect(correlation.opId).to.equal("op-template");
+    expect(correlation.graphId).to.equal("graph-template");
+    expect(correlation.nodeId).to.equal("node-template");
+  });
+});

--- a/tests/agents.supervisor.correlation.test.ts
+++ b/tests/agents.supervisor.correlation.test.ts
@@ -1,0 +1,97 @@
+import { expect } from "chai";
+
+import {
+  type SupervisorIncident,
+  inferSupervisorIncidentCorrelation,
+} from "../src/agents/supervisor.js";
+
+describe("supervisor incident correlation", () => {
+  it("extracts direct identifiers from incident context", () => {
+    const incident: SupervisorIncident = {
+      type: "loop",
+      severity: "critical",
+      reason: "test",
+      context: {
+        run_id: "run-123",
+        op_id: "op-456",
+        job_id: "job-789",
+        graph_id: "graph-321",
+        node_id: "node-654",
+        child_id: "child-987",
+      },
+    };
+
+    const correlation = inferSupervisorIncidentCorrelation(incident);
+
+    expect(correlation).to.deep.equal({
+      runId: "run-123",
+      opId: "op-456",
+      jobId: "job-789",
+      graphId: "graph-321",
+      nodeId: "node-654",
+      childId: "child-987",
+    });
+  });
+
+  it("derives hints from camelCase fields and single child arrays", () => {
+    const incident: SupervisorIncident = {
+      type: "starvation",
+      severity: "warning",
+      reason: "idle",
+      context: {
+        runId: "run-camel",
+        operationId: "op-camel",
+        jobId: "job-camel",
+        graphId: "graph-camel",
+        nodeId: "node-camel",
+        childIds: ["   child-array   "],
+      },
+    };
+
+    const correlation = inferSupervisorIncidentCorrelation(incident);
+
+    expect(correlation).to.deep.equal({
+      runId: "run-camel",
+      opId: "op-camel",
+      jobId: "job-camel",
+      graphId: "graph-camel",
+      nodeId: "node-camel",
+      childId: "child-array",
+    });
+  });
+
+  it("merges embedded correlation blocks without overriding extracted hints", () => {
+    const incident: SupervisorIncident = {
+      type: "stagnation",
+      severity: "warning",
+      reason: "backlog",
+      context: {
+        correlation: { runId: "embedded-run", childId: "embedded-child" },
+        run_id: "external-run",
+        idle_children: ["child-single"],
+      },
+    };
+
+    const correlation = inferSupervisorIncidentCorrelation(incident);
+
+    expect(correlation).to.deep.equal({
+      runId: "external-run",
+      childId: "child-single",
+    });
+  });
+
+  it("ignores ambiguous child lists", () => {
+    const incident: SupervisorIncident = {
+      type: "loop",
+      severity: "warning",
+      reason: "multi",
+      context: {
+        child_ids: ["child-a", "child-b"],
+      },
+    };
+
+    const correlation = inferSupervisorIncidentCorrelation(incident);
+
+    expect(correlation).to.deep.equal({});
+  });
+});

--- a/tests/e2e.contract-net.consensus.test.ts
+++ b/tests/e2e.contract-net.consensus.test.ts
@@ -115,12 +115,23 @@ describe("contract-net to consensus end-to-end flow", function () {
         { agent_id: "childB", cost: 48 },
         { agent_id: "childC", cost: 55 },
       ],
+      run_id: "run-triage",
+      op_id: "op-triage-auction",
+      job_id: "job-triage",
     });
 
     const announcement = handleCnpAnnounce(coordinationContext, announceInput);
     expect(announcement.awarded_agent_id).to.equal("childB");
     expect(announcement.bids).to.have.length(3);
     expect(announcement.tags).to.deep.equal([]);
+    expect(announcement.correlation).to.deep.equal({
+      runId: "run-triage",
+      opId: "op-triage-auction",
+      jobId: "job-triage",
+      graphId: null,
+      nodeId: null,
+      childId: null,
+    });
 
     // Prepare deterministic child outputs where the awarded child responds
     // first with a success while a different child returns an error.

--- a/tests/events.cognitive.test.ts
+++ b/tests/events.cognitive.test.ts
@@ -1,0 +1,116 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { buildChildCognitiveEvents, type QualityAssessmentSnapshot } from "../src/events/cognitive.js";
+import type { ReviewResult } from "../src/agents/metaCritic.js";
+import type { ReflectionResult } from "../src/agents/selfReflect.js";
+
+describe("events cognitive", () => {
+  it("builds correlated review and reflection events", () => {
+    const review: ReviewResult = {
+      overall: 0.82,
+      verdict: "pass",
+      feedback: ["Structure claire", "Couverture suffisante"],
+      suggestions: ["Renforcer la mitigation"],
+      breakdown: [
+        { criterion: "clarity", score: 0.8, reasoning: "Paragraphes concis" },
+        { criterion: "risks", score: 0.7, reasoning: "Risques identifiés" },
+      ],
+      fingerprint: "abcd1234ef567890",
+    };
+
+    const reflection: ReflectionResult = {
+      insights: ["Livrable exploitable"],
+      nextSteps: ["Planifier la mitigation"],
+      risks: ["Écart sur la couverture tests"],
+    };
+
+    const quality: QualityAssessmentSnapshot = {
+      kind: "plan",
+      score: 76,
+      rubric: { coverage: 0.6, coherence: 0.8 },
+      metrics: { coverage: 0.6, coherence: 0.8, risk: 0.35 },
+      gate: { enabled: true, threshold: 0.75, needs_revision: false },
+    };
+
+    const events = buildChildCognitiveEvents({
+      childId: "child-123",
+      jobId: "job-9",
+      summary: { text: "Étude du plan", tags: ["plan", "child-123"], kind: "plan" },
+      review,
+      reflection,
+      quality,
+      artifactCount: 2,
+      messageCount: 5,
+      correlationSources: [
+        { run_id: "run-abc", op_id: "op-xyz" },
+        { graph_id: "graph-12", node_id: "node-34" },
+      ],
+    });
+
+    expect(events.review.kind).to.equal("COGNITIVE");
+    expect(events.review.level).to.equal("info");
+    expect(events.review.childId).to.equal("child-123");
+    expect(events.review.jobId).to.equal("job-9");
+    expect(events.review.correlation).to.deep.equal({
+      childId: "child-123",
+      jobId: "job-9",
+      runId: "run-abc",
+      opId: "op-xyz",
+      graphId: "graph-12",
+      nodeId: "node-34",
+    });
+
+    const reviewPayload = events.review.payload as {
+      msg?: string;
+      summary?: { kind?: string; text?: string; tags?: string[] };
+      review?: ReviewResult;
+      metrics?: { artifacts?: number; messages?: number };
+      quality_assessment?: QualityAssessmentSnapshot | null;
+      run_id?: string | null;
+      op_id?: string | null;
+    };
+    expect(reviewPayload.msg).to.equal("child_meta_review");
+    expect(reviewPayload.summary?.kind).to.equal("plan");
+    expect(reviewPayload.summary?.tags).to.include("child-123");
+    expect(reviewPayload.review?.verdict).to.equal("pass");
+    expect(reviewPayload.metrics).to.deep.equal({ artifacts: 2, messages: 5 });
+    expect(reviewPayload.quality_assessment).to.deep.equal(quality);
+    expect(reviewPayload.run_id).to.equal("run-abc");
+    expect(reviewPayload.op_id).to.equal("op-xyz");
+
+    expect(events.reflection).to.not.equal(null);
+    const reflectionPayload = events.reflection?.payload as {
+      msg?: string;
+      reflection?: { insights?: string[]; next_steps?: string[]; risks?: string[] };
+    };
+    expect(reflectionPayload?.msg).to.equal("child_reflection");
+    expect(reflectionPayload?.reflection?.insights).to.deep.equal(reflection.insights);
+    expect(events.reflection?.correlation).to.deep.equal(events.review.correlation);
+  });
+
+  it("omits the reflection event when no reflection summary is available", () => {
+    const review: ReviewResult = {
+      overall: 0.55,
+      verdict: "warn",
+      feedback: ["Couverture partielle"],
+      suggestions: ["Ajouter des exemples"],
+      breakdown: [{ criterion: "coverage", score: 0.4, reasoning: "Sections manquantes" }],
+      fingerprint: "feedfacecafebeef",
+    };
+
+    const events = buildChildCognitiveEvents({
+      childId: "child-beta",
+      summary: { text: "Sortie textuelle", tags: ["text"], kind: "text" },
+      review,
+      artifactCount: 0,
+      messageCount: 1,
+      correlationSources: [{ child_id: "child-beta", run_id: "run-txt" }],
+    });
+
+    expect(events.review.childId).to.equal("child-beta");
+    expect(events.review.correlation.runId).to.equal("run-txt");
+    expect(events.reflection).to.equal(null);
+  });
+});
+

--- a/tests/events.correlation.test.ts
+++ b/tests/events.correlation.test.ts
@@ -1,0 +1,171 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import {
+  buildChildCorrelationHints,
+  buildJobCorrelationHints,
+  cloneCorrelationHints,
+  extractCorrelationHints,
+  mergeCorrelationHints,
+} from "../src/events/correlation.js";
+
+/**
+ * Dedicated unit coverage for the correlation helpers ensures regressions in
+ * the merge semantics are caught without relying solely on integration tests.
+ */
+describe("event correlation helpers", () => {
+  it("preserves existing identifiers when the source omits fields", () => {
+    const target = { runId: "run-1", opId: "op-1", jobId: "job-1" };
+    mergeCorrelationHints(target, { runId: undefined, jobId: null });
+
+    expect(target).to.deep.equal({ runId: "run-1", opId: "op-1", jobId: null });
+  });
+
+  it("overrides hints when the source provides explicit values", () => {
+    const target = { runId: null, opId: null };
+    mergeCorrelationHints(target, { runId: "run-22", opId: "op-55", graphId: "graph-9" });
+
+    expect(target).to.deep.equal({ runId: "run-22", opId: "op-55", graphId: "graph-9" });
+  });
+
+  it("produces a shallow clone when copying correlation hints", () => {
+    const source = { runId: "run-1", nodeId: "node-7" };
+    const cloned = cloneCorrelationHints(source);
+    expect(cloned).to.deep.equal({ runId: "run-1", nodeId: "node-7" });
+    expect(cloned).to.not.equal(source);
+  });
+
+  it("extracts identifiers from heterogeneous correlation records", () => {
+    const hints = extractCorrelationHints({
+      run_id: "run-snake",
+      correlation: { opId: "op-nested" },
+      jobId: "job-camel",
+      graph_id: "graph-123",
+      nodeId: "node-abc",
+      child_ids: ["child-only"],
+    });
+
+    expect(hints).to.deep.equal({
+      runId: "run-snake",
+      opId: "op-nested",
+      jobId: "job-camel",
+      graphId: "graph-123",
+      nodeId: "node-abc",
+      childId: "child-only",
+    });
+  });
+
+  it("ignores ambiguous child arrays when extracting hints", () => {
+    const hints = extractCorrelationHints({ childIds: ["child-a", "child-b"] });
+    expect(hints).to.deep.equal({});
+  });
+
+  it("preserves explicit null overrides when extracting hints", () => {
+    const hints = extractCorrelationHints({
+      run_id: null,
+      opId: null,
+      correlation: { job_id: null },
+      graph_id: "graph-42",
+      node_id: 99,
+    });
+
+    expect(hints).to.deep.equal({
+      runId: null,
+      opId: null,
+      jobId: null,
+      graphId: "graph-42",
+      nodeId: "99",
+    });
+  });
+
+  it("builds child correlation hints from job metadata and embedded records", () => {
+    const hints = buildChildCorrelationHints({
+      childId: "child-77",
+      jobId: " job-101 ",
+      sources: [
+        { correlation: { run_id: "run-55" } },
+        { opId: "op-89", graph_id: "graph-3" },
+      ],
+    });
+
+    expect(hints).to.deep.equal({
+      childId: "child-77",
+      jobId: "job-101",
+      runId: "run-55",
+      opId: "op-89",
+      graphId: "graph-3",
+    });
+  });
+
+  it("honours explicit null overrides provided by metadata when building child hints", () => {
+    const hints = buildChildCorrelationHints({
+      childId: "child-detached",
+      jobId: "job-native",
+      sources: [{ job_id: null, correlation: { op_id: null, runId: undefined } }],
+    });
+
+    expect(hints).to.deep.equal({
+      childId: "child-detached",
+      jobId: null,
+      opId: null,
+    });
+  });
+
+  it("builds job correlation hints from aggregated child metadata", () => {
+    const hints = buildJobCorrelationHints({
+      jobId: " job-204 ",
+      sources: [
+        { child_ids: ["child-primary"], correlation: { run_id: "run-204" } },
+        { job_id: "job-override", correlation: { opId: "op-88" } },
+        { graph_id: "graph-12", node_id: "node-alpha" },
+      ],
+    });
+
+    expect(hints).to.deep.equal({
+      jobId: "job-204",
+      childId: "child-primary",
+      runId: "run-204",
+      opId: "op-88",
+      graphId: "graph-12",
+      nodeId: "node-alpha",
+    });
+  });
+
+  it("respects explicit null overrides when building job correlation hints", () => {
+    const hints = buildJobCorrelationHints({
+      jobId: "job-explicit",
+      sources: [
+        { correlation: { job_id: null, run_id: null } },
+        { jobId: undefined, op_id: null },
+        { job_id: "job-other", correlation: { run_id: "run-other" } },
+      ],
+    });
+
+    expect(hints).to.deep.equal({
+      jobId: null,
+      runId: null,
+      opId: null,
+    });
+  });
+
+  it("returns trimmed job identifiers when no additional sources are provided", () => {
+    const hints = buildJobCorrelationHints({ jobId: "  job-alone  ", sources: [] });
+
+    expect(hints).to.deep.equal({ jobId: "job-alone" });
+  });
+
+  it("nullifies conflicting job identifiers discovered across sources", () => {
+    const hints = buildJobCorrelationHints({
+      sources: [
+        { correlation: { job_id: "job-one", run_id: "run-one" } },
+        { job_id: "job-two", correlation: { op_id: "op-two" } },
+      ],
+    });
+
+    expect(hints).to.deep.equal({
+      jobId: null,
+      runId: "run-one",
+      opId: "op-two",
+    });
+  });
+});

--- a/tests/events.subscribe.child-correlation.test.ts
+++ b/tests/events.subscribe.child-correlation.test.ts
@@ -1,0 +1,164 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import {
+  server,
+  graphState,
+  childSupervisor,
+  configureRuntimeFeatures,
+  getRuntimeFeatures,
+} from "../src/server.js";
+
+/**
+ * Integration coverage asserting that child lifecycle tools publish correlated events retrievable via
+ * the `events_subscribe` tool. The scenario exercises PROMPT/PENDING/REPLY/REPLY_PART emissions so
+ * downstream MCP clients can rely on consistent child/run/op identifiers while streaming outputs.
+ */
+describe("events subscribe child correlation", () => {
+  it("streams correlated child lifecycle events", async () => {
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "events-subscribe-child-correlation-test", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      configureRuntimeFeatures({ ...baselineFeatures, enableEventsBus: true });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "test-child-events" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const now = Date.now();
+      const jobId = "job_child_events";
+      const childId = "child_child_events";
+      const runId = "run-child";
+      const opId = "op-child";
+      const graphId = "graph-child";
+      const nodeId = "node-child";
+
+      graphState.createJob(jobId, { goal: "Validate child event correlations", createdAt: now, state: "running" });
+      graphState.createChild(jobId, childId, { name: "Responder", runtime: "codex" }, { createdAt: now, ttlAt: null });
+
+      childSupervisor.childrenIndex.registerChild({
+        childId,
+        pid: 4242,
+        workdir: "/tmp/test-child",
+        state: "ready",
+        startedAt: now,
+        metadata: { job_id: jobId, run_id: runId, op_id: opId, graph_id: graphId, node_id: nodeId },
+      });
+
+      const baselineResponse = await client.callTool({ name: "events_subscribe", arguments: { limit: 1 } });
+      expect(baselineResponse.isError ?? false).to.equal(false);
+      const baselineContent = baselineResponse.structuredContent as { next_seq: number | null };
+      const cursor = baselineContent?.next_seq ?? 0;
+
+      const promptResponse = await client.callTool({
+        name: "child_prompt",
+        arguments: {
+          child_id: childId,
+          messages: [
+            {
+              role: "user",
+              content: "Ping",
+            },
+          ],
+        },
+      });
+      expect(promptResponse.isError ?? false).to.equal(false);
+      const promptText = promptResponse.content?.[0]?.text ?? "{}";
+      const promptStructured = JSON.parse(promptText) as { pending_id?: string };
+      const pendingId = promptStructured.pending_id;
+      expect(pendingId, "pending_id should be returned by child_prompt").to.be.a("string");
+
+      const partialResponse = await client.callTool({
+        name: "child_push_partial",
+        arguments: { pending_id: pendingId, delta: "partial", done: false },
+      });
+      expect(partialResponse.isError ?? false).to.equal(false);
+
+      const finalResponse = await client.callTool({
+        name: "child_push_partial",
+        arguments: { pending_id: pendingId, delta: "final", done: true },
+      });
+      expect(finalResponse.isError ?? false).to.equal(false);
+
+      const eventsResponse = await client.callTool({
+        name: "events_subscribe",
+        arguments: {
+          from_seq: cursor,
+          child_id: childId,
+        },
+      });
+      expect(eventsResponse.isError ?? false).to.equal(false);
+
+      const structured = eventsResponse.structuredContent as {
+        events: Array<{
+          kind: string;
+          job_id: string | null;
+          run_id: string | null;
+          op_id: string | null;
+          graph_id: string | null;
+          node_id: string | null;
+          child_id: string | null;
+        }>;
+      };
+
+      const eventsByKind = new Map<string, { job_id: string | null; run_id: string | null; op_id: string | null; graph_id: string | null; node_id: string | null; child_id: string | null }>();
+      for (const event of structured.events) {
+        eventsByKind.set(event.kind, event);
+      }
+
+      const promptEvent = eventsByKind.get("PROMPT");
+      expect(promptEvent, "PROMPT event should be present").to.not.equal(undefined);
+      expect(promptEvent?.job_id).to.equal(jobId);
+      expect(promptEvent?.run_id).to.equal(runId);
+      expect(promptEvent?.op_id).to.equal(opId);
+      expect(promptEvent?.graph_id).to.equal(graphId);
+      expect(promptEvent?.node_id).to.equal(nodeId);
+      expect(promptEvent?.child_id).to.equal(childId);
+
+      const pendingEvent = eventsByKind.get("PENDING");
+      expect(pendingEvent, "PENDING event should be present").to.not.equal(undefined);
+      expect(pendingEvent?.job_id).to.equal(jobId);
+      expect(pendingEvent?.run_id).to.equal(runId);
+      expect(pendingEvent?.op_id).to.equal(opId);
+      expect(pendingEvent?.graph_id).to.equal(graphId);
+      expect(pendingEvent?.node_id).to.equal(nodeId);
+      expect(pendingEvent?.child_id).to.equal(childId);
+
+      const replyEvent = eventsByKind.get("REPLY");
+      expect(replyEvent, "REPLY event should be present").to.not.equal(undefined);
+      expect(replyEvent?.job_id).to.equal(jobId);
+      expect(replyEvent?.run_id).to.equal(runId);
+      expect(replyEvent?.op_id).to.equal(opId);
+      expect(replyEvent?.graph_id).to.equal(graphId);
+      expect(replyEvent?.node_id).to.equal(nodeId);
+      expect(replyEvent?.child_id).to.equal(childId);
+
+      const replyPartEvent = eventsByKind.get("REPLY_PART");
+      expect(replyPartEvent, "REPLY_PART event should be present").to.not.equal(undefined);
+      expect(replyPartEvent?.job_id).to.equal(jobId);
+      expect(replyPartEvent?.run_id).to.equal(runId);
+      expect(replyPartEvent?.op_id).to.equal(opId);
+      expect(replyPartEvent?.graph_id).to.equal(graphId);
+      expect(replyPartEvent?.node_id).to.equal(nodeId);
+      expect(replyPartEvent?.child_id).to.equal(childId);
+
+      expect(structured.events.length).to.be.at.least(4);
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+});

--- a/tests/events.subscribe.job-correlation.test.ts
+++ b/tests/events.subscribe.job-correlation.test.ts
@@ -1,0 +1,134 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import {
+  server,
+  graphState,
+  childSupervisor,
+  emitHeartbeatTick,
+  stopHeartbeat,
+  getRuntimeFeatures,
+  configureRuntimeFeatures,
+} from "../src/server.js";
+import type { MessageRecord } from "../src/types.js";
+
+/**
+ * Integration coverage asserting that job-scoped tools publish correlated events retrievable via
+ * the `events_subscribe` tool. The scenario exercises heartbeat, status and aggregate emissions so
+ * downstream MCP clients can rely on consistent run/op identifiers.
+ */
+describe("events subscribe job correlation", () => {
+  it("streams correlated heartbeat, status and aggregate events", async () => {
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "events-subscribe-job-correlation-test", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      configureRuntimeFeatures({ ...baselineFeatures, enableEventsBus: true });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "test-events" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const now = Date.now();
+      const jobId = "job_test_events";
+      const childId = "child_test_events";
+      const runId = "run-correlated";
+      const opId = "op-correlated";
+      const graphId = "graph-correlated";
+      const nodeId = "node-correlated";
+
+      graphState.createJob(jobId, { goal: "Validate event correlations", createdAt: now, state: "running" });
+      graphState.createChild(jobId, childId, { name: "Observer", runtime: "codex" }, { createdAt: now, ttlAt: null });
+      const message: MessageRecord = {
+        role: "assistant",
+        content: "Result payload",
+        ts: now + 1,
+        actor: "child",
+      };
+      graphState.appendMessage(childId, message);
+
+      childSupervisor.childrenIndex.registerChild({
+        childId,
+        pid: 12345,
+        workdir: "/tmp/test",
+        state: "ready",
+        startedAt: now,
+        metadata: { job_id: jobId, run_id: runId, op_id: opId, graph_id: graphId, node_id: nodeId },
+      });
+
+      const baselineResponse = await client.callTool({ name: "events_subscribe", arguments: { limit: 1 } });
+      expect(baselineResponse.isError ?? false).to.equal(false);
+      const baselineContent = baselineResponse.structuredContent as { next_seq: number | null };
+      const cursor = baselineContent.next_seq ?? 0;
+
+      emitHeartbeatTick();
+
+      const statusResponse = await client.callTool({ name: "status", arguments: { job_id: jobId } });
+      expect(statusResponse.isError ?? false).to.equal(false);
+
+      const aggregateResponse = await client.callTool({
+        name: "aggregate",
+        arguments: { job_id: jobId, strategy: "concat", include_system: false, include_goals: false },
+      });
+      expect(aggregateResponse.isError ?? false).to.equal(false);
+
+      const eventsResponse = await client.callTool({
+        name: "events_subscribe",
+        arguments: { from_seq: cursor, cats: ["status", "aggregate", "heartbeat"] },
+      });
+      expect(eventsResponse.isError ?? false).to.equal(false);
+
+      const structured = eventsResponse.structuredContent as {
+        events: Array<{
+          kind: string;
+          job_id: string | null;
+          run_id: string | null;
+          op_id: string | null;
+          graph_id: string | null;
+          node_id: string | null;
+          msg: string;
+        }>;
+      };
+
+      const byKind = new Map(structured.events.map((evt) => [evt.kind, evt]));
+
+      const heartbeat = byKind.get("HEARTBEAT");
+      expect(heartbeat, "heartbeat event should be recorded").to.not.equal(undefined);
+      expect(heartbeat?.job_id).to.equal(jobId);
+      expect(heartbeat?.run_id).to.equal(runId);
+      expect(heartbeat?.op_id).to.equal(opId);
+      expect(heartbeat?.graph_id).to.equal(graphId);
+      expect(heartbeat?.node_id).to.equal(nodeId);
+
+      const statusEvent = byKind.get("STATUS");
+      expect(statusEvent, "status event should be recorded").to.not.equal(undefined);
+      expect(statusEvent?.job_id).to.equal(jobId);
+      expect(statusEvent?.run_id).to.equal(runId);
+      expect(statusEvent?.op_id).to.equal(opId);
+
+      const aggregateEvent = byKind.get("AGGREGATE");
+      expect(aggregateEvent, "aggregate event should be recorded").to.not.equal(undefined);
+      expect(aggregateEvent?.job_id).to.equal(jobId);
+      expect(aggregateEvent?.run_id).to.equal(runId);
+      expect(aggregateEvent?.op_id).to.equal(opId);
+
+      expect(structured.events.length).to.be.at.least(3);
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      stopHeartbeat();
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+});

--- a/tests/events.subscribe.plan-correlation.test.ts
+++ b/tests/events.subscribe.plan-correlation.test.ts
@@ -1,0 +1,431 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import sinon from "sinon";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import {
+  server,
+  graphState,
+  childSupervisor,
+  configureRuntimeFeatures,
+  getRuntimeFeatures,
+} from "../src/server.js";
+import { childWorkspacePath, resolveWithin } from "../src/paths.js";
+
+/**
+ * Integration scenarios ensuring plan orchestration tools publish correlated events retrievable via
+ * the `events_subscribe` MCP tool. These tests exercise both Behaviour Tree executions and fan-out
+ * orchestration so downstream clients can rely on consistent run/op/job identifiers when tailing
+ * planner activity.
+ */
+describe("events subscribe plan correlation", () => {
+  const mockRunnerPath = fileURLToPath(new URL("./fixtures/mock-runner.js", import.meta.url));
+  const childrenRoot = process.env.MCP_CHILDREN_ROOT
+    ? path.resolve(process.cwd(), process.env.MCP_CHILDREN_ROOT)
+    : path.resolve(process.cwd(), "children");
+
+  it("streams correlated BT and reactive plan events", async function () {
+    this.timeout(10000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "events-subscribe-plan-bt", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      configureRuntimeFeatures({ ...baselineFeatures, enableEventsBus: true });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-events" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const baselineResponse = await client.callTool({ name: "events_subscribe", arguments: { limit: 1 } });
+      expect(baselineResponse.isError ?? false).to.equal(false);
+      const baselineContent = baselineResponse.structuredContent as { next_seq: number | null };
+      const cursor = baselineContent?.next_seq ?? 0;
+
+      const btResponse = await client.callTool({
+        name: "plan_run_bt",
+        arguments: {
+          tree: {
+            id: "coverage-bt",
+            root: { type: "task", id: "root", node_id: "root", tool: "noop", input_key: "payload" },
+          },
+          variables: { payload: { ping: "bt" } },
+          run_id: "plan-bt-run",
+          op_id: "plan-bt-op",
+          job_id: "plan-bt-job",
+          graph_id: "plan-bt-graph",
+          node_id: "plan-bt-node",
+        },
+      });
+      expect(btResponse.isError ?? false).to.equal(false);
+      const btResult = btResponse.structuredContent as {
+        run_id: string;
+        op_id: string;
+        job_id: string | null;
+        graph_id: string | null;
+        node_id: string | null;
+      };
+
+      const reactiveResponse = await client.callTool({
+        name: "plan_run_reactive",
+        arguments: {
+          tree: {
+            id: "coverage-reactive",
+            root: { type: "task", id: "root", node_id: "root", tool: "noop", input_key: "payload" },
+          },
+          variables: { payload: { ping: "reactive" } },
+          tick_ms: 10,
+          timeout_ms: 250,
+          run_id: "plan-reactive-run",
+          op_id: "plan-reactive-op",
+          job_id: "plan-reactive-job",
+          graph_id: "plan-reactive-graph",
+          node_id: "plan-reactive-node",
+        },
+      });
+      expect(reactiveResponse.isError ?? false).to.equal(false);
+      const reactiveResult = reactiveResponse.structuredContent as {
+        run_id: string;
+        op_id: string;
+        job_id: string | null;
+        graph_id: string | null;
+        node_id: string | null;
+      };
+
+      const eventsResponse = await client.callTool({
+        name: "events_subscribe",
+        arguments: {
+          from_seq: cursor,
+          cats: ["bt_run"],
+        },
+      });
+      expect(eventsResponse.isError ?? false).to.equal(false);
+
+      const structured = eventsResponse.structuredContent as {
+        events: Array<{
+          kind: string;
+          run_id: string | null;
+          op_id: string | null;
+          job_id: string | null;
+          graph_id: string | null;
+          node_id: string | null;
+          child_id: string | null;
+          data?: { [key: string]: unknown };
+        }>;
+      };
+
+      const btEvents = structured.events.filter((event) => event.kind === "BT_RUN");
+      expect(btEvents.length).to.be.at.least(2);
+
+      const btStart = btEvents.find((event) => {
+        const payload = (event.data ?? {}) as { phase?: string; mode?: string };
+        return payload.phase === "start" && payload.mode === "bt";
+      });
+      expect(btStart, "Behaviour Tree start event should be present").to.not.equal(undefined);
+      expect(btStart?.run_id).to.equal(btResult.run_id);
+      expect(btStart?.op_id).to.equal(btResult.op_id);
+      expect(btStart?.job_id).to.equal(btResult.job_id);
+      expect(btStart?.graph_id).to.equal(btResult.graph_id);
+      expect(btStart?.node_id).to.equal(btResult.node_id);
+
+      const reactiveStart = btEvents.find((event) => {
+        const payload = (event.data ?? {}) as { phase?: string; mode?: string };
+        return payload.phase === "start" && payload.mode === "reactive";
+      });
+      expect(reactiveStart, "Reactive loop start event should be present").to.not.equal(undefined);
+      expect(reactiveStart?.run_id).to.equal(reactiveResult.run_id);
+      expect(reactiveStart?.op_id).to.equal(reactiveResult.op_id);
+      expect(reactiveStart?.job_id).to.equal(reactiveResult.job_id);
+      expect(reactiveStart?.graph_id).to.equal(reactiveResult.graph_id);
+      expect(reactiveStart?.node_id).to.equal(reactiveResult.node_id);
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      await childSupervisor.disposeAll().catch(() => {});
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+
+  it("streams correlated events when reactive plans are paused and resumed", async function () {
+    this.timeout(15000);
+
+    const clock = sinon.useFakeTimers();
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "events-subscribe-plan-resume", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    let runPromise: ReturnType<Client["callTool"]> | null = null;
+
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableEventsBus: true,
+        enablePlanLifecycle: true,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-resume" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const baselineResponse = await client.callTool({ name: "events_subscribe", arguments: { limit: 1 } });
+      expect(baselineResponse.isError ?? false).to.equal(false);
+      const baselineContent = baselineResponse.structuredContent as { next_seq: number | null };
+      const cursor = baselineContent?.next_seq ?? 0;
+
+      const planArguments = {
+        tree: {
+          id: "plan-resume-tree",
+          root: {
+            type: "sequence",
+            id: "plan-resume-seq",
+            children: [
+              { type: "task", id: "fetch", node_id: "fetch", tool: "noop", input_key: "fetch" },
+              { type: "task", id: "deploy", node_id: "deploy", tool: "noop", input_key: "deploy" },
+              { type: "task", id: "verify", node_id: "verify", tool: "noop", input_key: "verify" },
+            ],
+          },
+        },
+        variables: {
+          fetch: { ref: "artifact" },
+          deploy: { environment: "prod" },
+          verify: { suite: "regression" },
+        },
+        tick_ms: 25,
+        timeout_ms: 1000,
+        run_id: "plan-resume-run",
+        op_id: "plan-resume-op",
+        job_id: "plan-resume-job",
+        graph_id: "plan-resume-graph",
+        node_id: "plan-resume-node",
+      } as const;
+
+      runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      // Allow the lifecycle registry to capture the start event before pausing the execution loop.
+      await clock.tickAsync(0);
+
+      const statusBefore = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(statusBefore.isError ?? false).to.equal(false);
+      const beforeSnapshot = statusBefore.structuredContent as { state: string; last_event: { phase: string } | null };
+      expect(beforeSnapshot.state).to.equal("running");
+      expect(beforeSnapshot.last_event?.phase).to.equal("start");
+
+      const pauseResponse = await client.callTool({ name: "plan_pause", arguments: { run_id: planArguments.run_id } });
+      expect(pauseResponse.isError ?? false).to.equal(false);
+      const pausedSnapshot = pauseResponse.structuredContent as { state: string; last_event: { phase: string } | null };
+      expect(pausedSnapshot.state).to.equal("paused");
+      expect(pausedSnapshot.last_event?.phase).to.equal("pause");
+
+      await clock.tickAsync(100);
+      const pausedStatus = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(pausedStatus.isError ?? false).to.equal(false);
+      const pausedStatusSnapshot = pausedStatus.structuredContent as { state: string; progress: number };
+      expect(pausedStatusSnapshot.state).to.equal("paused");
+
+      const resumeResponse = await client.callTool({ name: "plan_resume", arguments: { run_id: planArguments.run_id } });
+      expect(resumeResponse.isError ?? false).to.equal(false);
+      const resumedSnapshot = resumeResponse.structuredContent as { state: string; last_event: { phase: string } | null };
+      expect(resumedSnapshot.state).to.equal("running");
+      expect(resumedSnapshot.last_event?.phase).to.equal("resume");
+
+      await clock.tickAsync(100);
+
+      const runResponse = await runPromise;
+      expect(runResponse.isError ?? false).to.equal(false);
+      const runContent = runResponse.structuredContent as {
+        status: string;
+        invocations: Array<{ tool: string; input: unknown }>;
+      };
+      expect(runContent.status).to.equal("success");
+      expect(runContent.invocations).to.have.length(3);
+
+      const eventsResponse = await client.callTool({
+        name: "events_subscribe",
+        arguments: {
+          from_seq: cursor,
+          cats: ["bt_run"],
+          run_id: planArguments.run_id,
+        },
+      });
+      expect(eventsResponse.isError ?? false).to.equal(false);
+
+      const structured = eventsResponse.structuredContent as {
+        events: Array<{
+          seq: number;
+          kind: string;
+          data: { phase?: string; node_id?: string | null } | null;
+          run_id: string | null;
+        }>;
+      };
+
+      const runEvents = structured.events.filter((event) => event.run_id === planArguments.run_id);
+      expect(runEvents.some((event) => event.data?.phase === "start")).to.equal(true);
+      expect(runEvents.some((event) => event.data?.phase === "complete")).to.equal(true);
+
+      const nodeEvents = runEvents.filter((event) => event.data?.phase === "node");
+      const executedNodes = nodeEvents.map((event) => event.data?.node_id).filter((value): value is string => Boolean(value));
+      const executedNodeSet = new Set(executedNodes);
+      expect(executedNodeSet.has("fetch"), "fetch node should have executed").to.equal(true);
+      expect(executedNodeSet.has("deploy"), "deploy node should have executed").to.equal(true);
+      expect(executedNodeSet.has("verify"), "verify node should have executed").to.equal(true);
+    } finally {
+      if (runPromise) {
+        await runPromise.catch(() => {});
+      }
+      configureRuntimeFeatures(baselineFeatures);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      await childSupervisor.disposeAll().catch(() => {});
+      await client.close();
+      await server.close().catch(() => {});
+      clock.restore();
+    }
+  });
+
+  it("streams correlated plan fan-out events", async function () {
+    this.timeout(20000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "events-subscribe-plan-fanout", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const plannedChildren: string[] = [];
+
+    try {
+      configureRuntimeFeatures({ ...baselineFeatures, enableEventsBus: true });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-fanout" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const baselineResponse = await client.callTool({ name: "events_subscribe", arguments: { limit: 1 } });
+      expect(baselineResponse.isError ?? false).to.equal(false);
+      const baselineContent = baselineResponse.structuredContent as { next_seq: number | null };
+      const cursor = baselineContent?.next_seq ?? 0;
+
+      const hints = {
+        run_id: "plan-fanout-run",
+        op_id: "plan-fanout-op",
+        job_id: "plan-fanout-job",
+        graph_id: "plan-fanout-graph",
+        node_id: "plan-fanout-node",
+        child_id: "plan-fanout-parent",
+      } as const;
+
+      const fanoutResponse = await client.callTool({
+        name: "plan_fanout",
+        arguments: {
+          goal: "Collect plan coverage",
+          prompt_template: {
+            system: "Tu es {{child_name}} et tu aides au scenario planifié.",
+            user: "Objectif: {{goal}}",
+          },
+          children_spec: {
+            list: [
+              {
+                name: "scout",
+                command: process.execPath,
+                args: [mockRunnerPath, "--role", "scout"],
+                metadata: { origin: "plan-coverage" },
+              },
+            ],
+          },
+          parallelism: 1,
+          retry: { max_attempts: 1, delay_ms: 0 },
+          ...hints,
+        },
+      });
+      expect(fanoutResponse.isError ?? false).to.equal(false);
+      const fanoutResult = fanoutResponse.structuredContent as {
+        run_id: string;
+        op_id: string;
+        job_id: string;
+        graph_id: string | null;
+        node_id: string | null;
+        child_id: string | null;
+        child_ids: string[];
+      };
+      plannedChildren.push(...fanoutResult.child_ids);
+
+      const eventsResponse = await client.callTool({
+        name: "events_subscribe",
+        arguments: {
+          from_seq: cursor,
+          cats: ["plan"],
+        },
+      });
+      expect(eventsResponse.isError ?? false).to.equal(false);
+
+      const structured = eventsResponse.structuredContent as {
+        events: Array<{
+          kind: string;
+          run_id: string | null;
+          op_id: string | null;
+          job_id: string | null;
+          graph_id: string | null;
+          node_id: string | null;
+          child_id: string | null;
+          data?: { [key: string]: unknown };
+        }>;
+      };
+
+      const planEvent = structured.events.find((event) => event.kind === "PLAN");
+      expect(planEvent, "PLAN fan-out event should be present").to.not.equal(undefined);
+      expect(planEvent?.run_id).to.equal(hints.run_id);
+      expect(planEvent?.op_id).to.equal(hints.op_id);
+      expect(planEvent?.job_id).to.equal(hints.job_id);
+      expect(planEvent?.graph_id).to.equal(hints.graph_id);
+      expect(planEvent?.node_id).to.equal(hints.node_id);
+      expect(planEvent?.child_id).to.equal(hints.child_id);
+
+      const payload = (planEvent?.data ?? {}) as {
+        children?: Array<{ name?: string; runtime?: string }>;
+        rejected?: unknown[];
+      };
+      expect(payload.children, "fan-out event should list planned children").to.be.an("array");
+      expect(payload.children?.length).to.equal(1);
+      expect(payload.children?.[0]?.name).to.equal("scout");
+      expect(Array.isArray(payload.rejected)).to.equal(true);
+    } finally {
+      for (const childId of plannedChildren) {
+        await client.callTool({ name: "child_kill", arguments: { child_id: childId, timeout_ms: 500 } }).catch(() => {});
+        await client.callTool({ name: "child_gc", arguments: { child_id: childId } }).catch(() => {});
+        await rm(childWorkspacePath(childrenRoot, childId), { recursive: true, force: true }).catch(() => {});
+      }
+      await rm(resolveWithin(childrenRoot, "plan-fanout-run"), { recursive: true, force: true }).catch(() => {});
+
+      configureRuntimeFeatures(baselineFeatures);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      await childSupervisor.disposeAll().catch(() => {});
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+});

--- a/tests/logs.tail.filters.test.ts
+++ b/tests/logs.tail.filters.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { server, logJournal } from "../src/server.js";
+
+/**
+ * Integration coverage for the `logs_tail` MCP tool. The scenarios prime the journal with
+ * deterministic entries and assert that the server enforces stream-specific invariants while
+ * honouring pagination cursors.
+ */
+describe("logs tail tool", () => {
+  beforeEach(() => {
+    logJournal.reset();
+  });
+
+  it("returns orchestrator logs by default", async function () {
+    this.timeout(5000);
+
+    logJournal.record({
+      stream: "server",
+      bucketId: "orchestrator",
+      seq: 1,
+      ts: Date.now() - 50,
+      level: "info",
+      message: "runtime_started",
+      data: { scope: "test" },
+    });
+    logJournal.record({
+      stream: "server",
+      bucketId: "orchestrator",
+      seq: 2,
+      ts: Date.now(),
+      level: "warn",
+      message: "heartbeat_delayed",
+      data: { delay_ms: 42 },
+      runId: "run-server-1",
+      opId: "op-server-1",
+    });
+    await logJournal.flush();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "logs-tail-server", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const response = await client.callTool({ name: "logs_tail", arguments: {} });
+      expect(response.isError ?? false).to.equal(false);
+
+      const structured = response.structuredContent as {
+        stream: string;
+        entries: Array<{ seq: number; message: string; run_id: string | null }>;
+      };
+
+      expect(structured.stream).to.equal("server");
+      expect(structured.entries.length).to.equal(2);
+      expect(structured.entries[0].seq).to.equal(1);
+      expect(structured.entries[1].run_id).to.equal("run-server-1");
+      expect(structured.entries[1].message).to.equal("heartbeat_delayed");
+    } finally {
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+
+  it("applies from_seq filters on run streams", async function () {
+    this.timeout(5000);
+
+    logJournal.record({
+      stream: "run",
+      bucketId: "run-filter",
+      seq: 10,
+      ts: Date.now() - 25,
+      level: "info",
+      message: "run_start",
+      runId: "run-filter",
+      opId: "op-filter-1",
+    });
+    logJournal.record({
+      stream: "run",
+      bucketId: "run-filter",
+      seq: 11,
+      ts: Date.now(),
+      level: "info",
+      message: "run_progress",
+      runId: "run-filter",
+      opId: "op-filter-1",
+    });
+    await logJournal.flush();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "logs-tail-run", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const response = await client.callTool({
+        name: "logs_tail",
+        arguments: { stream: "run", id: "run-filter", from_seq: 10, limit: 5 },
+      });
+      expect(response.isError ?? false).to.equal(false);
+
+      const structured = response.structuredContent as {
+        entries: Array<{ seq: number; message: string }>;
+        next_seq: number;
+      };
+
+      expect(structured.entries.length).to.equal(1);
+      expect(structured.entries[0].seq).to.equal(11);
+      expect(structured.entries[0].message).to.equal("run_progress");
+      expect(structured.next_seq).to.equal(11);
+    } finally {
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+
+  it("rejects run streams without an identifier", async function () {
+    this.timeout(5000);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "logs-tail-errors", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const response = await client.callTool({ name: "logs_tail", arguments: { stream: "run" } });
+      expect(response.isError ?? true).to.equal(true);
+      expect(response.content?.[0]?.type).to.equal("text");
+    } finally {
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+});

--- a/tests/plan.lifecycle.test.ts
+++ b/tests/plan.lifecycle.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import {
+  server,
+  graphState,
+  childSupervisor,
+  configureRuntimeFeatures,
+  getRuntimeFeatures,
+} from "../src/server.js";
+import {
+  PlanLifecycleRegistry,
+  PlanLifecycleCompletedError,
+  PlanLifecycleUnsupportedError,
+} from "../src/executor/planLifecycle.js";
+
+/** Unit coverage for the lifecycle registry to guard manual pause/resume semantics. */
+describe("PlanLifecycleRegistry", () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("rejects resuming runs that already completed", async () => {
+    const registry = new PlanLifecycleRegistry({ clock: () => clock.now });
+    registry.registerRun({ runId: "run", opId: "op", mode: "reactive" });
+    registry.attachControls("run", { pause: async () => true, resume: async () => true });
+    registry.recordEvent("run", { phase: "complete", payload: {}, timestamp: clock.now });
+
+    try {
+      await registry.resume("run");
+      expect.fail("resume should fail once the run completed");
+    } catch (error) {
+      expect(error).to.be.instanceOf(PlanLifecycleCompletedError);
+    }
+  });
+
+  it("errors when pausing runs that do not expose controls", async () => {
+    const registry = new PlanLifecycleRegistry({ clock: () => clock.now });
+    registry.registerRun({ runId: "run", opId: "op", mode: "bt" });
+
+    try {
+      await registry.pause("run");
+      expect.fail("pause should require registered controls");
+    } catch (error) {
+      expect(error).to.be.instanceOf(PlanLifecycleUnsupportedError);
+    }
+  });
+});
+
+/**
+ * Integration scenarios asserting that plan lifecycle tools can pause, resume and inspect
+ * reactive Behaviour Tree executions without losing progress information.
+ */
+describe("plan lifecycle", () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("pauses and resumes reactive plan runs", async function () {
+    this.timeout(10000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "plan-lifecycle-client", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enablePlanLifecycle: true,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-lifecycle" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const planArguments = {
+        tree: {
+          id: "plan-lifecycle-tree",
+          root: { type: "task", id: "noop", node_id: "noop", tool: "noop", input_key: "payload" },
+        },
+        variables: { payload: { scenario: "plan-lifecycle" } },
+        tick_ms: 50,
+        timeout_ms: 1000,
+        run_id: "plan-lifecycle-run",
+        op_id: "plan-lifecycle-op",
+      } as const;
+
+      const runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      // Allow the server to register the lifecycle run without advancing ticks.
+      await clock.tickAsync(0);
+
+      const statusBefore = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(statusBefore.isError ?? false).to.equal(false);
+      const beforeSnapshot = statusBefore.structuredContent as {
+        run_id: string;
+        state: string;
+        progress: number;
+      };
+      expect(beforeSnapshot.state).to.equal("running");
+      expect(beforeSnapshot.progress).to.equal(0);
+
+      const pauseResponse = await client.callTool({ name: "plan_pause", arguments: { run_id: planArguments.run_id } });
+      expect(pauseResponse.isError ?? false).to.equal(false);
+      const pausedSnapshot = pauseResponse.structuredContent as {
+        state: string;
+        supports_resume: boolean;
+        progress: number;
+      };
+      expect(pausedSnapshot.state).to.equal("paused");
+      expect(pausedSnapshot.supports_resume).to.equal(true);
+
+      // Ensure no progress occurs while the run is paused.
+      await clock.tickAsync(100);
+      const pausedStatus = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(pausedStatus.isError ?? false).to.equal(false);
+      const pausedStatusSnapshot = pausedStatus.structuredContent as { state: string; progress: number };
+      expect(pausedStatusSnapshot.state).to.equal("paused");
+      expect(pausedStatusSnapshot.progress).to.equal(pausedSnapshot.progress);
+
+      const resumeResponse = await client.callTool({ name: "plan_resume", arguments: { run_id: planArguments.run_id } });
+      expect(resumeResponse.isError ?? false).to.equal(false);
+      const resumedSnapshot = resumeResponse.structuredContent as { state: string };
+      expect(resumedSnapshot.state).to.equal("running");
+
+      await clock.tickAsync(50);
+      const runResponse = await runPromise;
+      expect(runResponse.isError ?? false).to.equal(false);
+      const runContent = runResponse.structuredContent as { status: string };
+      expect(runContent.status).to.equal("success");
+
+      const finalStatus = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(finalStatus.isError ?? false).to.equal(false);
+      const finalSnapshot = finalStatus.structuredContent as { state: string; progress: number };
+      expect(finalSnapshot.state).to.equal("done");
+      expect(finalSnapshot.progress).to.equal(100);
+
+      const resumeAfterDone = await client.callTool({
+        name: "plan_resume",
+        arguments: { run_id: planArguments.run_id },
+      });
+      expect(resumeAfterDone.isError ?? false).to.equal(true);
+      const resumePayload = JSON.parse(resumeAfterDone.content?.[0]?.text ?? "{}");
+      expect(resumePayload.error).to.equal("E-PLAN-COMPLETED");
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
+    }
+  });
+
+  it("supports pausing and resuming reactive plans with multiple nodes", async function () {
+    this.timeout(10000);
+
+    // Capture the current orchestrator state so the scenario can restore it after execution.
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "plan-lifecycle-multi-node", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    // Track the asynchronous run promise so the cleanup step can await it when errors occur.
+    let runPromise: ReturnType<Client["callTool"]> | null = null;
+
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enablePlanLifecycle: true,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-lifecycle" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const planArguments = {
+        tree: {
+          id: "plan-lifecycle-multi",
+          root: {
+            type: "sequence",
+            id: "seq-root",
+            children: [
+              { type: "task", id: "fetch", node_id: "fetch", tool: "noop", input_key: "fetch" },
+              { type: "task", id: "deploy", node_id: "deploy", tool: "noop", input_key: "deploy" },
+              { type: "task", id: "verify", node_id: "verify", tool: "noop", input_key: "verify" },
+            ],
+          },
+        },
+        variables: {
+          fetch: { ref: "artifact" },
+          deploy: { environment: "staging" },
+          verify: { suite: "smoke" },
+        },
+        tick_ms: 25,
+        timeout_ms: 1000,
+        run_id: "plan-lifecycle-multi-run",
+        op_id: "plan-lifecycle-multi-op",
+      } as const;
+
+      runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      // Allow the registry to record the run before issuing lifecycle operations.
+      await clock.tickAsync(0);
+
+      const statusBefore = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(statusBefore.isError ?? false).to.equal(false);
+      const beforeSnapshot = statusBefore.structuredContent as {
+        run_id: string;
+        state: string;
+        progress: number;
+        last_event: { phase: string } | null;
+      };
+      expect(beforeSnapshot.state).to.equal("running");
+      expect(beforeSnapshot.last_event?.phase).to.equal("start");
+
+      const pauseResponse = await client.callTool({ name: "plan_pause", arguments: { run_id: planArguments.run_id } });
+      expect(pauseResponse.isError ?? false).to.equal(false);
+      const pausedSnapshot = pauseResponse.structuredContent as {
+        state: string;
+        supports_resume: boolean;
+        progress: number;
+        last_event: { phase: string } | null;
+      };
+      expect(pausedSnapshot.state).to.equal("paused");
+      expect(pausedSnapshot.supports_resume).to.equal(true);
+      expect(pausedSnapshot.last_event?.phase).to.equal("pause");
+      expect(pausedSnapshot.progress).to.equal(0);
+
+      // Advance fake time while paused to ensure no progress occurs before resuming.
+      await clock.tickAsync(100);
+      const pausedStatus = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(pausedStatus.isError ?? false).to.equal(false);
+      const pausedStatusSnapshot = pausedStatus.structuredContent as { state: string; progress: number };
+      expect(pausedStatusSnapshot.state).to.equal("paused");
+      expect(pausedStatusSnapshot.progress).to.equal(pausedSnapshot.progress);
+
+      const resumeResponse = await client.callTool({ name: "plan_resume", arguments: { run_id: planArguments.run_id } });
+      expect(resumeResponse.isError ?? false).to.equal(false);
+      const resumedSnapshot = resumeResponse.structuredContent as { state: string; last_event: { phase: string } | null };
+      expect(resumedSnapshot.state).to.equal("running");
+      expect(resumedSnapshot.last_event?.phase).to.equal("resume");
+
+      // Let the execution loop process the queued Behaviour Tree ticks.
+      await clock.tickAsync(50);
+
+      const runResponse = await runPromise;
+      expect(runResponse.isError ?? false).to.equal(false);
+      const runContent = runResponse.structuredContent as {
+        status: string;
+        invocations: Array<{ tool: string }>;
+      };
+      expect(runContent.status).to.equal("success");
+      expect(runContent.invocations.map((entry) => entry.tool)).to.deep.equal([
+        "noop",
+        "noop",
+        "noop",
+      ]);
+
+      const finalStatus = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(finalStatus.isError ?? false).to.equal(false);
+      const finalSnapshot = finalStatus.structuredContent as { state: string; progress: number };
+      expect(finalSnapshot.state).to.equal("done");
+      expect(finalSnapshot.progress).to.equal(100);
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
+      if (runPromise) {
+        await runPromise.catch(() => {});
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a multi-node reactive plan pause/resume scenario to plan lifecycle integration tests so resumptions execute every task
- extend the events subscribe integration suite with a paused/resumed reactive plan case and guard its node event assertions
- record iteration 132 in AGENTS.md with the new coverage and follow-up work

## Testing
- npm run lint
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0606fb0dc832f9c413ec6b38752db