### PR TITLE
Add SSE streaming support to resources_watch tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,11 +167,11 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 
 ### 2.4 Idempotency keys
 
-* [ ] **Créer** `src/infra/idempotency.ts` (store TTL)
-* [ ] **Modifier** tools : `child_create`, `plan_run_bt`, `cnp_announce`, `graph_batch_mutate`, `tx_begin`
+* [x] **Créer** `src/infra/idempotency.ts` (store TTL)
+* [x] **Modifier** tools : `child_create`, `plan_run_bt`, `cnp_announce`, `graph_batch_mutate`, `tx_begin`
 
-  * [ ] Accepter `idempotencyKey?` → rejouer résultat si déjà vu
-* [ ] **Tests** : `tests/idempotency.replay.test.ts` (simuler retry réseau)
+  * [x] Accepter `idempotencyKey?` → rejouer résultat si déjà vu
+* [x] **Tests** : `tests/idempotency.replay.test.ts` (simuler retry réseau)
 
 ### 2.5 Opérations bulk atomiques
 
@@ -220,33 +220,33 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 * [ ] **Modifier** `src/executor/bt/nodes.ts`
 
   * [ ] Décorateurs : `Retry(n, backoffJitter)`, `Timeout(ms)`, `Guard(cond)`, `Cancellable`
-  * [ ] Parallel policy : `all|any|quota(k)`
-* [ ] **Modifier** `src/executor/bt/interpreter.ts`
+  * [x] Parallel policy : `all|any|quota(k)`
+* [x] **Modifier** `src/executor/bt/interpreter.ts`
 
-  * [ ] Persistance d’état par nœud (resume après pause/cancel) ; progress %
+  * [x] Persistance d’état par nœud (resume après pause/cancel) ; progress %
 * [ ] **Tests** :
 
   * [ ] `tests/bt.decorators.retry-timeout-cancel.test.ts` (fake timers)
-  * [ ] `tests/bt.parallel.quota.test.ts`
+  * [x] `tests/bt.parallel.quota.test.ts`
 
 ### 4.2 Scheduler réactif (fairness & budgets)
 
-* [ ] **Modifier** `src/executor/reactiveScheduler.ts`
+* [x] **Modifier** `src/executor/reactiveScheduler.ts`
 
-  * [ ] Priorité = f(âge, criticité, stigmergie) avec **aging** (anti-starvation)
-  * [ ] Budgets CPU coopératifs (yield après quantum)
-* [ ] **Tests** :
+  * [x] Priorité = f(âge, criticité, stigmergie) avec **aging** (anti-starvation)
+  * [x] Budgets CPU coopératifs (yield après quantum)
+* [x] **Tests** :
 
-  * [ ] `tests/executor.scheduler.prio-aging.test.ts`
-  * [ ] `tests/executor.scheduler.budgets.test.ts`
+  * [x] `tests/executor.scheduler.prio-aging.test.ts`
+  * [x] `tests/executor.scheduler.budgets.test.ts`
 
 ### 4.3 Stigmergie paramétrable
 
-* [ ] **Modifier** `src/coord/stigmergy.ts`
+* [x] **Modifier** `src/coord/stigmergy.ts`
 
-  * [ ] Demi-vie configurable `halfLifeMs`, borne min/max intensité
-  * [ ] Snapshot heatmap (pour dashboard)
-* [ ] **Tests** : `tests/coord.stigmergy.field.test.ts` (évaporation contrôlée)
+  * [x] Demi-vie configurable `halfLifeMs`, borne min/max intensité
+  * [x] Snapshot heatmap (pour dashboard)
+* [x] **Tests** : `tests/coord.stigmergy.field.test.ts` (évaporation contrôlée)
 
 ### 4.4 Autoscaler & Superviseur
 
@@ -348,9 +348,9 @@ Contexte : TypeScript/Node ESM, local-first, une instance Codex par enfant, pas 
 * [ ] **Créer** `tests/concurrency.graph-mutations.test.ts`
 
   * [ ] Threads simulés : diffs concurrents → locks ; aucun deadlock
-* [ ] **Créer** `tests/concurrency.events-backpressure.test.ts`
+* [x] **Créer** `tests/concurrency.events-backpressure.test.ts`
 
-  * [ ] `events_subscribe/resources_watch` : limites, keep-alive, perte zéro
+  * [x] `events_subscribe/resources_watch` : limites, keep-alive, perte zéro
 
 ### 7.2 Cancellation & ressources
 
@@ -767,3 +767,292 @@ Si tu veux, je peux te générer à la demande les **squelettes TypeScript** exa
 - ✅ Ajouté un scénario multi-nœuds dans `tests/plan.lifecycle.test.ts` pour couvrir `plan_pause`/`plan_resume` avec un arbre en séquence et vérifier l'exécution complète après reprise.
 - ✅ Étendu `tests/events.subscribe.plan-correlation.test.ts` afin de valider le streaming des événements `BT_RUN` (start/node/complete) après une pause puis reprise d'un plan réactif corrélé.
 - 🔜 Prolonger la couverture `events_subscribe` aux flux `PLAN`/`BT_RUN` lors de reprises multiples (pause/résume répétés) et auditer les snapshots `plan_status` pour les plans annulés afin de préparer les scénarios E2E restants.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 133)
+- ✅ Ajouté la politique `quota` au nœud parallèle en normalisant la configuration côté runtime et en sécurisant les cas limites (`ParallelNode`, `BehaviorNodeDefinition`).
+- ✅ Introduit le test ciblé `tests/bt.parallel.quota.test.ts` pour couvrir les succès/échecs de seuil et exécuté `npm run lint`, `npm test` pour garantir la stabilité.
+- 🔜 Compléter les décorateurs restants (edge cases d'annulation `throwIfCancelled` non standard, quotas mixtes, garde/timeout additionnels) avant de cocher la case globale "Modifier src/executor/bt/nodes.ts" et finaliser la couverture associée.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 134)
+- ✅ Exporté `BehaviorTreeCancellationError`, documenté la remontée d'annulation dans le README et réaligné la distribution `dist/` via `npm run build`.
+- ✅ Rejoué `npm run lint`, `npm run build`, `npm run test:unit -- --exit` (verts) en nettoyant `children/`, `runs/` et `node_modules` pour garder l'arbre propre.
+- 🔜 Ajouter des tests décorateurs couvrant les exceptions arbitraires renvoyées par `throwIfCancelled` et finaliser l'audit des scénarios de cancellation avant de clôturer la checklist "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 135)
+- ✅ Normalisé `throwCancellation` pour encapsuler toute erreur arbitraire levée par `throwIfCancelled` dans un `BehaviorTreeCancellationError` tout en préservant la cause pour les orchestrateurs externes (`src/dist/executor/bt/nodes`).
+- ✅ Ajouté deux scénarios ciblés dans `tests/bt.decorators.retry-timeout-cancel.test.ts` pour vérifier l'encapsulation des erreurs `throwIfCancelled` et la réinitialisation systématique des enfants lorsque l'annulation survient avant ou après un tick.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test` (418 tests verts) après régénération des artefacts afin de garantir l'absence de régressions.
+- 🔜 Étendre la couverture cancellation aux décorateurs `guard`/`timeout` lorsque `throwIfCancelled` remonte des causes typées personnalisées et auditer les combinaisons quotas/annulation restantes avant de clôturer l'item "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 136)
+- ✅ Durci `GuardNode` et `TimeoutNode` pour réinitialiser les enfants lors des annulations coopératives et propager fidèlement les `OperationCancelledError` ou causes personnalisées, en couvrant `throwIfCancelled` avant/après ticks.
+- ✅ Enrichi `tests/bt.decorators.retry-timeout-cancel.test.ts` avec des scénarios `guard`/`timeout` (causes arbitraires, erreurs typées) et vérifié le wrapping `BehaviorTreeCancellationError` ainsi que la préservation des reset.
+- ✅ Rejoué `npm run lint`, `npm run build`, `npm test` (422 tests verts) pour confirmer l'absence de régressions après régénération des artefacts.
+- 🔜 Auditer les combinaisons quota/annulation restantes et couvrir les décorateurs `guard`/`timeout` face aux causes typées côté runtime (ex. signaux scheduler) avant de clôturer "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 137)
+- ✅ Durci `RetryNode` pour qu'il restaure proprement ses compteurs et enfants lorsqu'une annulation survient avant, pendant ou après l'attente de backoff (`src/executor/bt/nodes.ts`, `dist/executor/bt/nodes.js`).
+- ✅ Ajouté trois scénarios ciblés dans `tests/bt.decorators.retry-timeout-cancel.test.ts` couvrant les annulations pré-tick, intra-tick et pendant le backoff, avec vérification des resets et de la propagation des erreurs typées.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test`, puis `npm run test:unit -- --exit` (425 tests verts) en restaurant `node_modules/` après nettoyage pour éviter les divergences.
+- 🔜 Poursuivre l'audit des autres décorateurs/composites (séquence, sélecteur, tâches leaf) pour confirmer la remise à zéro côté annulation et préparer des tests d'intégration quotas × cancellation avant de valider "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 138)
+- ✅ Durci `SequenceNode` et `SelectorNode` pour qu'ils réinitialisent systématiquement leur curseur et leurs enfants lorsqu'une annulation est détectée avant l'invocation du prochain enfant ou lorsqu'un enfant propage `OperationCancelledError`/`BehaviorTreeCancellationError`.
+- ✅ Ajouté la suite dédiée `tests/bt.composites.cancel.test.ts` couvrant les annulations pré-tick et intra-tick sur les composites séquence/sélecteur, avec vérification des resets et de la reprise réussie après levée de l'annulation.
+- ✅ Rejoué `npm run lint`, `npm run build`, `npm test` pour garantir l'absence de régression après régénération des artefacts.
+- ✅ Audité les feuilles (`TaskLeaf` et outils associés) face aux annulations surfacées par `invokeTool` et préparé les scénarios quotas × cancellation afin de terminer l'item "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 139)
+- ✅ Normalisé `TaskLeaf` pour convertir les erreurs d'annulation `AbortError` en `BehaviorTreeCancellationError`, vérifier la coopération après résolution de `invokeTool` et préserver la propagation des `OperationCancelledError` natifs.
+- ✅ Ajouté la suite `tests/bt.tasks.cancel.test.ts` couvrant les annulations pré-invocation, intra-invocation (erreurs abort) et post-invocation tout en s'assurant que `invokeTool` n'est pas appelé inutilement.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test` pour confirmer l'absence de régressions après régénération des artefacts.
+- 🔜 Préparer les scénarios de tests combinant quotas parallèles et annulation (`ParallelNode` × `BehaviorTreeCancellationError`) puis auditer les interactions côté outils MCP pour clôturer "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 140)
+- ✅ Durci `ParallelNode` pour qu'il réinitialise ses caches de statut et ses enfants dès qu'une annulation coopérative survient, en harmonisant la propagation des erreurs et en attendant la stabilisation de toutes les branches (`Promise.allSettled`).
+- ✅ Ajouté `tests/bt.parallel.cancel.test.ts` couvrant la remontée d'annulation par un enfant ainsi que l'annulation déclenchée par `throwIfCancelled`, avec vérification des resets et de la reprise sous politique `quota`.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm test:unit -- --exit` puis `(graph-forge) npm run build` pour garantir la régénération des artefacts et la stabilité de la suite (435 tests verts).
+- 🔜 Étendre la couverture aux politiques `all`/`any` sous annulation et préparer des scénarios intégration (plan_run_bt + parallel quota) avant de finaliser la case "Modifier src/executor/bt/nodes.ts" et d'auditer la propagation côté outils MCP.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 141)
+- ✅ Étendu `tests/bt.parallel.cancel.test.ts` avec des scénarios `all` et `any` qui vérifient la remise à zéro complète après annulation (enfant qui annule, runtime `throwIfCancelled` post-exécution) et documenté les gardes coopératifs supplémentaires.
+- ✅ Rejoué `npm run lint`, `npm run build`, `npm run test:unit -- --exit` pour confirmer que la couverture accrue n'introduit pas de régression et que les artefacts `dist/` restent inchangés.
+- 🔜 Préparer les scénarios d'intégration `plan_run_bt` × `ParallelNode` (politiques quota/all/any sous annulation) et auditer la propagation des erreurs côté outils MCP avant de clôturer "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 142)
+- ✅ Couvert `plan_run_bt` × `ParallelNode` pour les politiques quota/all/any sous annulation via `tests/plan.bt.parallel-cancel.integration.test.ts`, en vérifiant les événements `BT_RUN` (`start/cancel/error/complete`) et la remise à zéro avant reprise.
+- ✅ Audité la propagation des erreurs côté outils MCP lors des intégrations `plan_run_bt` annulées afin de préparer la normalisation réalisée à l'itération 143.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 143)
+- ✅ Normalisé `plan_run_bt` et `plan_run_reactive` pour transformer les `BehaviorTreeCancellationError` en `OperationCancelledError`, consigner la raison d'annulation et émettre des événements `error` cohérents avant de remonter l'exception structurée.
+- ✅ Ajouté `tests/plan.bt.cancel-normalisation.test.ts` ainsi qu'un scénario dédié dans `tests/plan.run-reactive.test.ts` pour valider la normalisation côté outils MCP, documenté le comportement dans le README et régénéré `dist/` via `npm run build`.
+- 🔜 Préparer les scénarios quotas parallèles multi-niveaux et auditer la propagation des erreurs côté outils MCP hors `plan_run_*` (ex. `plan_cancel`, `plan_status`) avant de clôturer "Modifier src/executor/bt/nodes.ts".
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 144)
+- ✅ Implémenté la persistance des nœuds (snapshot/restore) et le suivi de progression dans `BehaviorTreeInterpreter`, en harmonisant les décorateurs/composites avec des états sérialisables.
+- ✅ Propagé le pourcentage de progression aux événements `plan_run_bt`/`plan_run_reactive` et ajusté le registre de lifecycle pour consommer les valeurs explicites.
+- ✅ Ajouté `tests/bt.interpreter.snapshot.test.ts` et étendu `tests/plan.lifecycle.test.ts` pour couvrir la reprise et la priorité donnée aux pourcentages fournis.
+- ✅ Documenté la nouvelle API de snapshot dans le README et régénéré les artefacts `dist/` via `npm run build`.
+- 🔜 Finaliser l'audit des décorateurs restants (`src/executor/bt/nodes.ts`) et étendre les scénarios MCP (plan_cancel/plan_status) avec le nouveau suivi de progression.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 145)
+- ✅ Reroulé `npm run test:unit -- --exit` jusqu'à complétion : conversion des doubles de tests `BehaviorNode` pour exposer `snapshot/restore/getProgress` et éviter les erreurs `this.root.getProgress is not a function`.
+- ✅ Normalisé les stubs des suites scheduler/composites/décorateurs/perf pour qu'ils maintiennent un statut/pointeur sérialisable et restituent un pourcentage cohérent pendant les snapshots.
+- ✅ Confirmé que la suite complète (444 tests) passe sans échec après l'ajout de la progression, laissant la pile MCP inchangée.
+- 🔜 Poursuivre l'audit des décorateurs runtime restants et étendre les scénarios `plan_cancel`/`plan_status` intégrant `progress` comme indiqué à l'itération 144.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 146)
+- ✅ `plan_cancel` retourne désormais `progress` et le snapshot `lifecycle` associé lorsque le suivi de progression est actif, avec journalisation de la progression finale pour les observateurs MCP.
+- ✅ Ajouté un scénario d'intégration `plan_cancel` × `plan_status` vérifiant la remise à zéro après annulation et la surface des raisons dans les snapshots, avec temporisation contrôlée via fake timers.
+- ✅ Documenté dans le README l'accès direct à la progression via `plan_cancel`/`plan_status` pour éviter les appels additionnels.
+- ✅ Contrôler les réponses `plan_cancel` lorsque le lifecycle est désactivé et propager la progression aux autres outils d'arrêt (`op_cancel`) avant de clôturer l'item plan lifecycle.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 147)
+- ✅ Factorisé la récupération des snapshots lifecycle côté serveur afin que `plan_cancel` et `op_cancel` exposent systématiquement progression et état lorsque disponibles, avec journalisation des dégradations.
+- ✅ Étendu `tests/plan.lifecycle.test.ts` avec des scénarios couvrant `plan_cancel` sans lifecycle ainsi qu'`op_cancel` avec lifecycle actif pour vérifier la surface de progression et la propagation des raisons d'annulation.
+- ✅ Documenté dans le README le nouveau comportement d'`op_cancel` et la dégradation à `null` lorsque le lifecycle est désactivé.
+- 🔜 Auditer les outils lifecycle restants (`plan_status`, `plan_pause`, `plan_resume`) lorsque la fonctionnalité est désactivée afin de garantir des dégradations homogènes et des messages d'erreur documentés.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 148)
+- ✅ Ajouté un helper `requirePlanLifecycle` qui journalise les appels lifecycle lorsque le registre est inactif et surface l'erreur `E-PLAN-LIFECYCLE-DISABLED` de manière cohérente dans `plan_status`/`plan_pause`/`plan_resume` (`src/tools/planTools.ts`).
+- ✅ Couvert la dégradation côté outils via un scénario d'intégration vérifiant les erreurs et hints renvoyés lorsque le lifecycle est désactivé (`tests/plan.lifecycle.test.ts`).
+- ✅ Documenté dans le README le comportement des outils lifecycle lorsque la fonctionnalité est désactivée.
+- 🔜 Auditer l'émission d'événements lifecycle (`plan_status`/`plan_pause`/`plan_resume`) lorsque le registre est réactivé en cours de run afin de garantir la continuité des snapshots et préparer l'item suivant sur le scheduler réactif.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 149)
+- ✅ Contextualisé les outils plan pour exposer en permanence le registre lifecycle tout en signalant l'état du flag, afin que les runs démarrés sans lifecycle continuent à publier des snapshots lorsque la fonctionnalité est réactivée (`src/tools/planTools.ts`, `src/server.ts`).
+- ✅ Ajouté un scénario d'intégration qui désactive puis réactive le lifecycle en cours d'exécution pour vérifier la reprise immédiate du statut et des contrôles pause/reprise (`tests/plan.lifecycle.test.ts`).
+- ✅ Documenté dans le README la continuité des snapshots lorsque la fonctionnalité est réactivée après coup.
+- 🔜 Préparer les ajustements côté scheduler réactif afin d'observer la remise en route des reconcilers et des événements quand le lifecycle est réactivé dynamiquement.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 150)
+- ✅ Ajouté un hook `afterTick` dans `ExecutionLoop` pour exposer la télémétrie des reconcilers (durées, statut, erreurs) et normalisé les identifiants de l'autoscaler/superviseur.
+- ✅ Étendu `plan_run_reactive` pour sérialiser l'événement ordonnanceur (`event_payload`) et publier les reconcilers exécutés dans les événements `loop`, avec tests unitaires ciblant la réactivation lifecycle (`tests/executor.loop.reconciler.test.ts`, `tests/plan.run-reactive.test.ts`).
+- ✅ Documenté dans le README les nouvelles métriques lifecycle (`tick_duration_ms`, liste des reconcilers) afin que les opérateurs puissent auditer la reprise après réactivation.
+- 🔜 Vérifier la diffusion des nouvelles métadonnées côté SSE/events_subscribe et préparer l'observabilité du scheduler réactif dans le dashboard.
+
+### 2025-10-05 – Agent `gpt-5-codex` (iteration 151)
+- ✅ Vérifié que `events_subscribe` relaie les métadonnées `reconcilers` des événements `BT_RUN` (JSON Lines & SSE) en ajoutant un scénario d'intégration dédié (`tests/events.subscribe.plan-correlation.test.ts`).
+- ✅ Documenté dans le README la récupération des reconcilers via `events_subscribe` pour guider les opérateurs.
+- ✅ Rejoué `npm run lint`, `npm run build`, `npm run test:unit -- --exit` pour couvrir la nouvelle intégration.
+- 🔜 Préparer l'instrumentation du dashboard SSE afin d'exposer les reconcilers et l'ordonnanceur réactif côté monitoring.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 152)
+- ✅ Implémenté l'aging logarithmique et le quantum coopératif dans `ReactiveScheduler` afin d'éviter la famine sous charge continue tout en laissant l'event loop respirer (`agingHalfLifeMs`, `agingFairnessBoost`, `batchQuantumMs`, `maxBatchTicks`).
+- ✅ Ajouté `tests/executor.scheduler.prio-aging.test.ts` couvrant la promotion des événements âgés et la coupure des batches selon le quantum.
+- ✅ Documenté dans le README les nouveaux paramètres d'aging/quantum et rejoué `npm run lint`, `npm run build`, `npm run test:unit -- --exit`.
+- 🔜 Brancher le dashboard SSE sur les compteurs de batch (`batchIndex`, `batchElapsedMs`) pour visualiser les yields du scheduler.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 153)
+- ✅ Factorisé les utilitaires de tests du scheduler réactif (`ManualClock`, `ScriptedNode`, `BusyNode`) dans `tests/helpers/reactiveSchedulerTestUtils.ts` et mis à jour la suite `executor.scheduler.prio-aging` pour les réutiliser.
+- ✅ Ajouté `tests/executor.scheduler.budgets.test.ts` afin de couvrir la remise à zéro des métriques de batch, la désactivation explicite des budgets coopératifs et la reprise après injection de nouveaux événements en cours de batch.
+- ✅ Exécuté `npm run lint`, `npm run build`, `npm run test:unit -- --exit` (455 tests verts) puis nettoyé `children/` et `runs/`.
+- 🔜 Instrumenter le dashboard SSE avec les métriques de batch (`batchIndex`, `ticksInBatch`, `batchElapsedMs`) et poursuivre l'audit stigmergie configurables (section 4.3).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 154)
+- ✅ Rendu `StigmergyField` paramétrable (`defaultHalfLifeMs`, bornes min/max) et exposé un snapshot heatmap normalisé, tout en réutilisant ces données côté dashboard (`computeDashboardHeatmap`).
+- ✅ Étendu `handleStigSnapshot` pour renvoyer la heatmap sérialisée, ajouté une batterie de tests (`tests/coord.stigmergy.field.test.ts`, `tests/monitor.dashboard*.test.ts`) couvrant les nouveaux comportements et les valeurs normalisées.
+- ✅ Documenté les options de configuration/heatmap dans le README et mis à jour la checklist stigmergie.
+- 🔜 Brancher la configuration stigmergie sur le serveur/CLI (flags ou config runtime) et diffuser les métriques normalisées côté SSE dashboard.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 156)
+- ✅ Propagé les bornes stigmergiques jusqu'aux outils `plan_run_bt` / `plan_run_reactive` et aux événements `events_subscribe`, avec sérialisation normalisée (`pheromone_bounds`).
+- ✅ Étendu `ReactiveScheduler` et le pont `bridgeStigmergyEvents` pour transporter les limites min/max ainsi que le plafond de normalisation, en ajoutant la couverture unitaire/intégration correspondante.
+- ✅ Mis à jour la documentation (`README.md`) et les tests (`tests/coord.stigmergy.field.test.ts`, `tests/plan.run-reactive.test.ts`, `tests/events.subscribe.plan-correlation.test.ts`, `tests/events.bridges.test.ts`) pour vérifier la nouvelle télémétrie.
+- 🔜 Finaliser la propagation des bornes dans les agents d'autoscaling / Contract-Net et auditer l'impact sur la priorisation scheduler.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 157)
+- ✅ Propagé les bornes stigmergiques jusqu'à l'autoscaler : nouvelles mises à jour `updatePheromoneBounds`, événements incluant `pheromone_bounds` et couverture dédiée (`tests/plan.run-reactive.test.ts`, `tests/agents.autoscaler.correlation.test.ts`).
+- ✅ Enrichi le Contract-Net (outil & pont d'événements) avec les limites normalisées, permettant à `cnp_announce` et aux événements `cnp_call_*` de refléter les bornes en vigueur ; tests `idempotency.replay` et `events.bridges` mis à jour.
+- ✅ Documenté la propagation unifiée des bornes (autoscaler, Contract-Net) dans le README.
+- ✅ Connecter les métriques de bornes aux dashboards (autoscaler/Contract-Net) et observer leur impact sur les heuristiques de sélection côté Contract-Net.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 158)
+- ✅ Exposé `pheromone_bounds` dans les snapshots `/metrics` & `/stream` du dashboard et injecté les bornes normalisées dans la heatmap (`src/monitor/dashboard.ts`).
+- ✅ Étendu les suites `monitor.dashboard` (HTTP & SSE) pour vérifier la présence des bornes normalisées et la stabilité du plafond de normalisation.
+- ✅ Documenté la disponibilité des bornes côté dashboard dans le README afin d'aligner l'interface avec la télémétrie MCP.
+- 🔜 Mettre à jour l'UI dashboard/autoscaler pour afficher explicitement `pheromone_bounds` (tableau, heatmap tooltip) et auditer l'exploitation des bornes côté heuristiques Contract-Net (scénarios variation plafond).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 159)
+- ✅ Ajouté un résumé `stigmergy.rows` et une infobulle `heatmap.boundsTooltip` afin que le dashboard/UI autoscaler puissent afficher directement les bornes normalisées sans logique supplémentaire (`src/monitor/dashboard.ts`).
+- ✅ Étendu les tests dashboard (HTTP & SSE) pour couvrir les nouvelles données de tableau/tooltip et documenté l'API (`README.md`).
+- 🔜 Vérifier l'exploitation des bornes côté heuristiques Contract-Net (variation du plafond) et brancher l'autoscaler UI sur le tableau `stigmergy.rows`.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 160)
+- ✅ `ContractNetCoordinator` capture désormais `pheromone_bounds` lors des annonces et les relaie aux snapshots/événements ; `handleCnpAnnounce` sérialise les bornes normalisées pour aligner l'outil avec la télémétrie scheduler (`src/coord/contractNet.ts`, `src/tools/coordTools.ts`).
+- ✅ Ajouté `tests/coord.contractnet.pheromone-bounds.test.ts` pour vérifier l'évolution du plafond de normalisation et la conservation des bornes dans l'idempotence (`tests/idempotency.replay.test.ts`, `tests/events.bridges.test.ts` ajustés).
+- ✅ Regénéré `dist/` via `npm run build` après lint + 460 tests verts (`npm run lint`, `npm run test:unit -- --exit`).
+- ✅ Brancher l'autoscaler UI (dashboard/agents) sur `stigmergy.rows` pour exploiter les nouvelles bornes formatées (réalisé à l'itération 161).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 161)
+- ✅ Étendu `stig_snapshot` pour exposer `pheromone_bounds`, un bloc `summary.rows` pré-formaté et `heatmap.bounds_tooltip`, en factorisant les helpers de formatage dans `src/coord/stigmergy.ts` afin que l'autoscaler/dashboard puissent consommer directement `stigmergy.rows`.
+- ✅ Mis à jour `tests/coord.stigmergy.field.test.ts` avec un scénario couvrant la nouvelle sortie `stig_snapshot` et documenté les champs (`README.md`, `docs/mcp-api.md`).
+- ✅ Rejoué `npm run lint`, `npm run test:unit -- --exit`, `npm run build` pour valider la compilation de `dist/`.
+- ✅ Audité les heuristiques Contract-Net pour exploiter effectivement les bornes lors de la priorisation (`computeEffectiveCost`).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 162)
+- ✅ Multiplé `busy_penalty` par un facteur de pression dérivé des bornes stigmergiques dans `computeEffectiveCost`, en exposant `computePheromonePressure` pour documenter le calcul et garder les tests alignés.
+- ✅ Ajouté un scénario Contract-Net prouvant que la pression fait basculer l'attribution lorsque le plafond normalisé augmente, ainsi que des tests unitaires dédiés au helper (logarithme sur champ non borné).
+- ✅ Documenté dans le README la modulation du `busy_penalty` par `pheromone_bounds`.
+- ✅ (traité it.163) Évaluer la mise à jour dynamique des enchères heuristiques (`autoBid`) lorsque les bornes évoluent pendant la vie d'un call afin d'anticiper la ré-émission de bids sous forte pression.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 163)
+- ✅ Ajouté `ContractNetCoordinator.updateCallPheromoneBounds` pour synchroniser les bornes d'un call ouvert et réémettre les enchères heuristiques avec la pression stigmergique actuelle (`auto_refresh`) sans toucher aux offres manuelles.
+- ✅ Étendu `tests/coord.contractnet.pheromone-bounds.test.ts` afin de couvrir le rafraîchissement des bids, l'inclusion des nouveaux agents et le mode `refreshAutoBids: false`.
+- ✅ Enrichi les snapshots (`auto_bid_enabled`, `metadata.pheromone_pressure`) et documenté l'API Contract-Net afin que les observateurs et outils MCP détectent la réémission des bids.
+- ✅ Exposer le rafraîchissement des bornes côté outils/bridges (ex. commande MCP dédiée) et brancher le scheduler pour déclencher automatiquement `updateCallPheromoneBounds` lorsque la pression stigmergique évolue.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 164)
+- ✅ Ajouté l'outil `cnp_refresh_bounds` et documenté la nouvelle commande MCP, y compris les champs `refreshed_agents` / `auto_bid_refreshed`.
+- ✅ Branché `watchContractNetPheromoneBounds` pour auto-synchroniser les appels ouverts dès que les bornes stigmergiques évoluent et diffusé l'événement `cnp_call_bounds_updated` sur le bus.
+- ✅ Étendu les suites de tests Contract-Net / bridges pour couvrir l'événement, le watcher et le flux outil → coordinateur.
+- 🔜 Surveiller le bruit des rafraîchissements automatiques (coalescer les mises à jour successives, journaliser les suppressions potentielles) et envisager une API pour déclencher des rafraîchissements ciblés par tags d'appel.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 165)
+- ✅ Ajouté une fenêtre de coalescence (`coalesce_window_ms`, 50 ms par défaut) au watcher Contract-Net pour regrouper les rafales de mises à jour stigmergiques avant de rafraîchir les appels ouverts.
+- ✅ Adapté la suite `coord.contractnet.pheromone-bounds` avec une couverture asynchrone et un scénario de coalescence, garantissant un seul événement `call_bounds_updated` pour des rafales rapprochées.
+- ✅ Documenté la nouvelle option dans le README et conservé le flush final lors du détachement du watcher pour ne pas perdre d'update en vol.
+- ✅ Évaluer des métriques de télémétrie (compteur de rafraîchissements coalescés/supprimés) pour surveiller l'impact en production et décider d'exposer un contrôle par appel (`cnp_refresh_bounds` ciblé par tag) si nécessaire (traité it.166).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 166)
+- ✅ Instrumenté `watchContractNetPheromoneBounds` avec un callback `onTelemetry` et un log `contract_net_bounds_watcher_telemetry` exposant les compteurs `received_updates`, `coalesced_updates`, `skipped_refreshes`, `flushes` et `applied_refreshes`.
+- ✅ Étendu `tests/coord.contractnet.pheromone-bounds.test.ts` avec des scénarios de coalescence et de rafraîchissement inchangé vérifiant les nouveaux compteurs, ainsi que la propagation des instantanés de télémétrie au détachement.
+- ✅ Documenté le callback de télémétrie dans le README et rejoué `npm run lint`, `npm run test:unit -- --exit`, `npm run build`.
+- ✅ (traité it.167) Décider si l'on expose ces compteurs via une API MCP (par exemple `cnp_watch_bounds_telemetry`) ou via le dashboard Contract-Net pour diagnostiquer les suppressions de rafraîchissements en production.
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 167)
+- ✅ Relié le watcher Contract-Net côté serveur avec un collecteur dédié (`ContractNetWatcherTelemetryRecorder`) et démarré l'observateur au boot pour alimenter automatiquement les métriques.
+- ✅ Exposé les compteurs via l'outil MCP `cnp_watcher_telemetry`, enregistré `cnp_refresh_bounds` et enrichi la documentation (README + `docs/mcp-api.md`) avec la nouvelle surface.
+- ✅ Ajouté un test unitaire couvrant l'outil de télémétrie ainsi que la configuration serveur, puis mis à jour `tests/coord.contractnet.pheromone-bounds.test.ts` en conséquence.
+- ✅ Publier ces compteurs sur un flux dashboard/SSE pour surveiller les rafraîchissements en temps réel (ou proposer des filtres par tag d'appel côté API).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 168)
+- ✅ Exposé `contractNetWatcherTelemetry` dans les réponses `/metrics` et `/stream` du dashboard afin que les snapshots SSE reflètent les compteurs du watcher Contract-Net.
+- ✅ Ajouté une couverture HTTP/SSE dédiée vérifiant la sérialisation des compteurs (`tests/monitor.dashboard.test.ts`, `tests/monitor.dashboard.streams.test.ts`) et documenté le nouveau bloc dans le README.
+- ✅ Routé le collecteur via `startDashboardServer` et mis à jour `AGENTS.md` pour clôturer la diffusion SSE.
+- ✅ Brancher l'UI dashboard/autoscaler sur `contractNetWatcherTelemetry` (tableaux/graphes) afin d'exposer les compteurs en front-end (page HTML ajoutée it.171).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 169)
+- ✅ Ajouté `createContractNetWatcherTelemetryListener` pour mutualiser l'enregistrement des compteurs du watcher et leur diffusion sur le bus d'événements (`cat:"contract_net"`, `msg:"cnp_watcher_telemetry"`).
+- ✅ Branché le serveur sur ce listener afin que chaque rafraîchissement Contract-Net publie une entrée temps réel et continue d'alimenter le recorder (`src/events/bridges.ts`, `src/server.ts`).
+- ✅ Étendu `tests/events.bridges.test.ts` avec une couverture dédiée, documenté l'événement dans `README.md`/`docs/mcp-api.md` et regénéré `dist/`.
+- ✅ Implémenter la visualisation UI des compteurs `contractNetWatcherTelemetry` dans le dashboard/autoscaler (graphiques, tableaux) pour tirer parti du flux SSE et du nouvel événement bus (réalisé it.171).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 170)
+- ✅ Aligné le dashboard (`/metrics`, `/stream`) sur la télémétrie Contract-Net en ajoutant `contractNetWatcherTelemetry` aux snapshots et en étendant les tests HTTP/SSE pour vérifier la présence et la stabilité des compteurs (`src/monitor/dashboard.ts`, `tests/monitor.dashboard*.test.ts`).
+- ✅ Complété `ContractNetCoordinator` avec `listOpenCalls`, l'événement `call_bounds_updated` et les métadonnées `autoBidRefreshed`/`refreshedAgents` afin que le watcher et les outils exposent réellement les compteurs attendus (`src/coord/contractNet.ts`, `dist/coord/contractNet.js`).
+- ✅ Regénéré les artefacts compilés (`npm run build`) après lint + 474 tests verts pour synchroniser `dist/` avec les sources.
+- ✅ Brancher le front dashboard/autoscaler sur `contractNetWatcherTelemetry` (tableaux/graphes) maintenant que les snapshots exposent les compteurs et poursuivre l'audit des visualisations côté UI (complété it.171).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 171)
+- ✅ Ajouté une page HTML `GET /` au dashboard affichant le résumé Contract-Net (compteurs, dernière émission, bornes) ainsi que les sections stigmergie et scheduler pour offrir une vue front-end immédiate (`src/monitor/dashboard.ts`).
+- ✅ Étendu `tests/monitor.dashboard.test.ts` afin de valider la nouvelle route HTML et la présence des compteurs Contract-Net renderisés côté UI, puis documenté l'usage dans le README.
+- ✅ Enrichir la page HTML avec des visualisations dynamiques (graphiques temps réel/SSE) et prévoir des captures UI pour la documentation opérateur (réalisé it.174).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 172)
+- ✅ Restauré `ContractNetCoordinator.listOpenCalls`, la propagation de `autoBidRefreshed`/`refreshedAgents` et l'émission `call_bounds_updated` afin que le watcher Contract-Net et les outils MCP utilisent réellement ces données (`src/coord/contractNet.ts`).
+- ✅ Aligné `events/bridges` pour sérialiser `cnp_call_bounds_updated` sur le bus avec les métadonnées de rafraîchissement attendues et régénéré les artefacts `dist/`.
+- 🔜 Vérifier côté orchestrateur HTTP que le bootstrap dashboard + watcher fonctionne désormais sans erreur en environnement dist (relancer un `npm run start:dashboard`).
+
+### 2025-10-06 – Agent `gpt-5-codex` (iteration 173)
+- ✅ Ajouté un scénario `graph_batch_mutate` dans `tests/idempotency.replay.test.ts` pour prouver que les mutations sont rejouées depuis le cache tant que le TTL n’expire pas, avec un troisième appel qui revalide l’exécution après expiration.
+- ✅ Marqué la checklist « Idempotency keys » comme complétée et documenté la couverture désormais exhaustive (tools + tests).
+- ✅ Relancé `npm run start:dashboard` sur le bundle dist pour confirmer que le bootstrap dashboard/watcher fonctionne désormais sans erreur.
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 174)
+- ✅ Dynamisé la page HTML du dashboard (`GET /`) : connexion SSE automatique, statut visuel, re-rendu DOM sécurisé pour le watcher Contract-Net, la stigmergie et le scheduler (`src/monitor/dashboard.ts`).
+- ✅ Ajouté des helpers d'échappement/serialisation pour sécuriser le bootstrap inline et aligné la mise en page initiale sur le rendu client.
+- ✅ Renforcé `tests/monitor.dashboard.test.ts` avec des assertions sur le script SSE, l'échappement HTML et la présence du bootstrap dynamique.
+- ✅ Documenté la mise à jour automatique côté README et validé que les snapshots SSE restent cohérents avec `/metrics`.
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 175)
+- ✅ Corrigé le bootstrap SSE du dashboard pour interpoler le snapshot sérialisé au lieu de laisser l’expression littérale `${serialisedSnapshot}`, garantissant l’échappement de `<script>` côté HTML (`src/monitor/dashboard.ts`, `dist/monitor/dashboard.js`).
+- ✅ Précisé dans le README que le HTML racine se met désormais à jour en continu via SSE sans rechargement manuel.
+- ✅ Durci `tests/monitor.dashboard.test.ts` avec un motif `<script>` malveillant et une vérification de l’encodage `\u003c` afin de prévenir toute régression d’échappement.
+- ✅ Rejoué `npm run lint`, `npm run build`, `npm run test:unit -- --exit` (475 tests verts) pour valider la correction et la génération `dist/`.
+- 🔜 Ajouter un scénario de test couvrant les raisons SSE contenant des séparateurs Unicode (U+2028/U+2029) afin de vérifier l’échappement côté client.
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 176)
+- ✅ Étendu `tests/monitor.dashboard.test.ts` avec un motif Contract-Net combinant `<script>` et les séparateurs Unicode U+2028/U+2029 pour confirmer que le bootstrap SSE les sérialise via `\u2028`/`\u2029`.
+- ✅ Vérifié que le HTML du dashboard affiche toujours le résumé Contract-Net sans injection tout en conservant les libellés « next line » / « paragraph ».
+- 🔜 Prévoir un audit des flux SSE multi-lignes (reasons volumineuses) afin de confirmer l’absence de fragmentation côté clients streaming.
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 177)
+- ✅ Normalisé le flux SSE `/stream` pour sérialiser chaque snapshot sur une seule ligne (échappement `\n`/`\r`/U+2028/U+2029) et éviter la fragmentation côté clients `EventSource`.
+- ✅ Ajouté un test `monitor.dashboard.streams` couvrant une raison Contract-Net multi-ligne avec séparateurs Unicode afin de garantir la stabilité du transport et la restitution exacte après `JSON.parse`.
+- ✅ Documenté l’invariance côté README et vérifié que le flux d’événements reste propre via `StreamResponse`.
+- ✅ Étendre l’audit aux flux SSE `events_subscribe` / watchers futurs pour partager l’utilitaire d’échappement et ajouter une couverture d’intégration avec un parser SSE côté tests (voir it.178).
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 178)
+- ✅ Factorisé l’échappement SSE dans `src/events/sse.ts` et réutilisé le helper côté dashboard et `events_subscribe` pour garantir un transport monoligne.
+- ✅ Ajouté `tests/events.subscribe.sse-escaping.test.ts` : le scénario annote un cancel avec `\r`, `\n`, `U+2028`/`U+2029`, vérifie que le flux SSE ne contient plus ces séparateurs et que `JSON.parse` restitue bien la raison.
+- ✅ Documenté la normalisation SSE dans le README et `docs/mcp-api.md`, puis mis à jour `dist/` via `npm run build` après lint/tests.
+- ✅ Enrichir la couverture avec un parseur SSE événement par événement (stream réel) et aligner les futurs watchers (`resources_watch` notamment) sur `serialiseForSse` dès leur implémentation (parseur couvert it.179, alignement watchers à appliquer lors de leur exposition SSE).
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 179)
+- ✅ Ajouté `tests/helpers/sse.ts` avec un parseur SSE côté tests pour valider le framing événement par événement.
+- ✅ Étendu `tests/events.subscribe.sse-escaping.test.ts` afin d’utiliser le parseur et d’asserter chaque bloc `data:` après `JSON.parse`.
+- ✅ Rejoué `npm run lint`, `npm run test:unit -- --exit`, `npm run build` (477 tests verts) et mis à jour cette checklist.
+- ✅ Propagé `serialiseForSse` au flux `resources_watch` lors de l'implémentation du format SSE (voir it.183).
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 180)
+- ✅ Ajouté `tests/concurrency.events-backpressure.test.ts` pour simuler un drain limité du bus d'événements et vérifier l'absence de pertes (`next_seq` prêt pour le keep-alive).
+- ✅ Couvert `resources_watch` sur les événements de run en paginant via `from_seq`/`limit`, en validant `nextSeq` et la reprise après un keep-alive.
+- ✅ Étendu la couverture backpressure aux journaux enfants (`sc://children/<id>/logs`) pour préparer le branchement SSE (voir it.181).
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 181)
+- ✅ Ajouté `tests/concurrency.child-logs-backpressure.test.ts` pour vérifier la pagination déterministe des journaux enfants, y compris les keep-alives et la reprise après ajout d'entrées.
+- ✅ Couvert les drains intercalés sur plusieurs enfants afin de prouver que chaque seau conserve ses propres curseurs sans fuite d'événements.
+- ✅ Aligné les watchers enfants/run sur le flux SSE via le format `resources_watch` `sse` (couvert it.183).
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 182)
+- ✅ Ajouté `src/resources/sse.ts` avec les helpers `serialiseResourceWatchResultForSse` et `renderResourceWatchSseMessages` afin de produire des messages `resource_run_event`/`resource_child_log`/`resource_keep_alive` échappés pour le futur flux SSE.
+- ✅ Écrit `tests/resources.watch.sse.test.ts` en s'appuyant sur `parseSseStream` pour garantir l'échappement (`\n`, `\r`, `U+2028`, `U+2029`) et la réversibilité des payloads, y compris le cas keep-alive.
+- ✅ Documenté le format SSE (README + docs/mcp-api.md) et noté que `next_seq` est inclus pour faciliter les reconnexions.
+- ✅ Branché les helpers SSE dans le tool `resources_watch` (format `sse`) et vérifié la propagation des métadonnées côté client/tests (it.183).
+
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 183)
+- ✅ Ajouté le paramètre `format="sse"` au tool `resources_watch` pour générer `messages` et `stream` via les helpers SSE partagés.
+- ✅ Couvert l'intégration MCP (client in-memory) en vérifiant l'échappement monoligne et la fidélité des payloads SSE.
+- ✅ Actualisé README + `docs/mcp-api.md` et exporté `resources` afin de faciliter les scénarios de test autour du registre.
+- 🔜 Envisager une route HTTP/SSE dédiée (`/resources/watch/stream`) si un flux long-lived hors MCP devient nécessaire.

--- a/dist/agents/autoscaler.js
+++ b/dist/agents/autoscaler.js
@@ -49,6 +49,8 @@ const DEFAULT_THRESHOLDS = {
  * period to avoid oscillations.
  */
 export class Autoscaler {
+    /** Identifier surfaced in execution loop diagnostics and lifecycle events. */
+    id = "autoscaler";
     supervisor;
     logger;
     now;

--- a/dist/agents/supervisor.js
+++ b/dist/agents/supervisor.js
@@ -5,6 +5,8 @@ import { extractCorrelationHints } from "../events/correlation.js";
  * so it can be registered alongside the autoscaler inside the execution loop.
  */
 export class OrchestratorSupervisor {
+    /** Identifier surfaced in execution loop diagnostics and lifecycle events. */
+    id = "supervisor";
     childManager;
     logger;
     actions;

--- a/dist/coord/contractNetWatchers.js
+++ b/dist/coord/contractNetWatchers.js
@@ -1,0 +1,187 @@
+/**
+ * Collector recording the latest Contract-Net bounds watcher telemetry. The
+ * recorder stores cumulative counters and the timestamp of the last emission so
+ * MCP tools can surface up-to-date diagnostics without holding a reference to
+ * the watcher itself.
+ */
+export class ContractNetWatcherTelemetryRecorder {
+    now;
+    lastSnapshot = null;
+    emissions = 0;
+    lastEmittedAtMs = null;
+    constructor(now = () => Date.now()) {
+        this.now = now;
+    }
+    /** Records a new watcher snapshot and updates the aggregated metadata. */
+    record(snapshot) {
+        this.lastSnapshot = {
+            ...snapshot,
+            lastBounds: snapshot.lastBounds ? { ...snapshot.lastBounds } : null,
+        };
+        this.emissions += 1;
+        this.lastEmittedAtMs = this.now();
+    }
+    /** Clears the aggregated counters, useful when restarting the watcher. */
+    reset() {
+        this.lastSnapshot = null;
+        this.emissions = 0;
+        this.lastEmittedAtMs = null;
+    }
+    /** Returns the most recent watcher telemetry alongside emission metadata. */
+    snapshot() {
+        return {
+            emissions: this.emissions,
+            lastEmittedAtMs: this.lastEmittedAtMs,
+            lastSnapshot: this.lastSnapshot
+                ? {
+                    ...this.lastSnapshot,
+                    lastBounds: this.lastSnapshot.lastBounds ? { ...this.lastSnapshot.lastBounds } : null,
+                }
+                : null,
+        };
+    }
+}
+/**
+ * Subscribes to stigmergy updates and refreshes the pheromone bounds of every
+ * open Contract-Net call whenever the normalisation ceiling changes.
+ */
+export function watchContractNetPheromoneBounds(options) {
+    const { field, contractNet, logger, refreshAutoBids = true, includeNewAgents = true, coalesceWindowMs = 50, onTelemetry, } = options;
+    if (!Number.isFinite(coalesceWindowMs) || coalesceWindowMs < 0) {
+        throw new Error("coalesceWindowMs must be a finite number greater than or equal to 0");
+    }
+    let lastBounds = null;
+    let flushTimer = null;
+    let pendingDirty = false;
+    let receivedUpdates = 0;
+    let coalescedUpdates = 0;
+    let skippedRefreshes = 0;
+    let appliedRefreshes = 0;
+    let flushes = 0;
+    const emitTelemetry = (reason) => {
+        if (!onTelemetry && !logger) {
+            return;
+        }
+        const snapshot = {
+            reason,
+            receivedUpdates,
+            coalescedUpdates,
+            skippedRefreshes,
+            appliedRefreshes,
+            flushes,
+            lastBounds: lastBounds ? { ...lastBounds } : null,
+        };
+        onTelemetry?.(snapshot);
+        logger?.debug?.("contract_net_bounds_watcher_telemetry", {
+            reason,
+            received_updates: snapshot.receivedUpdates,
+            coalesced_updates: snapshot.coalescedUpdates,
+            skipped_refreshes: snapshot.skippedRefreshes,
+            applied_refreshes: snapshot.appliedRefreshes,
+            last_bounds: snapshot.lastBounds,
+        });
+    };
+    const captureBounds = () => {
+        const snapshot = field.getIntensityBounds();
+        return {
+            min_intensity: snapshot.minIntensity,
+            max_intensity: Number.isFinite(snapshot.maxIntensity) ? snapshot.maxIntensity : null,
+            normalisation_ceiling: snapshot.normalisationCeiling,
+        };
+    };
+    const refreshOpenCalls = (bounds) => {
+        const openCalls = contractNet.listOpenCalls();
+        if (openCalls.length === 0) {
+            return;
+        }
+        appliedRefreshes += 1;
+        for (const call of openCalls) {
+            try {
+                const result = contractNet.updateCallPheromoneBounds(call.callId, bounds, {
+                    refreshAutoBids,
+                    includeNewAgents,
+                });
+                logger?.info("contract_net_auto_bounds_refresh", {
+                    call_id: call.callId,
+                    refreshed_agents: result.refreshedAgents.length,
+                    auto_bid_refreshed: result.autoBidRefreshed,
+                    bounds: result.pheromoneBounds,
+                });
+            }
+            catch (error) {
+                logger?.warn("contract_net_auto_bounds_refresh_failed", {
+                    call_id: call.callId,
+                    message: error instanceof Error ? error.message : String(error),
+                });
+            }
+        }
+    };
+    const flush = (reason) => {
+        const shouldProcess = pendingDirty;
+        pendingDirty = false;
+        if (!shouldProcess) {
+            if (reason === "detach") {
+                emitTelemetry("detach");
+            }
+            return;
+        }
+        const bounds = captureBounds();
+        if (boundsEqual(bounds, lastBounds)) {
+            skippedRefreshes += 1;
+            emitTelemetry(reason);
+            return;
+        }
+        lastBounds = bounds ? { ...bounds } : null;
+        flushes += 1;
+        refreshOpenCalls(lastBounds ? { ...lastBounds } : null);
+        emitTelemetry(reason);
+    };
+    const scheduleRefresh = () => {
+        pendingDirty = true;
+        if (coalesceWindowMs === 0) {
+            flush("flush");
+            return;
+        }
+        if (flushTimer) {
+            coalescedUpdates += 1;
+            return;
+        }
+        flushTimer = setTimeout(() => {
+            flushTimer = null;
+            flush("flush");
+        }, coalesceWindowMs);
+        flushTimer.unref?.();
+    };
+    const listener = () => {
+        receivedUpdates += 1;
+        scheduleRefresh();
+    };
+    // Prime the watcher so calls announced before the subscription stays aligned.
+    lastBounds = captureBounds();
+    refreshOpenCalls(lastBounds ? { ...lastBounds } : null);
+    emitTelemetry("initial");
+    const detach = field.onChange(listener);
+    return () => {
+        detach();
+        if (flushTimer) {
+            clearTimeout(flushTimer);
+            flushTimer = null;
+        }
+        flush("detach");
+    };
+}
+function boundsEqual(a, b) {
+    if (a === b) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    return (almostEqual(a.min_intensity, b.min_intensity) &&
+        ((a.max_intensity === null && b.max_intensity === null) ||
+            (a.max_intensity !== null && b.max_intensity !== null && almostEqual(a.max_intensity, b.max_intensity))) &&
+        almostEqual(a.normalisation_ceiling, b.normalisation_ceiling));
+}
+function almostEqual(a, b) {
+    return Math.abs(a - b) <= 1e-6;
+}

--- a/dist/events/sse.js
+++ b/dist/events/sse.js
@@ -1,0 +1,16 @@
+/**
+ * Serialises an arbitrary payload so it can be written on a single `data:` line
+ * in a Server-Sent Events (SSE) stream. JSON encoding leaves Unicode line
+ * separators (U+2028/U+2029) untouched which breaks the SSE contract by
+ * introducing unintended record delimiters. The helper therefore performs an
+ * additional escape pass for carriage returns, line feeds and Unicode line
+ * separators while preserving the ability for consumers to recover the original
+ * data through `JSON.parse`.
+ */
+export function serialiseForSse(payload) {
+    return JSON.stringify(payload)
+        .replace(/\r/g, "\\r")
+        .replace(/\n/g, "\\n")
+        .replace(/\u2028/g, "\\u2028")
+        .replace(/\u2029/g, "\\u2029");
+}

--- a/dist/executor/bt/interpreter.js
+++ b/dist/executor/bt/interpreter.js
@@ -90,7 +90,7 @@ export function buildBehaviorTree(definition, options = {}, idPrefix = "root") {
             case "retry": {
                 const id = nextId(`${prefix}-retry`, node.id);
                 const child = instantiate(node.child, `${id}-child`);
-                return track(new RetryNode(id, node.max_attempts, child, node.backoff_ms));
+                return track(new RetryNode(id, node.max_attempts, child, node.backoff_ms, node.backoff_jitter_ms));
             }
             case "timeout": {
                 const id = nextId(`${prefix}-timeout`, node.id);

--- a/dist/executor/bt/nodes.js
+++ b/dist/executor/bt/nodes.js
@@ -1,3 +1,70 @@
+import { OperationCancelledError } from "../cancel.js";
+/**
+ * Error thrown when cooperative cancellation is triggered at runtime.
+ * Exported so callers embedding the Behaviour Tree runtime can detect the
+ * cancellation path without depending on implementation details.
+ */
+export class BehaviorTreeCancellationError extends Error {
+    constructor(message, options) {
+        super(message, options);
+        this.name = "BehaviorTreeCancellationError";
+    }
+}
+/** Convenience guard ensuring errors raised by cancellation can be identified. */
+function isCancellationError(error) {
+    return error instanceof BehaviorTreeCancellationError || error instanceof OperationCancelledError;
+}
+/**
+ * Determine whether the provided value represents an abort signal coming from
+ * an `AbortController`/`AbortSignal` pair. MCP tools may surface these errors
+ * when the orchestrator cancels an in-flight tool invocation.
+ */
+function isAbortLikeError(error) {
+    if (error instanceof Error && error.name === "AbortError") {
+        return true;
+    }
+    if (error && typeof error === "object") {
+        const candidate = error;
+        if (typeof candidate.name === "string" && candidate.name.toLowerCase() === "aborterror") {
+            return true;
+        }
+        if (typeof candidate.code === "string" && candidate.code.toUpperCase() === "ABORT_ERR") {
+            return true;
+        }
+        if (typeof candidate.code === "number") {
+            const abortCode = typeof DOMException !== "undefined" ? DOMException.ABORT_ERR : 20;
+            if (candidate.code === abortCode) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+/** Standard message surfaced when cancellation preempts a Behaviour Tree run. */
+const DEFAULT_CANCELLATION_MESSAGE = "Behaviour Tree execution cancelled";
+/**
+ * Convert arbitrary cancellation reasons into the orchestrator-level error used by
+ * the Behaviour Tree runtime. Preserves the root cause when available.
+ */
+function throwCancellation(cause) {
+    if (cause instanceof BehaviorTreeCancellationError) {
+        throw cause;
+    }
+    if (cause instanceof OperationCancelledError) {
+        throw cause;
+    }
+    if (cause instanceof Error) {
+        const message = cause.message && cause.message.trim().length > 0 ? cause.message : DEFAULT_CANCELLATION_MESSAGE;
+        throw new BehaviorTreeCancellationError(message, { cause });
+    }
+    if (typeof cause === "string") {
+        throw new BehaviorTreeCancellationError(cause);
+    }
+    if (cause !== undefined) {
+        throw new BehaviorTreeCancellationError(DEFAULT_CANCELLATION_MESSAGE, { cause });
+    }
+    throw new BehaviorTreeCancellationError(DEFAULT_CANCELLATION_MESSAGE);
+}
 /** Utility constant representing a successful tick result. */
 const SUCCESS_RESULT = { status: "success" };
 /** Utility constant representing a failed tick result. */
@@ -15,7 +82,19 @@ function isTerminal(status) {
 /** Guard helper executing the runtime cancellation callback when available. */
 function ensureNotCancelled(runtime) {
     if (typeof runtime.throwIfCancelled === "function") {
-        runtime.throwIfCancelled();
+        try {
+            runtime.throwIfCancelled();
+        }
+        catch (error) {
+            throwCancellation(error);
+        }
+    }
+    if (typeof runtime.isCancelled === "function" && runtime.isCancelled()) {
+        throwCancellation();
+    }
+    const signal = runtime.cancellationSignal;
+    if (signal?.aborted) {
+        throwCancellation(signal.reason);
     }
 }
 /** Behaviour Tree sequence composite node. */
@@ -35,8 +114,29 @@ export class SequenceNode {
     async tick(runtime) {
         while (this.currentIndex < this.children.length) {
             const child = this.children[this.currentIndex];
-            ensureNotCancelled(runtime);
-            const result = await child.tick(runtime);
+            try {
+                ensureNotCancelled(runtime);
+            }
+            catch (error) {
+                if (isCancellationError(error)) {
+                    // Cooperative cancellation must rewind the sequence so future ticks start
+                    // from the first child instead of resuming mid-way through the cursor.
+                    this.reset();
+                }
+                throw error;
+            }
+            let result;
+            try {
+                result = await child.tick(runtime);
+            }
+            catch (error) {
+                if (isCancellationError(error)) {
+                    // Child initiated cancellation should leave the composite in a clean state
+                    // so orchestrators can safely retry the sequence from scratch.
+                    this.reset();
+                }
+                throw error;
+            }
             if (result.status === "running") {
                 return result;
             }
@@ -73,8 +173,27 @@ export class SelectorNode {
     async tick(runtime) {
         while (this.currentIndex < this.children.length) {
             const child = this.children[this.currentIndex];
-            ensureNotCancelled(runtime);
-            const result = await child.tick(runtime);
+            try {
+                ensureNotCancelled(runtime);
+            }
+            catch (error) {
+                if (isCancellationError(error)) {
+                    // Reset the selector so cancelled runs do not keep their previous cursor.
+                    this.reset();
+                }
+                throw error;
+            }
+            let result;
+            try {
+                result = await child.tick(runtime);
+            }
+            catch (error) {
+                if (isCancellationError(error)) {
+                    // Cancellation bubbling from the child must clear the selector state.
+                    this.reset();
+                }
+                throw error;
+            }
             if (result.status === "running") {
                 return result;
             }
@@ -95,16 +214,28 @@ export class SelectorNode {
         }
     }
 }
+/** Convert user provided policy configuration into the internal representation. */
+function normaliseParallelPolicy(policy, childCount) {
+    if (policy === "all" || policy === "any") {
+        return { kind: policy };
+    }
+    const threshold = Number(policy.threshold);
+    if (!Number.isFinite(threshold) || threshold <= 0) {
+        throw new Error("Parallel quota threshold must be a positive integer");
+    }
+    const clamped = Math.max(1, Math.min(childCount, Math.floor(threshold)));
+    return { kind: "quota", successThreshold: clamped };
+}
 /** Behaviour Tree parallel composite node. */
 export class ParallelNode {
     id;
-    policy;
     children;
     childStates = new Map();
+    policy;
     constructor(id, policy, children) {
         this.id = id;
-        this.policy = policy;
         this.children = children;
+        this.policy = normaliseParallelPolicy(policy, children.length);
     }
     /**
      * Execute all children concurrently. The policy controls the aggregation of
@@ -113,43 +244,105 @@ export class ParallelNode {
      * - `any`: success once one child succeeds, failure when all fail
      */
     async tick(runtime) {
-        ensureNotCancelled(runtime);
-        const results = await Promise.all(this.children.map(async (child) => {
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                // Cooperative cancellations should rewind cached child states so the next
+                // tick restarts every branch from a clean slate.
+                this.reset();
+            }
+            throw error;
+        }
+        const childPromises = this.children.map(async (child) => {
             const previous = this.childStates.get(child.id);
             if (previous && isTerminal(previous)) {
                 return { status: previous };
             }
             ensureNotCancelled(runtime);
-            const result = await child.tick(runtime);
-            if (isTerminal(result.status)) {
-                this.childStates.set(child.id, result.status);
+            try {
+                const result = await child.tick(runtime);
+                if (isTerminal(result.status)) {
+                    this.childStates.set(child.id, result.status);
+                }
+                return result;
             }
-            return result;
-        }));
+            catch (error) {
+                if (isCancellationError(error)) {
+                    // The composite-level catch will perform the reset once every child
+                    // settled to avoid double rewinds while other branches complete.
+                }
+                throw error;
+            }
+        });
+        let results;
+        try {
+            results = await Promise.all(childPromises);
+        }
+        catch (error) {
+            await Promise.allSettled(childPromises);
+            if (isCancellationError(error)) {
+                // Cancellation should evict cached terminal states to prevent partially
+                // completed runs from being treated as finished once the orchestrator
+                // retries the parallel composite.
+                this.reset();
+            }
+            throw error;
+        }
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                this.reset();
+            }
+            throw error;
+        }
         const statuses = results.map((result) => result.status);
         const successes = statuses.filter((status) => status === "success").length;
         const failures = statuses.filter((status) => status === "failure").length;
         const running = statuses.filter((status) => status === "running").length;
-        if (this.policy === "all") {
-            if (failures > 0) {
-                this.reset();
-                return FAILURE_RESULT;
+        switch (this.policy.kind) {
+            case "all": {
+                if (failures > 0) {
+                    this.reset();
+                    return FAILURE_RESULT;
+                }
+                if (running === 0 && successes === this.children.length) {
+                    this.reset();
+                    return SUCCESS_RESULT;
+                }
+                return { status: "running" };
             }
-            if (running === 0 && successes === this.children.length) {
-                this.reset();
-                return SUCCESS_RESULT;
+            case "any": {
+                if (successes > 0) {
+                    this.reset();
+                    return SUCCESS_RESULT;
+                }
+                if (running === 0 && failures === this.children.length) {
+                    this.reset();
+                    return FAILURE_RESULT;
+                }
+                return { status: "running" };
             }
-            return { status: "running" };
+            case "quota": {
+                if (successes >= this.policy.successThreshold) {
+                    this.reset();
+                    return SUCCESS_RESULT;
+                }
+                const remainingPotential = this.children.length - failures;
+                if (remainingPotential < this.policy.successThreshold) {
+                    this.reset();
+                    return FAILURE_RESULT;
+                }
+                return { status: "running" };
+            }
+            default: {
+                const exhaustive = this.policy;
+                throw new Error(`unsupported parallel policy ${exhaustive.kind}`);
+            }
         }
-        if (successes > 0) {
-            this.reset();
-            return SUCCESS_RESULT;
-        }
-        if (running === 0 && failures === this.children.length) {
-            this.reset();
-            return FAILURE_RESULT;
-        }
-        return { status: "running" };
     }
     /** Reset cached statuses and child nodes. */
     reset() {
@@ -165,20 +358,44 @@ export class RetryNode {
     maxAttempts;
     child;
     backoffMs;
+    backoffJitterMs;
     attempts = 0;
-    constructor(id, maxAttempts, child, backoffMs = 0) {
+    constructor(id, maxAttempts, child, backoffMs = 0, backoffJitterMs = 0) {
         this.id = id;
         this.maxAttempts = maxAttempts;
         this.child = child;
         this.backoffMs = backoffMs;
+        this.backoffJitterMs = backoffJitterMs;
     }
     /**
      * Retry the child node when it fails, waiting for the configured backoff
      * between attempts.
      */
     async tick(runtime) {
-        ensureNotCancelled(runtime);
-        const result = await this.child.tick(runtime);
+        let childStarted = false;
+        let childReset = false;
+        const handleCancellation = (error) => {
+            if (isCancellationError(error)) {
+                this.resetAfterCancellation(childStarted, childReset);
+            }
+            throw error;
+        };
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            handleCancellation(error);
+            throw error;
+        }
+        let result;
+        try {
+            childStarted = true;
+            result = await this.child.tick(runtime);
+        }
+        catch (error) {
+            handleCancellation(error);
+            throw error;
+        }
         if (result.status === "success") {
             this.reset();
             return result;
@@ -192,10 +409,31 @@ export class RetryNode {
             return FAILURE_RESULT;
         }
         this.child.reset();
+        childReset = true;
         const delayFn = runtime.wait ?? defaultDelay;
-        if (this.backoffMs > 0) {
-            ensureNotCancelled(runtime);
-            await delayFn(this.backoffMs);
+        const delay = this.computeBackoffDelay(runtime);
+        if (delay > 0) {
+            try {
+                ensureNotCancelled(runtime);
+            }
+            catch (error) {
+                handleCancellation(error);
+                throw error;
+            }
+            try {
+                await delayFn(delay);
+            }
+            catch (error) {
+                handleCancellation(error);
+                throw error;
+            }
+            try {
+                ensureNotCancelled(runtime);
+            }
+            catch (error) {
+                handleCancellation(error);
+                throw error;
+            }
         }
         return { status: "running" };
     }
@@ -203,6 +441,42 @@ export class RetryNode {
     reset() {
         this.attempts = 0;
         this.child.reset();
+    }
+    /**
+     * Restore the retry state after a cooperative cancellation so the next tick starts
+     * from a clean slate without double-resetting children that were already rewound.
+     */
+    resetAfterCancellation(childStarted, childAlreadyReset) {
+        this.attempts = 0;
+        if (childStarted && !childAlreadyReset) {
+            this.child.reset();
+        }
+    }
+    /**
+     * Compute the backoff delay enriched with jitter when configured. Jitter
+     * relies on a runtime-provided pseudo-random source when available to keep
+     * tests deterministic.
+     */
+    computeBackoffDelay(runtime) {
+        const base = Math.max(0, this.backoffMs);
+        const jitter = Math.max(0, this.backoffJitterMs);
+        if (jitter === 0) {
+            return base;
+        }
+        const sampler = typeof runtime.random === "function" ? runtime.random : Math.random;
+        let sample;
+        try {
+            sample = sampler();
+        }
+        catch {
+            sample = Math.random();
+        }
+        if (!Number.isFinite(sample)) {
+            sample = Math.random();
+        }
+        const boundedSample = Math.min(Math.max(sample, 0), 1);
+        const jitterComponent = Math.round(boundedSample * jitter);
+        return base + jitterComponent;
     }
 }
 /** Behaviour Tree timeout decorator node. */
@@ -224,13 +498,32 @@ export class TimeoutNode {
      * duration to the runtime so loop detectors can adjust future budgets.
      */
     async tick(runtime) {
-        ensureNotCancelled(runtime);
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                // Align timeout cancellation semantics with other decorators by rewinding
+                // the child when interrupted before execution begins.
+                this.child.reset();
+            }
+            throw error;
+        }
         const wait = runtime.wait ?? defaultDelay;
         const start = runtime.now ? runtime.now() : Date.now();
         const budget = this.resolveBudget(runtime);
         const timeoutPromise = wait(budget).then(() => TIMEOUT_SENTINEL);
         const childPromise = this.child.tick(runtime);
-        const winner = await Promise.race([timeoutPromise, childPromise]);
+        let winner;
+        try {
+            winner = (await Promise.race([timeoutPromise, childPromise]));
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                this.child.reset();
+            }
+            throw error;
+        }
         if (winner === TIMEOUT_SENTINEL) {
             const end = runtime.now ? runtime.now() : Date.now();
             this.recordOutcome(runtime, end - start, false, budget);
@@ -298,16 +591,49 @@ export class GuardNode {
      * does not hold the guard short-circuits with a failure and resets the child.
      */
     async tick(runtime) {
-        ensureNotCancelled(runtime);
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                // Guard decorators do not maintain internal state, yet resetting the child
+                // ensures partially evaluated work is abandoned when cooperative
+                // cancellation interrupts before the condition is read.
+                this.child.reset();
+            }
+            throw error;
+        }
         const actual = runtime.variables[this.conditionKey];
         const matches = this.expected === undefined ? Boolean(actual) : actual === this.expected;
         if (!matches) {
             this.child.reset();
             return FAILURE_RESULT;
         }
-        const result = await this.child.tick(runtime);
+        let result;
+        try {
+            result = await this.child.tick(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                // The child may surface cancellation while evaluating; reset before
+                // bubbling the error so the next tick starts from a clean slate.
+                this.child.reset();
+            }
+            throw error;
+        }
         if (result.status !== "running") {
             this.reset();
+            return result;
+        }
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                // Running children are rewound when cancellation triggers between ticks.
+                this.child.reset();
+            }
+            throw error;
         }
         return result;
     }
@@ -337,7 +663,20 @@ export class TaskLeaf {
         const rawInput = this.inputKey ? runtime.variables[this.inputKey] : undefined;
         const parsedInput = this.schema ? this.schema.parse(rawInput ?? {}) : rawInput ?? {};
         ensureNotCancelled(runtime);
-        const output = await runtime.invokeTool(this.toolName, parsedInput);
+        let output;
+        try {
+            output = await runtime.invokeTool(this.toolName, parsedInput);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                throw error;
+            }
+            if (isAbortLikeError(error)) {
+                throwCancellation(error);
+            }
+            throw error;
+        }
+        ensureNotCancelled(runtime);
         return { status: "success", output };
     }
     /** Task leaves are stateless, nothing to reset. */
@@ -354,10 +693,38 @@ export class CancellableNode {
         this.child = child;
     }
     async tick(runtime) {
-        ensureNotCancelled(runtime);
-        const result = await this.child.tick(runtime);
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                this.child.reset();
+            }
+            throw error;
+        }
+        let result;
+        try {
+            result = await this.child.tick(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                this.child.reset();
+            }
+            this.reset();
+            throw error;
+        }
         if (result.status !== "running") {
             this.reset();
+            return result;
+        }
+        try {
+            ensureNotCancelled(runtime);
+        }
+        catch (error) {
+            if (isCancellationError(error)) {
+                this.child.reset();
+            }
+            throw error;
         }
         return result;
     }

--- a/dist/executor/bt/types.js
+++ b/dist/executor/bt/types.js
@@ -15,7 +15,15 @@ export const BehaviorNodeDefinitionSchema = z.lazy(() => z
     z.object({
         type: z.literal("parallel"),
         id: z.string().min(1).optional(),
-        policy: z.enum(["all", "any"]),
+        policy: z.union([
+            z.enum(["all", "any"]),
+            z
+                .object({
+                mode: z.literal("quota"),
+                threshold: z.number().int().min(1),
+            })
+                .strict(),
+        ]),
         children: z.array(BehaviorNodeDefinitionSchema).min(1),
     }),
     z.object({
@@ -23,6 +31,7 @@ export const BehaviorNodeDefinitionSchema = z.lazy(() => z
         id: z.string().min(1).optional(),
         max_attempts: z.number().int().min(1),
         backoff_ms: z.number().int().min(0).optional(),
+        backoff_jitter_ms: z.number().int().min(0).optional(),
         child: BehaviorNodeDefinitionSchema,
     }),
     z.object({

--- a/dist/executor/planLifecycle.js
+++ b/dist/executor/planLifecycle.js
@@ -178,10 +178,12 @@ export class PlanLifecycleRegistry {
             case "tick":
             case "loop":
             case "node": {
-                if (entry.snapshot.state !== "running") {
-                    entry.snapshot.state = "running";
+                if (entry.snapshot.state !== "done" && entry.snapshot.state !== "failed") {
+                    if (entry.snapshot.state !== "running") {
+                        entry.snapshot.state = "running";
+                    }
+                    entry.snapshot.paused_at = null;
                 }
-                entry.snapshot.paused_at = null;
                 break;
             }
             case "complete": {

--- a/dist/monitor/dashboard.js
+++ b/dist/monitor/dashboard.js
@@ -3,6 +3,8 @@ import { clearInterval, setInterval } from "node:timers";
 import { URL } from "node:url";
 import { z } from "zod";
 import { StructuredLogger } from "../logger.js";
+import { serialiseForSse } from "../events/sse.js";
+import { buildStigmergySummary, formatPheromoneBoundsTooltip, normalisePheromoneBoundsForTelemetry, } from "../coord/stigmergy.js";
 /** Zod schema validating the pause endpoint payload. */
 const PauseRequestSchema = z.object({
     childId: z.string().min(1, "childId is required"),
@@ -28,6 +30,7 @@ export function createDashboardRouter(options) {
     const stigmergy = options.stigmergy;
     const btStatusRegistry = options.btStatusRegistry;
     const supervisorAgent = options.supervisorAgent;
+    const contractNetWatcherTelemetry = options.contractNetWatcherTelemetry;
     const streamIntervalMs = Math.max(250, options.streamIntervalMs ?? 2_000);
     const clients = new Set();
     const autoBroadcast = options.autoBroadcast ?? true;
@@ -37,7 +40,7 @@ export function createDashboardRouter(options) {
             if (clients.size === 0) {
                 return;
             }
-            broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+            broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger);
         }, streamIntervalMs);
     }
     const handler = async (req, res) => {
@@ -48,31 +51,36 @@ export function createDashboardRouter(options) {
         const requestUrl = new URL(req.url, "http://dashboard.local");
         const pathname = requestUrl.pathname;
         try {
+            if (req.method === "GET" && pathname === "/") {
+                const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry);
+                writeHtml(res, 200, renderDashboardHtml(snapshot));
+                return;
+            }
             if (req.method === "GET" && pathname === "/health") {
                 writeJson(res, 200, { status: "ok" });
                 return;
             }
             if (req.method === "GET" && pathname === "/metrics") {
-                writeJson(res, 200, buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent));
+                writeJson(res, 200, buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry));
                 return;
             }
             if (req.method === "GET" && pathname === "/stream") {
-                handleStreamRequest(res, clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger, streamIntervalMs);
+                handleStreamRequest(res, clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger, streamIntervalMs);
                 return;
             }
             if (req.method === "POST" && pathname === "/controls/pause") {
                 await handlePauseRequest(req, res, graphState, logger);
-                broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+                broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger);
                 return;
             }
             if (req.method === "POST" && pathname === "/controls/cancel") {
                 await handleCancelRequest(req, res, graphState, supervisor, logger);
-                broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+                broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger);
                 return;
             }
             if (req.method === "POST" && pathname === "/controls/prioritise") {
                 await handlePrioritiseRequest(req, res, graphState, logger);
-                broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+                broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger);
                 return;
             }
             writeJson(res, 404, { error: "NOT_FOUND" });
@@ -93,7 +101,7 @@ export function createDashboardRouter(options) {
     return {
         streamIntervalMs,
         handleRequest: handler,
-        broadcast: () => broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger),
+        broadcast: () => broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger),
         async close() {
             if (interval) {
                 clearInterval(interval);
@@ -132,6 +140,7 @@ export async function startDashboardServer(options) {
         stigmergy: options.stigmergy,
         btStatusRegistry: options.btStatusRegistry,
         supervisorAgent: options.supervisorAgent,
+        contractNetWatcherTelemetry: options.contractNetWatcherTelemetry,
     });
     const server = createServer((req, res) => {
         void router.handleRequest(req, res);
@@ -172,6 +181,15 @@ function writeJson(res, status, payload) {
         "Cache-Control": "no-store",
     });
     res.end(json);
+}
+/** Serialises a response as HTML with UTF-8 encoding. */
+function writeHtml(res, status, payload) {
+    res.writeHead(status, {
+        "Content-Type": "text/html; charset=utf-8",
+        "Content-Length": Buffer.byteLength(payload),
+        "Cache-Control": "no-store",
+    });
+    res.end(payload);
 }
 /** Reads the full request body and parses it as JSON. */
 async function parseJsonBody(req) {
@@ -247,7 +265,7 @@ async function handlePrioritiseRequest(req, res, graphState, logger) {
     writeJson(res, 200, { status: "prioritised", priority: parsed.data.priority });
 }
 /** Configures the HTTP response to behave as an SSE stream and pushes a snapshot. */
-function handleStreamRequest(res, clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger, streamIntervalMs) {
+function handleStreamRequest(res, clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger, streamIntervalMs) {
     res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-store",
@@ -258,28 +276,31 @@ function handleStreamRequest(res, clients, graphState, eventStore, stigmergy, bt
     res.on("close", () => {
         clients.delete(res);
     });
-    const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent);
-    res.write(`data: ${JSON.stringify(snapshot)}\n\n`);
+    const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry);
+    const payload = serialiseForSse(snapshot);
+    res.write(`data: ${payload}\n\n`);
     logger.debug("dashboard_stream_connected", { clients: clients.size });
 }
 /** Pushes a fresh snapshot to every connected SSE client. */
-function broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger) {
+function broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry, logger) {
     if (clients.size === 0) {
         return;
     }
-    const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent);
-    const payload = `data: ${JSON.stringify(snapshot)}\n\n`;
+    const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry);
+    const payload = `data: ${serialiseForSse(snapshot)}\n\n`;
     for (const client of clients) {
         client.write(payload);
     }
     logger.debug("dashboard_stream_broadcast", { clients: clients.size });
 }
 /** Builds a snapshot mixing metrics, children summaries and heatmap data. */
-function buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent) {
+function buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, contractNetWatcherTelemetry) {
     const metrics = graphState.collectMetrics();
     const heatmap = computeDashboardHeatmap(graphState, eventStore, stigmergy);
+    const stigmergySummary = buildStigmergySummary(heatmap.bounds);
     const scheduler = buildSchedulerSnapshot(supervisorAgent);
     const behaviorTrees = normaliseBehaviorTreeSnapshots(btStatusRegistry.snapshot());
+    const contractNetWatcherState = contractNetWatcherTelemetry?.snapshot() ?? null;
     const children = graphState.listChildSnapshots().map((child) => {
         const lastActivityAt = child.lastTs ?? child.lastHeartbeatAt ?? child.createdAt;
         return {
@@ -299,8 +320,11 @@ function buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supe
         timestamp: Date.now(),
         metrics,
         heatmap,
+        pheromoneBounds: heatmap.bounds,
+        stigmergy: stigmergySummary,
         scheduler,
         behaviorTrees,
+        contractNetWatcherTelemetry: contractNetWatcherState,
         children,
     };
 }
@@ -364,16 +388,20 @@ export function computeDashboardHeatmap(graphState, eventStore, stigmergy) {
         }
     }
     tokens.sort((a, b) => b.value - a.value);
-    const fieldSnapshot = stigmergy.fieldSnapshot();
-    const pheromones = fieldSnapshot.totals
-        .filter((total) => total.intensity > 0)
-        .map((total) => ({
-        childId: total.nodeId,
-        label: total.nodeId,
-        value: total.intensity,
+    // Compute the current bounds before normalising cells so we reuse the same
+    // reference across every consumer (heatmap cells, dashboards, telemetry).
+    const bounds = normalisePheromoneBoundsForTelemetry(stigmergy.getIntensityBounds());
+    const boundsTooltip = formatPheromoneBoundsTooltip(bounds);
+    const fieldHeatmap = stigmergy.heatmapSnapshot();
+    const pheromones = fieldHeatmap.cells
+        .map((cell) => ({
+        childId: cell.nodeId,
+        label: cell.nodeId,
+        value: cell.totalIntensity,
+        normalised: cell.normalised,
     }))
         .sort((a, b) => b.value - a.value);
-    return { idle, errors, tokens, pheromones };
+    return { idle, errors, tokens, pheromones, bounds, boundsTooltip };
 }
 /** Builds a scheduler snapshot suitable for dashboard consumption. */
 function buildSchedulerSnapshot(supervisorAgent) {
@@ -405,4 +433,426 @@ function normaliseBehaviorTreeSnapshots(snapshots) {
             updatedAt: node.updatedAt,
         })),
     }));
+}
+/**
+ * Renders a lightweight HTML dashboard exposing key metrics alongside the
+ * Contract-Net watcher counters. The page is intentionally static so operators
+ * can obtain a quick overview without depending on external tooling.
+ */
+function renderDashboardHtml(snapshot) {
+    const watcher = snapshot.contractNetWatcherTelemetry;
+    const watcherSummary = renderMetricsTableHtml(watcher
+        ? [
+            ["Emissions", formatNumber(watcher.emissions)],
+            ["Dernier événement", formatTimestamp(watcher.lastEmittedAtMs)],
+        ]
+        : [], "Aucune télémétrie Contract-Net disponible.");
+    const watcherDetails = renderMetricsTableHtml(watcher?.lastSnapshot
+        ? [
+            ["Raison", watcher.lastSnapshot.reason],
+            ["Notifications reçues", formatNumber(watcher.lastSnapshot.receivedUpdates)],
+            ["Notifications coalescées", formatNumber(watcher.lastSnapshot.coalescedUpdates)],
+            ["Rafraîchissements ignorés", formatNumber(watcher.lastSnapshot.skippedRefreshes)],
+            ["Rafraîchissements appliqués", formatNumber(watcher.lastSnapshot.appliedRefreshes)],
+            ["Flushs", formatNumber(watcher.lastSnapshot.flushes)],
+        ]
+        : [], watcher
+        ? "Le watcher n'a pas encore publié de compteur."
+        : "Aucune télémétrie Contract-Net disponible.");
+    const bounds = renderMetricsTableHtml(watcher?.lastSnapshot?.lastBounds
+        ? [
+            ["Min intensity", formatNumber(watcher.lastSnapshot.lastBounds.min_intensity)],
+            [
+                "Max intensity",
+                formatNullableNumber(watcher.lastSnapshot.lastBounds.max_intensity),
+            ],
+            [
+                "Normalisation ceiling",
+                formatNumber(watcher.lastSnapshot.lastBounds.normalisation_ceiling),
+            ],
+        ]
+        : [], watcher?.lastSnapshot
+        ? "Aucune borne normalisée n'a été enregistrée."
+        : "Aucune télémétrie Contract-Net disponible.");
+    const stigSummaryRows = snapshot.stigmergy.rows
+        .map((row) => `<tr><th scope="row">${escapeHtml(row.label)}</th><td>${escapeHtml(row.value)}</td></tr>`)
+        .join("\n");
+    const tooltip = snapshot.heatmap.boundsTooltip ?? "";
+    const initialSnapshotScriptPayload = serialiseSnapshotForInlineScript(snapshot);
+    return `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Orchestrateur – Dashboard</title>
+    <style>
+      body { font-family: system-ui, -apple-system, \"Segoe UI\", sans-serif; margin: 0; padding: 24px; background: #0f172a; color: #e2e8f0; }
+      h1, h2, h3 { margin: 0 0 12px; }
+      section { margin-bottom: 32px; padding: 16px 20px; background: #1e293b; border-radius: 12px; box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35); }
+      .metrics-table { border-collapse: collapse; width: 100%; }
+      .metrics-table th { text-align: left; padding: 8px 12px; font-weight: 600; color: #cbd5f5; width: 55%; }
+      .metrics-table td { padding: 8px 12px; color: #e0f2fe; }
+      .metrics-table tr:nth-child(even) { background: rgba(148, 163, 184, 0.1); }
+      .empty-state { margin: 0; padding: 12px 16px; background: rgba(148, 163, 184, 0.15); border-radius: 8px; color: #f8fafc; }
+      .two-columns { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+      .status { margin: 8px 0 0; font-size: 0.95rem; font-weight: 500; }
+      .status--pending { color: #facc15; }
+      .status--connected { color: #4ade80; }
+      .status--error { color: #f87171; }
+      .dashboard-card { min-height: 40px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Orchestrateur – Tableau de bord</h1>
+      <p>Instantané généré le <strong id="dashboard-timestamp">${formatTimestamp(snapshot.timestamp)}</strong>.</p>
+      <p id="connection-status" class="status status--pending" role="status">SSE : initialisation…</p>
+    </header>
+
+    <section aria-labelledby="contract-net-watcher">
+      <h2 id="contract-net-watcher">Contract-Net Watcher</h2>
+      <div class="two-columns">
+        <article>
+          <h3>Résumé</h3>
+          <div id="contract-net-summary" class="dashboard-card" aria-live="polite">
+            ${watcherSummary}
+          </div>
+        </article>
+        <article>
+          <h3>Derniers compteurs</h3>
+          <div id="contract-net-details" class="dashboard-card" aria-live="polite">
+            ${watcherDetails}
+          </div>
+        </article>
+      </div>
+      <article>
+        <h3>Dernières bornes normalisées</h3>
+        <div id="contract-net-bounds" class="dashboard-card" aria-live="polite">
+          ${bounds}
+        </div>
+      </article>
+    </section>
+
+    <section aria-labelledby="stigmergy-summary">
+      <h2 id="stigmergy-summary">Stigmergie</h2>
+      <table class="metrics-table">
+        <tbody id="stigmergy-summary-rows">
+          ${stigSummaryRows}
+        </tbody>
+      </table>
+      <p id="stigmergy-tooltip">${escapeHtml(tooltip)}</p>
+    </section>
+
+    <section aria-labelledby="scheduler-summary">
+      <h2 id="scheduler-summary">Scheduler</h2>
+      <table class="metrics-table">
+        <tbody>
+          <tr><th scope="row">Tick</th><td><span id="scheduler-tick">${snapshot.scheduler.tick}</span></td></tr>
+          <tr><th scope="row">Backlog</th><td><span id="scheduler-backlog">${snapshot.scheduler.backlog}</span></td></tr>
+          <tr><th scope="row">Tâches complétées</th><td><span id="scheduler-completed">${snapshot.scheduler.completed}</span></td></tr>
+          <tr><th scope="row">Tâches en échec</th><td><span id="scheduler-failed">${snapshot.scheduler.failed}</span></td></tr>
+          <tr><th scope="row">Mise à jour</th><td><span id="scheduler-updated-at">${formatTimestamp(snapshot.scheduler.updatedAt)}</span></td></tr>
+        </tbody>
+      </table>
+    </section>
+    <script>
+${buildDashboardBootstrapScript(initialSnapshotScriptPayload)}
+    </script>
+  </body>
+</html>`;
+}
+/** Formats timestamps (epoch milliseconds) into ISO strings or `n/a`. */
+function formatTimestamp(value) {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return "n/a";
+    }
+    try {
+        return new Date(value).toISOString();
+    }
+    catch {
+        return String(value);
+    }
+}
+/** Formats finite numbers with a compact representation for HTML tables. */
+function formatNumber(value) {
+    if (!Number.isFinite(value)) {
+        return "n/a";
+    }
+    if (Math.abs(value) >= 1_000 || Number.isInteger(value)) {
+        return value.toString();
+    }
+    return value.toFixed(3);
+}
+/** Formats nullable numbers, returning `n/a` when no value is available. */
+function formatNullableNumber(value) {
+    return value === null ? "n/a" : formatNumber(value);
+}
+/** Escapes HTML special characters to avoid injection in static strings. */
+function escapeHtml(value) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+/**
+ * Renders a small table (or fallback paragraph) summarising metrics. The
+ * helper is used for the Contract-Net watcher sections so both the server-side
+ * HTML and the client bootstrap share the same layout.
+ */
+function renderMetricsTableHtml(rows, emptyMessage) {
+    if (rows.length === 0) {
+        return `<p class="empty-state">${escapeHtml(emptyMessage)}</p>`;
+    }
+    const renderedRows = rows
+        .map(([label, value]) => `<tr><th scope="row">${escapeHtml(label)}</th><td>${escapeHtml(value)}</td></tr>`)
+        .join("\n");
+    return `<table class="metrics-table"><tbody>${renderedRows}</tbody></table>`;
+}
+/**
+ * Builds the inline dashboard bootstrap script as a pre-indented block. The helper
+ * mostly uses plain string literals and relies on a single template interpolation
+ * to inject the sanitised snapshot so TypeScript treats the browser code as an
+ * opaque string while still embedding data safely.
+*/
+function buildDashboardBootstrapScript(serialisedSnapshot) {
+    const lines = [
+        "(() => {",
+        "  // Inline bootstrap executed in the dashboard context. The script keeps the",
+        "  // HTML view synchronised with the `/stream` SSE endpoint so operators can",
+        "  // observe metrics without refreshing the page. Values are updated using",
+        "  // DOM APIs (textContent/appendChild) to avoid HTML injection concerns.",
+        `  const initialSnapshot = ${serialisedSnapshot};`,
+        "",
+        "  // Updates the textual status banner displayed below the title.",
+        "  const statusElement = document.getElementById(\"connection-status\");",
+        "  function updateStatus(message, variant) {",
+        "    if (!statusElement) {",
+        "      return;",
+        "    }",
+        "    statusElement.textContent = message;",
+        "    statusElement.classList.remove(\"status--pending\", \"status--connected\", \"status--error\");",
+        "    statusElement.classList.add(\"status--\" + variant);",
+        "  }",
+        "",
+        "  // Formats timestamps (epoch milliseconds) into ISO strings or `n/a`.",
+        "  function formatTimestampForClient(value) {",
+        "    if (typeof value !== \"number\" || !Number.isFinite(value)) {",
+        "      return \"n/a\";",
+        "    }",
+        "    try {",
+        "      return new Date(value).toISOString();",
+        "    } catch (error) {",
+        "      console.warn(\"dashboard_timestamp_parse_failure\", error);",
+        "      return String(value);",
+        "    }",
+        "  }",
+        "",
+        "  // Mirrors the server-side formatting logic for compact numbers.",
+        "  function formatNumberForClient(value) {",
+        "    if (!Number.isFinite(value)) {",
+        "      return \"n/a\";",
+        "    }",
+        "    if (Math.abs(value) >= 1000 || Number.isInteger(value)) {",
+        "      return String(value);",
+        "    }",
+        "    return value.toFixed(3);",
+        "  }",
+        "",
+        "  // Formats nullable numbers, returning `n/a` when empty.",
+        "  function formatNullableNumberForClient(value) {",
+        "    return value === null ? \"n/a\" : formatNumberForClient(value);",
+        "  }",
+        "",
+        "  // Renders a metrics table inside the provided container. When no rows are",
+        "  // available the function falls back to an informative empty state.",
+        "  function renderMetricsTable(containerId, rows, emptyMessage) {",
+        "    const container = document.getElementById(containerId);",
+        "    if (!container) {",
+        "      return;",
+        "    }",
+        "    container.textContent = \"\";",
+        "    if (!rows.length) {",
+        "      const empty = document.createElement(\"p\");",
+        "      empty.className = \"empty-state\";",
+        "      empty.textContent = emptyMessage;",
+        "      container.appendChild(empty);",
+        "      return;",
+        "    }",
+        "    const table = document.createElement(\"table\");",
+        "    table.className = \"metrics-table\";",
+        "    const body = document.createElement(\"tbody\");",
+        "    for (const [label, value] of rows) {",
+        "      const tr = document.createElement(\"tr\");",
+        "      const th = document.createElement(\"th\");",
+        "      th.scope = \"row\";",
+        "      th.textContent = label;",
+        "      const td = document.createElement(\"td\");",
+        "      td.textContent = value;",
+        "      tr.appendChild(th);",
+        "      tr.appendChild(td);",
+        "      body.appendChild(tr);",
+        "    }",
+        "    table.appendChild(body);",
+        "    container.appendChild(table);",
+        "  }",
+        "",
+        "  // Updates the Stigmergy summary table and tooltip.",
+        "  function updateStigmergy(snapshot) {",
+        "    const tbody = document.getElementById(\"stigmergy-summary-rows\");",
+        "    if (tbody) {",
+        "      tbody.textContent = \"\";",
+        "      for (const row of snapshot.stigmergy.rows) {",
+        "        const tr = document.createElement(\"tr\");",
+        "        const th = document.createElement(\"th\");",
+        "        th.scope = \"row\";",
+        "        th.textContent = row.label;",
+        "        const td = document.createElement(\"td\");",
+        "        td.textContent = row.value;",
+        "        tr.appendChild(th);",
+        "        tr.appendChild(td);",
+        "        tbody.appendChild(tr);",
+        "      }",
+        "    }",
+        "    const tooltip = document.getElementById(\"stigmergy-tooltip\");",
+        "    if (tooltip) {",
+        "      tooltip.textContent = snapshot.heatmap.boundsTooltip ?? \"\";",
+        "    }",
+        "  }",
+        "",
+        "  // Updates Contract-Net watcher counters and bounds.",
+        "  function updateContractNet(snapshot) {",
+        "    const watcher = snapshot.contractNetWatcherTelemetry;",
+        "    if (!watcher) {",
+        "      renderMetricsTable(\"contract-net-summary\", [], \"Aucune télémétrie Contract-Net disponible.\");",
+        "      renderMetricsTable(\"contract-net-details\", [], \"Aucune télémétrie Contract-Net disponible.\");",
+        "      renderMetricsTable(\"contract-net-bounds\", [], \"Aucune télémétrie Contract-Net disponible.\");",
+        "      return;",
+        "    }",
+        "    renderMetricsTable(",
+        "      \"contract-net-summary\",",
+        "      [",
+        "        [\"Emissions\", formatNumberForClient(watcher.emissions)],",
+        "        [\"Dernier événement\", formatTimestampForClient(watcher.lastEmittedAtMs)],",
+        "      ],",
+        "      \"Aucune télémétrie Contract-Net disponible.\",",
+        "    );",
+        "",
+        "    const snapshotDetails = watcher.lastSnapshot;",
+        "    renderMetricsTable(",
+        "      \"contract-net-details\",",
+        "      snapshotDetails",
+        "        ? [",
+        "            [\"Raison\", snapshotDetails.reason],",
+        "            [\"Notifications reçues\", formatNumberForClient(snapshotDetails.receivedUpdates)],",
+        "            [\"Notifications coalescées\", formatNumberForClient(snapshotDetails.coalescedUpdates)],",
+        "            [\"Rafraîchissements ignorés\", formatNumberForClient(snapshotDetails.skippedRefreshes)],",
+        "            [\"Rafraîchissements appliqués\", formatNumberForClient(snapshotDetails.appliedRefreshes)],",
+        "            [\"Flushs\", formatNumberForClient(snapshotDetails.flushes)],",
+        "          ]",
+        "        : [],",
+        "      snapshotDetails",
+        "        ? \"Le watcher n'a pas encore publié de compteur.\",",
+        "        : \"Aucune télémétrie Contract-Net disponible.\",",
+        "    );",
+        "",
+        "    const bounds = snapshotDetails?.lastBounds;",
+        "    renderMetricsTable(",
+        "      \"contract-net-bounds\",",
+        "      bounds",
+        "        ? [",
+        "            [\"Min intensity\", formatNumberForClient(bounds.min_intensity)],",
+        "            [\"Max intensity\", formatNullableNumberForClient(bounds.max_intensity)],",
+        "            [\"Normalisation ceiling\", formatNumberForClient(bounds.normalisation_ceiling)],",
+        "          ]",
+        "        : [],",
+        "      bounds",
+        "        ? \"Aucune borne normalisée n'a été enregistrée.\",",
+        "        : \"Aucune télémétrie Contract-Net disponible.\",",
+        "    );",
+        "  }",
+        "",
+        "  // Updates scheduler counters embedded in the HTML table.",
+        "  function updateScheduler(snapshot) {",
+        "    const tick = document.getElementById(\"scheduler-tick\");",
+        "    if (tick) {",
+        "      tick.textContent = String(snapshot.scheduler.tick);",
+        "    }",
+        "    const backlog = document.getElementById(\"scheduler-backlog\");",
+        "    if (backlog) {",
+        "      backlog.textContent = String(snapshot.scheduler.backlog);",
+        "    }",
+        "    const completed = document.getElementById(\"scheduler-completed\");",
+        "    if (completed) {",
+        "      completed.textContent = String(snapshot.scheduler.completed);",
+        "    }",
+        "    const failed = document.getElementById(\"scheduler-failed\");",
+        "    if (failed) {",
+        "      failed.textContent = String(snapshot.scheduler.failed);",
+        "    }",
+        "    const updatedAt = document.getElementById(\"scheduler-updated-at\");",
+        "    if (updatedAt) {",
+        "      updatedAt.textContent = formatTimestampForClient(snapshot.scheduler.updatedAt);",
+        "    }",
+        "  }",
+        "",
+        "  // Synchronises the title timestamp with the latest snapshot.",
+        "  function updateHeader(snapshot) {",
+        "    const timestamp = document.getElementById(\"dashboard-timestamp\");",
+        "    if (timestamp) {",
+        "      timestamp.textContent = formatTimestampForClient(snapshot.timestamp);",
+        "    }",
+        "  }",
+        "",
+        "  // Applies the provided snapshot to every dashboard section.",
+        "  function applySnapshot(snapshot) {",
+        "    updateHeader(snapshot);",
+        "    updateContractNet(snapshot);",
+        "    updateStigmergy(snapshot);",
+        "    updateScheduler(snapshot);",
+        "  }",
+        "",
+        "  // Render the initial server-provided snapshot immediately.",
+        "  applySnapshot(initialSnapshot);",
+        "",
+        "  if (typeof window === \"undefined\" || !(\"EventSource\" in window)) {",
+        "    updateStatus(\"Flux SSE non supporté par ce navigateur.\", \"error\");",
+        "    return;",
+        "  }",
+        "",
+        "  updateStatus(\"Connexion SSE en cours…\", \"pending\");",
+        "  const source = new EventSource(\"stream\");",
+        "  source.onopen = () => {",
+        "    updateStatus(\"Flux SSE connecté\", \"connected\");",
+        "  };",
+        "  source.onmessage = (event) => {",
+        "    try {",
+        "      const parsed = JSON.parse(event.data);",
+        "      applySnapshot(parsed);",
+        "    } catch (error) {",
+        "      console.error(\"dashboard_stream_parse_failure\", error);",
+        "      updateStatus(\"Flux SSE : parsing JSON invalide.\", \"error\");",
+        "    }",
+        "  };",
+        "  source.onerror = () => {",
+        "    updateStatus(\"Flux SSE déconnecté – reconnexion automatique…\", \"error\");",
+        "  };",
+        "})();",
+    ];
+    return lines
+        .map((line) => (line.length > 0 ? `      ${line}` : ""))
+        .join("\n");
+}
+/**
+ * Serialises a snapshot for inclusion in the inline dashboard bootstrap. The
+ * payload escapes characters that could prematurely terminate the script tag
+ * (such as `</script>` or U+2028 line separators).
+ */
+function serialiseSnapshotForInlineScript(snapshot) {
+    return JSON.stringify(snapshot)
+        .replace(/</g, "\\u003c")
+        .replace(/>/g, "\\u003e")
+        .replace(/&/g, "\\u0026")
+        .replace(/\u2028/g, "\\u2028")
+        .replace(/\u2029/g, "\\u2029");
 }

--- a/dist/resources/sse.js
+++ b/dist/resources/sse.js
@@ -1,0 +1,98 @@
+import { serialiseForSse } from "../events/sse.js";
+/**
+ * Normalises a run event for transport by switching to `snake_case` keys and
+ * removing `undefined` values. The helper keeps the original payload intact so
+ * downstream tools receive the same structure as `resources_watch`.
+ */
+function normaliseRunEvent(event) {
+    return {
+        type: "run_event",
+        seq: event.seq,
+        ts: event.ts,
+        kind: event.kind,
+        level: event.level,
+        job_id: event.jobId ?? null,
+        run_id: event.runId,
+        op_id: event.opId ?? null,
+        graph_id: event.graphId ?? null,
+        node_id: event.nodeId ?? null,
+        child_id: event.childId ?? null,
+        payload: event.payload ?? null,
+    };
+}
+/**
+ * Normalises a child log entry for SSE transport. Optional fields are coerced to
+ * `null` so JSON serialisation stays stable and consumers can rely on explicit
+ * keys when decoding the stream.
+ */
+function normaliseChildLog(entry) {
+    return {
+        type: "child_log",
+        seq: entry.seq,
+        ts: entry.ts,
+        stream: entry.stream,
+        message: entry.message,
+        job_id: entry.jobId ?? null,
+        run_id: entry.runId ?? null,
+        op_id: entry.opId ?? null,
+        graph_id: entry.graphId ?? null,
+        node_id: entry.nodeId ?? null,
+        child_id: entry.childId,
+        raw: entry.raw ?? null,
+        parsed: entry.parsed ?? null,
+    };
+}
+/**
+ * Builds the JSON payload transported on the SSE `data:` line. The payload
+ * includes the resource URI and `next_seq` pointer so reconnecting clients can
+ * resume a watch operation without additional bookkeeping.
+ */
+function buildPayload(result, record) {
+    return {
+        uri: result.uri,
+        kind: result.kind,
+        next_seq: result.nextSeq,
+        record,
+    };
+}
+/**
+ * Serialises a `resources_watch` page into SSE records. Run events and child log
+ * entries are emitted individually while empty pages produce a keep-alive so the
+ * transport stays active and clients retain the `next_seq` cursor.
+ */
+export function serialiseResourceWatchResultForSse(result) {
+    if (result.events.length === 0) {
+        const keepAlivePayload = buildPayload(result, { type: "keep_alive" });
+        return [
+            {
+                id: `${result.uri}:${result.nextSeq}`,
+                event: "resource_keep_alive",
+                data: serialiseForSse(keepAlivePayload),
+            },
+        ];
+    }
+    return result.events.map((event) => {
+        if (result.kind === "run_events") {
+            const payload = buildPayload(result, normaliseRunEvent(event));
+            return {
+                id: `${result.uri}:${event.seq}`,
+                event: "resource_run_event",
+                data: serialiseForSse(payload),
+            };
+        }
+        const payload = buildPayload(result, normaliseChildLog(event));
+        return {
+            id: `${result.uri}:${event.seq}`,
+            event: "resource_child_log",
+            data: serialiseForSse(payload),
+        };
+    });
+}
+/**
+ * Renders SSE messages into a wire-ready string. Tests and upcoming HTTP
+ * handlers share this helper to keep the framing (`id/event/data` + blank line)
+ * consistent with the other SSE endpoints.
+ */
+export function renderResourceWatchSseMessages(messages) {
+    return messages.map((message) => `id: ${message.id}\nevent: ${message.event}\ndata: ${message.data}\n\n`).join("");
+}

--- a/dist/server.js
+++ b/dist/server.js
@@ -13,7 +13,8 @@ import { EventStore } from "./eventStore.js";
 import { EventBus } from "./events/bus.js";
 import { buildChildCorrelationHints, buildJobCorrelationHints, mergeCorrelationHints, } from "./events/correlation.js";
 import { buildChildCognitiveEvents } from "./events/cognitive.js";
-import { bridgeBlackboardEvents, bridgeCancellationEvents, bridgeConsensusEvents, bridgeContractNetEvents, bridgeValueEvents, bridgeStigmergyEvents, } from "./events/bridges.js";
+import { bridgeBlackboardEvents, bridgeCancellationEvents, bridgeConsensusEvents, bridgeContractNetEvents, bridgeValueEvents, bridgeStigmergyEvents, createContractNetWatcherTelemetryListener, } from "./events/bridges.js";
+import { serialiseForSse } from "./events/sse.js";
 import { startHttpServer } from "./httpServer.js";
 import { startDashboardServer } from "./monitor/dashboard.js";
 import { LogJournal } from "./monitor/log.js";
@@ -31,16 +32,18 @@ import { selectMemoryContext } from "./memory/attention.js";
 import { LoopDetector } from "./guard/loopDetector.js";
 import { BlackboardStore } from "./coord/blackboard.js";
 import { ContractNetCoordinator } from "./coord/contractNet.js";
+import { ContractNetWatcherTelemetryRecorder, watchContractNetPheromoneBounds } from "./coord/contractNetWatchers.js";
 import { StigmergyField } from "./coord/stigmergy.js";
 import { KnowledgeGraph } from "./knowledge/knowledgeGraph.js";
 import { CausalMemory } from "./knowledge/causalMemory.js";
 import { ValueGraph } from "./values/valueGraph.js";
 import { ResourceRegistry, ResourceRegistryError } from "./resources/registry.js";
+import { renderResourceWatchSseMessages, serialiseResourceWatchResultForSse } from "./resources/sse.js";
 import { IdempotencyRegistry } from "./infra/idempotency.js";
-import { PlanLifecycleRegistry } from "./executor/planLifecycle.js";
+import { PlanLifecycleRegistry, PlanRunNotFoundError } from "./executor/planLifecycle.js";
 import { ChildCancelInputShape, ChildCancelInputSchema, ChildCollectInputShape, ChildCollectInputSchema, ChildCreateInputShape, ChildCreateInputSchema, ChildGcInputShape, ChildGcInputSchema, ChildKillInputShape, ChildKillInputSchema, ChildSendInputShape, ChildSendInputSchema, ChildStreamInputShape, ChildStreamInputSchema, ChildStatusInputShape, ChildStatusInputSchema, ChildSpawnCodexInputShape, ChildSpawnCodexInputSchema, ChildBatchCreateInputShape, ChildBatchCreateInputSchema, ChildAttachInputShape, ChildAttachInputSchema, ChildSetRoleInputShape, ChildSetRoleInputSchema, ChildSetLimitsInputShape, ChildSetLimitsInputSchema, handleChildCancel, handleChildCollect, handleChildCreate, handleChildSpawnCodex, handleChildBatchCreate, handleChildAttach, handleChildSetRole, handleChildSetLimits, handleChildGc, handleChildKill, handleChildSend, handleChildStream, handleChildStatus, } from "./tools/childTools.js";
 import { PlanFanoutInputSchema, PlanFanoutInputShape, PlanJoinInputSchema, PlanJoinInputShape, PlanCompileBTInputSchema, PlanCompileBTInputShape, PlanRunBTInputSchema, PlanRunBTInputShape, PlanRunReactiveInputSchema, PlanRunReactiveInputShape, PlanReduceInputSchema, PlanReduceInputShape, PlanDryRunInputSchema, PlanDryRunInputShape, PlanStatusInputSchema, PlanStatusInputShape, PlanPauseInputSchema, PlanPauseInputShape, PlanResumeInputSchema, PlanResumeInputShape, handlePlanFanout, handlePlanJoin, handlePlanCompileBT, handlePlanRunBT, handlePlanRunReactive, handlePlanReduce, handlePlanDryRun, handlePlanStatus, handlePlanPause, handlePlanResume, ValueGuardRejectionError, } from "./tools/planTools.js";
-import { BbGetInputSchema, BbGetInputShape, BbQueryInputSchema, BbQueryInputShape, BbSetInputSchema, BbSetInputShape, BbBatchSetInputSchema, BbBatchSetInputShape, BbWatchInputSchema, BbWatchInputShape, CnpAnnounceInputSchema, CnpAnnounceInputShape, handleBbGet, handleBbBatchSet, handleBbQuery, handleBbSet, handleBbWatch, StigDecayInputSchema, StigDecayInputShape, StigMarkInputSchema, StigMarkInputShape, StigBatchInputSchema, StigBatchInputShape, StigSnapshotInputSchema, StigSnapshotInputShape, handleStigDecay, handleStigMark, handleStigBatch, handleStigSnapshot, handleCnpAnnounce, ConsensusVoteInputSchema, ConsensusVoteInputShape, handleConsensusVote, } from "./tools/coordTools.js";
+import { BbGetInputSchema, BbGetInputShape, BbQueryInputSchema, BbQueryInputShape, BbSetInputSchema, BbSetInputShape, BbBatchSetInputSchema, BbBatchSetInputShape, BbWatchInputSchema, BbWatchInputShape, CnpAnnounceInputSchema, CnpAnnounceInputShape, handleBbGet, handleBbBatchSet, handleBbQuery, handleBbSet, handleBbWatch, StigDecayInputSchema, StigDecayInputShape, StigMarkInputSchema, StigMarkInputShape, StigBatchInputSchema, StigBatchInputShape, StigSnapshotInputSchema, StigSnapshotInputShape, handleStigDecay, handleStigMark, handleStigBatch, handleStigSnapshot, CnpRefreshBoundsInputSchema, CnpRefreshBoundsInputShape, handleCnpRefreshBounds, handleCnpAnnounce, CnpWatcherTelemetryInputSchema, CnpWatcherTelemetryInputShape, handleCnpWatcherTelemetry, ConsensusVoteInputSchema, ConsensusVoteInputShape, handleConsensusVote, } from "./tools/coordTools.js";
 import { requestCancellation, cancelRun, getCancellation } from "./executor/cancel.js";
 import { AgentAutoscaleSetInputSchema, AgentAutoscaleSetInputShape, handleAgentAutoscaleSet, } from "./tools/agentTools.js";
 import { GraphGenerateInputSchema, GraphGenerateInputShape, GraphMutateInputSchema, GraphMutateInputShape, GraphDescriptorSchema, GraphPathsConstrainedInputSchema, GraphPathsConstrainedInputShape, GraphPathsKShortestInputSchema, GraphPathsKShortestInputShape, GraphCentralityBetweennessInputSchema, GraphCentralityBetweennessInputShape, GraphCriticalPathInputSchema, GraphCriticalPathInputShape, GraphOptimizeInputSchema, GraphOptimizeInputShape, GraphOptimizeMooInputSchema, GraphOptimizeMooInputShape, GraphCausalAnalyzeInputSchema, GraphCausalAnalyzeInputShape, GraphRewriteApplyInputSchema, GraphRewriteApplyInputShape, GraphHyperExportInputSchema, GraphHyperExportInputShape, GraphPartitionInputSchema, GraphPartitionInputShape, GraphSummarizeInputSchema, GraphSummarizeInputShape, GraphSimulateInputSchema, GraphSimulateInputShape, GraphValidateInputSchema, GraphValidateInputShape, handleGraphGenerate, handleGraphMutate, handleGraphRewriteApply, handleGraphHyperExport, handleGraphPathsConstrained, handleGraphPathsKShortest, handleGraphCentralityBetweenness, handleGraphCriticalPath, handleGraphOptimize, handleGraphOptimizeMoo, handleGraphCausalAnalyze, handleGraphPartition, handleGraphSummarize, handleGraphSimulate, handleGraphValidate, normaliseGraphPayload, serialiseNormalisedGraph, } from "./tools/graphTools.js";
@@ -77,6 +80,8 @@ const resources = new ResourceRegistry({ blackboard });
 const stigmergy = new StigmergyField();
 /** Shared contract-net coordinator balancing task assignments. */
 const contractNet = new ContractNetCoordinator();
+/** Telemetry recorder tracking automatic Contract-Net bounds refreshes. */
+const contractNetWatcherTelemetry = new ContractNetWatcherTelemetryRecorder();
 /** Registry replaying cached results for idempotent operations. */
 const idempotencyRegistry = new IdempotencyRegistry();
 /** Shared knowledge graph storing reusable plan patterns. */
@@ -316,6 +321,17 @@ let activeLoggerOptions = { ...baseLoggerOptions };
 let logger = instantiateLogger(activeLoggerOptions);
 const eventStore = new EventStore({ maxHistory: 5000, logger });
 const eventBus = new EventBus({ historyLimit: 5000 });
+const contractNetWatcherTelemetryListener = createContractNetWatcherTelemetryListener({
+    bus: eventBus,
+    recorder: contractNetWatcherTelemetry,
+});
+const detachContractNetBoundsWatcher = watchContractNetPheromoneBounds({
+    field: stigmergy,
+    contractNet,
+    logger,
+    onTelemetry: contractNetWatcherTelemetryListener,
+});
+process.once("exit", () => detachContractNetBoundsWatcher());
 // Bridge coordination primitives to the unified event bus so downstream MCP
 // clients can observe blackboard and stigmergic activity without bespoke
 // wiring. The returned disposers are intentionally ignored because the server
@@ -868,7 +884,8 @@ function getPlanToolContext() {
         loopDetector,
         autoscaler: runtimeFeatures.enableAutoscaler ? autoscaler : undefined,
         btStatusRegistry,
-        planLifecycle: runtimeFeatures.enablePlanLifecycle ? planLifecycle : undefined,
+        planLifecycle,
+        planLifecycleFeatureEnabled: runtimeFeatures.enablePlanLifecycle,
         idempotency: runtimeFeatures.enableIdempotency ? idempotencyRegistry : undefined,
     };
 }
@@ -910,6 +927,7 @@ function getCoordinationToolContext() {
         contractNet,
         logger,
         idempotency: runtimeFeatures.enableIdempotency ? idempotencyRegistry : undefined,
+        contractNetWatcherTelemetry,
     };
 }
 function getAgentToolContext() {
@@ -1313,6 +1331,7 @@ const ResourceWatchInputSchema = z
     uri: z.string().min(1),
     from_seq: z.number().int().min(0).optional(),
     limit: z.number().int().positive().max(500).optional(),
+    format: z.enum(["json", "sse"]).optional(),
 })
     .strict();
 const ResourceWatchInputShape = ResourceWatchInputSchema.shape;
@@ -1990,15 +2009,28 @@ server.registerTool("resources_watch", {
             fromSeq: parsed.from_seq,
             limit: parsed.limit,
         });
-        const structured = {
+        const format = parsed.format ?? "json";
+        const baseStructured = {
             uri: result.uri,
             kind: result.kind,
             events: result.events,
             next_seq: result.nextSeq,
+            format,
         };
+        if (format === "sse") {
+            // Convert each record to a single-line SSE payload so streaming transports remain
+            // resilient when cancellation reasons or log lines contain control characters.
+            const messages = serialiseResourceWatchResultForSse(result);
+            const stream = renderResourceWatchSseMessages(messages);
+            const structured = { ...baseStructured, stream, messages };
+            return {
+                content: [{ type: "text", text: j({ tool: "resources_watch", result: structured }) }],
+                structuredContent: structured,
+            };
+        }
         return {
-            content: [{ type: "text", text: j({ tool: "resources_watch", result: structured }) }],
-            structuredContent: structured,
+            content: [{ type: "text", text: j({ tool: "resources_watch", result: baseStructured }) }],
+            structuredContent: baseStructured,
         };
     }
     catch (error) {
@@ -2053,7 +2085,7 @@ server.registerTool("events_subscribe", {
         const format = parsed.format ?? "jsonlines";
         const stream = format === "sse"
             ? serialised
-                .map((evt) => [`id: ${evt.seq}`, `event: ${evt.cat}`, `data: ${JSON.stringify(evt)}`, ``].join("\n"))
+                .map((evt) => [`id: ${evt.seq}`, `event: ${evt.cat}`, `data: ${serialiseForSse(evt)}`, ``].join("\n"))
                 .join("\n")
             : serialised.map((evt) => JSON.stringify(evt)).join("\n");
         const nextSeq = events.length ? events[events.length - 1].seq : parsed.from_seq ?? null;
@@ -4130,6 +4162,9 @@ server.registerTool("op_cancel", {
         const parsed = OpCancelInputSchema.parse(input);
         const outcome = requestCancellation(parsed.op_id, { reason: parsed.reason ?? null });
         const handle = getCancellation(parsed.op_id);
+        const lifecycleSnapshot = handle?.runId != null
+            ? tryGetPlanLifecycleSnapshot(handle.runId, logger, "op_cancel_lifecycle_snapshot_failed")
+            : null;
         // Surface the correlation metadata recorded when the operation was
         // registered so observers can link cancellation requests to plan
         // lifecycle artefacts.
@@ -4142,6 +4177,8 @@ server.registerTool("op_cancel", {
             graph_id: handle?.graphId ?? null,
             node_id: handle?.nodeId ?? null,
             child_id: handle?.childId ?? null,
+            progress: lifecycleSnapshot?.progress ?? null,
+            lifecycle: lifecycleSnapshot,
         };
         logger.info("op_cancel", result);
         return {
@@ -4176,13 +4213,24 @@ server.registerTool("plan_cancel", {
             child_id: operation.childId,
         }));
         const reason = parsed.reason ?? null;
+        // Surface the lifecycle snapshot (state, progress, failure details) when
+        // the plan registry is enabled so MCP clients do not need to issue an
+        // immediate follow-up `plan_status` call after cancelling a run.
+        const lifecycleSnapshot = tryGetPlanLifecycleSnapshot(parsed.run_id, logger, "plan_cancel_lifecycle_snapshot_failed");
         logger.info("plan_cancel", {
             run_id: parsed.run_id,
             reason,
             affected: serialisedOperations.length,
             operations: serialisedOperations,
+            progress: lifecycleSnapshot?.progress ?? null,
         });
-        const result = { run_id: parsed.run_id, reason, operations: serialisedOperations };
+        const result = {
+            run_id: parsed.run_id,
+            reason,
+            operations: serialisedOperations,
+            progress: lifecycleSnapshot?.progress ?? null,
+            lifecycle: lifecycleSnapshot,
+        };
         return {
             content: [{ type: "text", text: j({ tool: "plan_cancel", result }) }],
             structuredContent: result,
@@ -4370,6 +4418,41 @@ server.registerTool("cnp_announce", {
     }
     catch (error) {
         return coordinationToolError("cnp_announce", error);
+    }
+});
+server.registerTool("cnp_refresh_bounds", {
+    title: "Contract-Net refresh bounds",
+    description: "Met à jour les bornes de phéromones d'un appel Contract-Net ouvert.",
+    inputSchema: CnpRefreshBoundsInputShape,
+}, async (input) => {
+    try {
+        pruneExpired();
+        const parsed = CnpRefreshBoundsInputSchema.parse(input);
+        const result = handleCnpRefreshBounds(getCoordinationToolContext(), parsed);
+        return {
+            content: [{ type: "text", text: j({ tool: "cnp_refresh_bounds", result }) }],
+            structuredContent: result,
+        };
+    }
+    catch (error) {
+        return coordinationToolError("cnp_refresh_bounds", error);
+    }
+});
+server.registerTool("cnp_watcher_telemetry", {
+    title: "Contract-Net watcher telemetry",
+    description: "Expose les compteurs du watcher de bornes Contract-Net (rafraîchissements auto).",
+    inputSchema: CnpWatcherTelemetryInputShape,
+}, async (input) => {
+    try {
+        const parsed = CnpWatcherTelemetryInputSchema.parse(input);
+        const result = handleCnpWatcherTelemetry(getCoordinationToolContext(), parsed);
+        return {
+            content: [{ type: "text", text: j({ tool: "cnp_watcher_telemetry", result }) }],
+            structuredContent: result,
+        };
+    }
+    catch (error) {
+        return coordinationToolError("cnp_watcher_telemetry", error);
     }
 });
 server.registerTool("consensus_vote", {
@@ -5372,6 +5455,7 @@ if (isMain) {
                 btStatusRegistry,
                 supervisorAgent: orchestratorSupervisor,
                 logger,
+                contractNetWatcherTelemetry,
             });
             cleanup.push(handle.close);
         }
@@ -5403,4 +5487,27 @@ if (isMain) {
         process.exit(0);
     });
 }
-export { server, graphState, childSupervisor, logJournal, DEFAULT_CHILD_RUNTIME, buildLiveEvents, setDefaultChildRuntime, GraphSubgraphExtractInputSchema, GraphSubgraphExtractInputShape, emitHeartbeatTick, stopHeartbeat, };
+export { server, graphState, childSupervisor, resources, logJournal, DEFAULT_CHILD_RUNTIME, buildLiveEvents, setDefaultChildRuntime, GraphSubgraphExtractInputSchema, GraphSubgraphExtractInputShape, emitHeartbeatTick, stopHeartbeat, };
+/**
+ * Helper returning the latest lifecycle snapshot associated with the provided run identifier.
+ * The lookup is guarded by the feature toggle so cancellation tools can call the helper without
+ * duplicating defensive checks or log plumbing in every handler.
+ */
+function tryGetPlanLifecycleSnapshot(runId, logger, logEvent) {
+    if (!runtimeFeatures.enablePlanLifecycle) {
+        return null;
+    }
+    try {
+        return planLifecycle.getSnapshot(runId);
+    }
+    catch (error) {
+        if (error instanceof PlanRunNotFoundError) {
+            return null;
+        }
+        logger.warn(logEvent, {
+            run_id: runId,
+            message: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+    }
+}

--- a/src/agents/autoscaler.ts
+++ b/src/agents/autoscaler.ts
@@ -147,6 +147,9 @@ const DEFAULT_THRESHOLDS: AutoscalerThresholds = {
  * period to avoid oscillations.
  */
 export class Autoscaler implements LoopReconciler {
+  /** Identifier surfaced in execution loop diagnostics and lifecycle events. */
+  public readonly id = "autoscaler";
+
   private readonly supervisor: AutoscalerSupervisor;
   private readonly logger?: StructuredLogger;
   private readonly now: () => number;

--- a/src/agents/supervisor.ts
+++ b/src/agents/supervisor.ts
@@ -71,6 +71,9 @@ export interface OrchestratorSupervisorOptions {
  * so it can be registered alongside the autoscaler inside the execution loop.
  */
 export class OrchestratorSupervisor implements LoopReconciler {
+  /** Identifier surfaced in execution loop diagnostics and lifecycle events. */
+  public readonly id = "supervisor";
+
   private readonly childManager: SupervisorChildManager;
   private readonly logger?: StructuredLogger;
   private readonly actions: Required<SupervisorActions>;

--- a/src/coord/contractNetWatchers.ts
+++ b/src/coord/contractNetWatchers.ts
@@ -1,0 +1,312 @@
+import { ContractNetCoordinator, type ContractNetPheromoneBounds } from "./contractNet.js";
+import { StigmergyField } from "./stigmergy.js";
+import { StructuredLogger } from "../logger.js";
+
+/**
+ * Options consumed when synchronising Contract-Net calls with the latest
+ * stigmergic bounds. The watcher reacts to every change reported by the
+ * {@link StigmergyField} and transparently refreshes heuristic bids so
+ * operators do not have to trigger manual updates.
+ */
+export interface ContractNetPheromoneWatcherOptions {
+  /** Stigmergic field emitting intensity changes. */
+  field: StigmergyField;
+  /** Contract-Net coordinator holding the calls to refresh. */
+  contractNet: ContractNetCoordinator;
+  /** Optional structured logger used for observability. */
+  logger?: StructuredLogger;
+  /**
+   * When true (default), the watcher reissues heuristic bids so the refreshed
+   * snapshots line up with the latest pheromone pressure.
+   */
+  refreshAutoBids?: boolean;
+  /**
+   * Controls whether agents registered after the call announcement should be
+   * invited to submit heuristic bids during an automatic refresh. Defaults to
+   * true so newly available workers participate in the auction.
+   */
+  includeNewAgents?: boolean;
+  /**
+   * Duration (milliseconds) used to coalesce successive stigmergy updates
+   * before refreshing every open call. Defaults to `50ms`, providing enough
+   * time for bursts of pheromone updates (e.g. batch marks) to settle while
+   * still keeping the Contract-Net snapshots fresh. Setting the value to `0`
+   * disables coalescing and forces immediate refreshes, matching the historic
+   * behaviour.
+   */
+  coalesceWindowMs?: number;
+  /**
+   * Optional telemetry sink invoked whenever the watcher refreshes or skips a
+   * batch of Contract-Net calls. The callback receives cumulative counters so
+   * operators can observe how often updates are coalesced or short-circuited.
+   */
+  onTelemetry?: (snapshot: ContractNetWatcherTelemetrySnapshot) => void;
+}
+
+/**
+ * Aggregated counters emitted whenever the watcher performs a refresh cycle or
+ * detaches. The fields capture both the raw number of stigmergy updates and the
+ * amount of work suppressed by the coalescing window.
+ */
+export interface ContractNetWatcherTelemetrySnapshot {
+  /**
+   * Reason that triggered the telemetry emission. Useful to distinguish the
+   * initial prime, subsequent flushes, and the final snapshot collected when
+   * the watcher is detached.
+   */
+  readonly reason: "initial" | "flush" | "detach";
+  /** Total number of change notifications received from the stigmergy field. */
+  readonly receivedUpdates: number;
+  /**
+   * Number of notifications that landed while a coalescing timer was pending
+   * and therefore did not trigger an immediate refresh.
+   */
+  readonly coalescedUpdates: number;
+  /**
+   * Number of flush attempts skipped because the resolved bounds did not
+   * change. This helps quantify how often the watcher avoided unnecessary
+   * Contract-Net refreshes.
+   */
+  readonly skippedRefreshes: number;
+  /**
+   * Number of refresh operations that actually called
+   * {@link ContractNetCoordinator.updateCallPheromoneBounds}. Each refresh may
+   * still choose to refresh zero calls if none are open.
+   */
+  readonly appliedRefreshes: number;
+  /** Count of flushes that resolved new bounds regardless of open call count. */
+  readonly flushes: number;
+  /** Last bounds applied by the watcher (mirrors the coordinator snapshots). */
+  readonly lastBounds: ContractNetPheromoneBounds | null;
+}
+
+/**
+ * Snapshot returned by {@link ContractNetWatcherTelemetryRecorder} aggregating
+ * the latest watcher counters and some metadata about the emission cadence.
+ */
+export interface ContractNetWatcherTelemetryState {
+  /**
+   * Number of telemetry emissions recorded since the watcher was started. The
+   * initial prime counts as the first emission.
+   */
+  readonly emissions: number;
+  /**
+   * Epoch millisecond timestamp captured when the last snapshot was recorded.
+   * `null` indicates that no telemetry has been observed yet.
+   */
+  readonly lastEmittedAtMs: number | null;
+  /** Latest watcher counters, or `null` when nothing has been recorded. */
+  readonly lastSnapshot: ContractNetWatcherTelemetrySnapshot | null;
+}
+
+/**
+ * Collector recording the latest Contract-Net bounds watcher telemetry. The
+ * recorder stores cumulative counters and the timestamp of the last emission so
+ * MCP tools can surface up-to-date diagnostics without holding a reference to
+ * the watcher itself.
+ */
+export class ContractNetWatcherTelemetryRecorder {
+  private lastSnapshot: ContractNetWatcherTelemetrySnapshot | null = null;
+  private emissions = 0;
+  private lastEmittedAtMs: number | null = null;
+
+  constructor(private readonly now: () => number = () => Date.now()) {}
+
+  /** Records a new watcher snapshot and updates the aggregated metadata. */
+  record(snapshot: ContractNetWatcherTelemetrySnapshot): void {
+    this.lastSnapshot = {
+      ...snapshot,
+      lastBounds: snapshot.lastBounds ? { ...snapshot.lastBounds } : null,
+    };
+    this.emissions += 1;
+    this.lastEmittedAtMs = this.now();
+  }
+
+  /** Clears the aggregated counters, useful when restarting the watcher. */
+  reset(): void {
+    this.lastSnapshot = null;
+    this.emissions = 0;
+    this.lastEmittedAtMs = null;
+  }
+
+  /** Returns the most recent watcher telemetry alongside emission metadata. */
+  snapshot(): ContractNetWatcherTelemetryState {
+    return {
+      emissions: this.emissions,
+      lastEmittedAtMs: this.lastEmittedAtMs,
+      lastSnapshot: this.lastSnapshot
+        ? {
+            ...this.lastSnapshot,
+            lastBounds: this.lastSnapshot.lastBounds ? { ...this.lastSnapshot.lastBounds } : null,
+          }
+        : null,
+    };
+  }
+}
+
+/**
+ * Subscribes to stigmergy updates and refreshes the pheromone bounds of every
+ * open Contract-Net call whenever the normalisation ceiling changes.
+ */
+export function watchContractNetPheromoneBounds(options: ContractNetPheromoneWatcherOptions): () => void {
+  const {
+    field,
+    contractNet,
+    logger,
+    refreshAutoBids = true,
+    includeNewAgents = true,
+    coalesceWindowMs = 50,
+    onTelemetry,
+  } = options;
+  if (!Number.isFinite(coalesceWindowMs) || coalesceWindowMs < 0) {
+    throw new Error("coalesceWindowMs must be a finite number greater than or equal to 0");
+  }
+  let lastBounds: ContractNetPheromoneBounds | null = null;
+  let flushTimer: NodeJS.Timeout | null = null;
+  let pendingDirty = false;
+  let receivedUpdates = 0;
+  let coalescedUpdates = 0;
+  let skippedRefreshes = 0;
+  let appliedRefreshes = 0;
+  let flushes = 0;
+
+  const emitTelemetry = (reason: ContractNetWatcherTelemetrySnapshot["reason"]): void => {
+    if (!onTelemetry && !logger) {
+      return;
+    }
+    const snapshot: ContractNetWatcherTelemetrySnapshot = {
+      reason,
+      receivedUpdates,
+      coalescedUpdates,
+      skippedRefreshes,
+      appliedRefreshes,
+      flushes,
+      lastBounds: lastBounds ? { ...lastBounds } : null,
+    };
+    onTelemetry?.(snapshot);
+    logger?.debug?.("contract_net_bounds_watcher_telemetry", {
+      reason,
+      received_updates: snapshot.receivedUpdates,
+      coalesced_updates: snapshot.coalescedUpdates,
+      skipped_refreshes: snapshot.skippedRefreshes,
+      applied_refreshes: snapshot.appliedRefreshes,
+      last_bounds: snapshot.lastBounds,
+    });
+  };
+
+  const captureBounds = (): ContractNetPheromoneBounds | null => {
+    const snapshot = field.getIntensityBounds();
+    return {
+      min_intensity: snapshot.minIntensity,
+      max_intensity: Number.isFinite(snapshot.maxIntensity) ? snapshot.maxIntensity : null,
+      normalisation_ceiling: snapshot.normalisationCeiling,
+    };
+  };
+
+  const refreshOpenCalls = (bounds: ContractNetPheromoneBounds | null): void => {
+    const openCalls = contractNet.listOpenCalls();
+    if (openCalls.length === 0) {
+      return;
+    }
+    appliedRefreshes += 1;
+    for (const call of openCalls) {
+      try {
+        const result = contractNet.updateCallPheromoneBounds(call.callId, bounds, {
+          refreshAutoBids,
+          includeNewAgents,
+        });
+        logger?.info("contract_net_auto_bounds_refresh", {
+          call_id: call.callId,
+          refreshed_agents: result.refreshedAgents.length,
+          auto_bid_refreshed: result.autoBidRefreshed,
+          bounds: result.pheromoneBounds,
+        });
+      } catch (error) {
+        logger?.warn("contract_net_auto_bounds_refresh_failed", {
+          call_id: call.callId,
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  };
+
+  const flush = (reason: "flush" | "detach"): void => {
+    const shouldProcess = pendingDirty;
+    pendingDirty = false;
+    if (!shouldProcess) {
+      if (reason === "detach") {
+        emitTelemetry("detach");
+      }
+      return;
+    }
+    const bounds = captureBounds();
+    if (boundsEqual(bounds, lastBounds)) {
+      skippedRefreshes += 1;
+      emitTelemetry(reason);
+      return;
+    }
+    lastBounds = bounds ? { ...bounds } : null;
+    flushes += 1;
+    refreshOpenCalls(lastBounds ? { ...lastBounds } : null);
+    emitTelemetry(reason);
+  };
+
+  const scheduleRefresh = (): void => {
+    pendingDirty = true;
+    if (coalesceWindowMs === 0) {
+      flush("flush");
+      return;
+    }
+    if (flushTimer) {
+      coalescedUpdates += 1;
+      return;
+    }
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      flush("flush");
+    }, coalesceWindowMs);
+    flushTimer.unref?.();
+  };
+
+  const listener = (): void => {
+    receivedUpdates += 1;
+    scheduleRefresh();
+  };
+
+  // Prime the watcher so calls announced before the subscription stays aligned.
+  lastBounds = captureBounds();
+  refreshOpenCalls(lastBounds ? { ...lastBounds } : null);
+  emitTelemetry("initial");
+
+  const detach = field.onChange(listener);
+  return () => {
+    detach();
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+    flush("detach");
+  };
+}
+
+function boundsEqual(
+  a: ContractNetPheromoneBounds | null,
+  b: ContractNetPheromoneBounds | null,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    almostEqual(a.min_intensity, b.min_intensity) &&
+    ((a.max_intensity === null && b.max_intensity === null) ||
+      (a.max_intensity !== null && b.max_intensity !== null && almostEqual(a.max_intensity, b.max_intensity))) &&
+    almostEqual(a.normalisation_ceiling, b.normalisation_ceiling)
+  );
+}
+
+function almostEqual(a: number, b: number): boolean {
+  return Math.abs(a - b) <= 1e-6;
+}

--- a/src/coord/stigmergy.ts
+++ b/src/coord/stigmergy.ts
@@ -23,6 +23,12 @@ const EPSILON = 1e-6;
 export interface StigmergyFieldOptions {
   /** Custom clock leveraged to keep tests deterministic. Defaults to {@link Date.now}. */
   now?: () => number;
+  /** Default half-life (ms) applied by {@link StigmergyField.evaporate} when callers omit an explicit value. */
+  defaultHalfLifeMs?: number;
+  /** Minimum intensity kept in the field; lower values evaporate immediately. Defaults to `0`. */
+  minIntensity?: number;
+  /** Maximum intensity allowed per pheromone entry. Defaults to `Infinity`. */
+  maxIntensity?: number;
 }
 
 /** Snapshot representing the intensity of a specific pheromone type on a node. */
@@ -69,6 +75,79 @@ export interface StigmergyFieldSnapshot {
   totals: StigmergyTotalSnapshot[];
 }
 
+/**
+ * Bounds describing the configured intensity range and the effective ceiling
+ * currently observed in the field. Consumers combine these values to
+ * normalise pheromone data (e.g. for dashboards or scheduling telemetry).
+ */
+export interface StigmergyIntensityBounds {
+  /** Lower bound applied when clamping pheromone intensities. */
+  minIntensity: number;
+  /** Upper bound applied when clamping pheromone intensities (Infinity when unbounded). */
+  maxIntensity: number;
+  /**
+   * Effective ceiling used for normalisation. Falls back to the configured
+   * upper bound or the highest observed total intensity.
+   */
+  normalisationCeiling: number;
+}
+
+/**
+ * Normalised representation surfaced to telemetry consumers. Using explicit
+ * snake_case keys mirrors the structures returned by tools and lifecycle
+ * events while keeping Infinity values predictable (`null`).
+ */
+export interface NormalisedPheromoneBounds {
+  min_intensity: number;
+  max_intensity: number | null;
+  normalisation_ceiling: number;
+}
+
+/**
+ * Converts arbitrary pheromone bounds (either scheduler or stigmergy derived)
+ * into a serialisable structure suitable for logs, events, or API responses.
+ * When the upper bound is unbounded (`Infinity`) the helper returns `null`
+ * instead so JSON consumers do not have to special-case the value.
+ */
+export function normalisePheromoneBoundsForTelemetry(
+  bounds: { minIntensity: number; maxIntensity: number; normalisationCeiling: number } | null | undefined,
+): NormalisedPheromoneBounds | null {
+  if (!bounds) {
+    return null;
+  }
+  return {
+    min_intensity: bounds.minIntensity,
+    max_intensity: Number.isFinite(bounds.maxIntensity) ? bounds.maxIntensity : null,
+    normalisation_ceiling: bounds.normalisationCeiling,
+  };
+}
+
+/** Normalised contribution for a single pheromone type. */
+export interface StigmergyHeatmapPoint {
+  nodeId: string;
+  type: string;
+  intensity: number;
+  normalised: number;
+  updatedAt: number;
+}
+
+/** Aggregated heatmap cell for a node combining every pheromone type. */
+export interface StigmergyHeatmapCell {
+  nodeId: string;
+  totalIntensity: number;
+  normalised: number;
+  updatedAt: number;
+  points: StigmergyHeatmapPoint[];
+}
+
+/** Snapshot tailored for heatmap consumers (dashboards, exporters, ...). */
+export interface StigmergyHeatmapSnapshot {
+  generatedAt: number;
+  minIntensity: number;
+  maxIntensity: number;
+  cells: StigmergyHeatmapCell[];
+}
+
 interface StigmergyEntry {
   nodeId: string;
   type: string;
@@ -94,9 +173,33 @@ export class StigmergyField {
   private readonly totals = new Map<string, NodeTotal>();
   private readonly emitter = new EventEmitter();
   private readonly now: () => number;
+  private readonly defaultHalfLifeMs?: number;
+  private readonly minIntensity: number;
+  private readonly maxIntensity: number;
+  private readonly evictionThreshold: number;
 
   constructor(options: StigmergyFieldOptions = {}) {
     this.now = options.now ?? (() => Date.now());
+    if (options.defaultHalfLifeMs !== undefined && (!Number.isFinite(options.defaultHalfLifeMs) || options.defaultHalfLifeMs <= 0)) {
+      throw new Error("defaultHalfLifeMs must be a positive finite number when provided");
+    }
+    if (options.minIntensity !== undefined && (!Number.isFinite(options.minIntensity) || options.minIntensity < 0)) {
+      throw new Error("minIntensity must be a finite number greater than or equal to 0");
+    }
+    if (options.maxIntensity !== undefined && (!Number.isFinite(options.maxIntensity) || options.maxIntensity <= 0)) {
+      throw new Error("maxIntensity must be a positive finite number when provided");
+    }
+
+    const min = options.minIntensity ?? 0;
+    const max = options.maxIntensity ?? Number.POSITIVE_INFINITY;
+    if (max <= min) {
+      throw new Error("maxIntensity must be greater than minIntensity");
+    }
+
+    this.defaultHalfLifeMs = options.defaultHalfLifeMs;
+    this.minIntensity = min;
+    this.maxIntensity = max;
+    this.evictionThreshold = EPSILON;
   }
 
   /** Adds pheromone to the field and returns the updated point snapshot. */
@@ -107,18 +210,13 @@ export class StigmergyField {
     const normalisedType = normaliseType(type);
     const timestamp = this.now();
     const key = this.makeKey(nodeId, normalisedType);
-    const existing = this.entries.get(key);
-    const previousIntensity = existing?.intensity ?? 0;
-    const nextIntensity = previousIntensity + intensity;
-    const entry: StigmergyEntry = {
+    const { snapshot, total } = this.applyEntryMutation({
       nodeId,
       type: normalisedType,
-      intensity: nextIntensity,
-      updatedAt: timestamp,
-    };
-    this.entries.set(key, entry);
-    const total = this.adjustTotal(nodeId, nextIntensity - previousIntensity, timestamp);
-    const snapshot = this.cloneEntry(entry);
+      delta: intensity,
+      timestamp,
+      key,
+    });
     this.emitChange({
       nodeId,
       type: normalisedType,
@@ -159,18 +257,13 @@ export class StigmergyField {
         const normalisedType = normaliseType(payload.type);
         const timestamp = this.now();
         const key = this.makeKey(payload.nodeId, normalisedType);
-        const existing = this.entries.get(key);
-        const previousIntensity = existing?.intensity ?? 0;
-        const nextIntensity = previousIntensity + payload.intensity;
-        const entry: StigmergyEntry = {
+        const { snapshot, total } = this.applyEntryMutation({
           nodeId: payload.nodeId,
           type: normalisedType,
-          intensity: nextIntensity,
-          updatedAt: timestamp,
-        };
-        this.entries.set(key, entry);
-        const total = this.adjustTotal(payload.nodeId, nextIntensity - previousIntensity, timestamp);
-        const snapshot = this.cloneEntry(entry);
+          delta: payload.intensity,
+          timestamp,
+          key,
+        });
         results.push({ point: snapshot, nodeTotal: { nodeId: payload.nodeId, intensity: total.intensity, updatedAt: total.updatedAt } });
         events.push({
           nodeId: payload.nodeId,
@@ -205,8 +298,12 @@ export class StigmergyField {
    * field. The method returns the list of points that changed so callers can
    * propagate updates.
    */
-  evaporate(halfLifeMs: number): StigmergyChangeEvent[] {
-    if (!Number.isFinite(halfLifeMs) || halfLifeMs <= 0) {
+  evaporate(halfLifeMs?: number): StigmergyChangeEvent[] {
+    const effectiveHalfLife = halfLifeMs ?? this.defaultHalfLifeMs;
+    if (effectiveHalfLife === undefined) {
+      throw new Error("halfLifeMs must be provided when no defaultHalfLifeMs is configured");
+    }
+    if (!Number.isFinite(effectiveHalfLife) || effectiveHalfLife <= 0) {
       throw new Error("halfLifeMs must be a positive finite number");
     }
     const timestamp = this.now();
@@ -218,16 +315,16 @@ export class StigmergyField {
         entry.updatedAt = timestamp;
         continue;
       }
-      const decayFactor = Math.pow(0.5, elapsed / halfLifeMs);
+      const decayFactor = Math.pow(0.5, elapsed / effectiveHalfLife);
       const decayed = entry.intensity * decayFactor;
-      const nextIntensity = decayed <= EPSILON ? 0 : decayed;
+      const nextIntensity = decayed <= this.evictionThreshold ? 0 : this.clampIntensity(decayed);
       const delta = nextIntensity - entry.intensity;
       if (Math.abs(delta) <= EPSILON) {
         entry.updatedAt = timestamp;
         continue;
       }
 
-      if (nextIntensity <= EPSILON) {
+      if (nextIntensity <= this.evictionThreshold) {
         this.entries.delete(key);
       } else {
         entry.intensity = nextIntensity;
@@ -258,6 +355,21 @@ export class StigmergyField {
     return { nodeId, intensity: total.intensity, updatedAt: total.updatedAt };
   }
 
+  /**
+   * Exposes the configured intensity bounds alongside the current
+   * normalisation ceiling so downstream consumers can map pheromones to a
+   * fixed scale without duplicating the field's logic.
+   */
+  getIntensityBounds(): StigmergyIntensityBounds {
+    const intensities = [...this.totals.values()].map((total) => total.intensity);
+    const normalisationCeiling = this.resolveNormalisationCeiling(intensities);
+    return {
+      minIntensity: this.minIntensity,
+      maxIntensity: this.maxIntensity,
+      normalisationCeiling,
+    };
+  }
+
   /** Produces a deterministic snapshot of the entire field for diagnostics. */
   fieldSnapshot(): StigmergyFieldSnapshot {
     const generatedAt = this.now();
@@ -280,6 +392,73 @@ export class StigmergyField {
     return { generatedAt, points, totals };
   }
 
+  /** Builds a heatmap-friendly snapshot aggregating intensities per node and type. */
+  heatmapSnapshot(): StigmergyHeatmapSnapshot {
+    const generatedAt = this.now();
+    const totals: Map<string, { intensity: number; updatedAt: number }> = new Map();
+    const contributions: Map<string, StigmergyEntry[]> = new Map();
+
+    for (const entry of this.entries.values()) {
+      const pointBucket = contributions.get(entry.nodeId) ?? [];
+      pointBucket.push(entry);
+      contributions.set(entry.nodeId, pointBucket);
+
+      const total = totals.get(entry.nodeId);
+      if (!total) {
+        totals.set(entry.nodeId, { intensity: entry.intensity, updatedAt: entry.updatedAt });
+      } else {
+        total.intensity += entry.intensity;
+        if (entry.updatedAt > total.updatedAt) {
+          total.updatedAt = entry.updatedAt;
+        }
+      }
+    }
+
+    const intensities = [...totals.values()].map((total) => total.intensity);
+    const normalisationCeiling = this.resolveNormalisationCeiling(intensities);
+
+    const cells: StigmergyHeatmapCell[] = [];
+    for (const [nodeId, total] of totals.entries()) {
+      const rawPoints = contributions.get(nodeId) ?? [];
+      const points = rawPoints
+        .map<StigmergyHeatmapPoint>((entry) => ({
+          nodeId: entry.nodeId,
+          type: entry.type,
+          intensity: entry.intensity,
+          normalised: this.normaliseIntensity(entry.intensity, normalisationCeiling),
+          updatedAt: entry.updatedAt,
+        }))
+        .sort((a, b) => {
+          if (b.intensity === a.intensity) {
+            return a.type.localeCompare(b.type);
+          }
+          return b.intensity - a.intensity;
+        });
+      const cell: StigmergyHeatmapCell = {
+        nodeId,
+        totalIntensity: total.intensity,
+        normalised: this.normaliseIntensity(total.intensity, normalisationCeiling),
+        updatedAt: total.updatedAt,
+        points,
+      };
+      cells.push(cell);
+    }
+
+    cells.sort((a, b) => {
+      if (b.totalIntensity === a.totalIntensity) {
+        return a.nodeId.localeCompare(b.nodeId);
+      }
+      return b.totalIntensity - a.totalIntensity;
+    });
+
+    return {
+      generatedAt,
+      minIntensity: this.minIntensity,
+      maxIntensity: normalisationCeiling,
+      cells,
+    };
+  }
+
   /** Registers a listener invoked for every mutation of the field. */
   onChange(listener: StigmergyChangeListener): () => void {
     this.emitter.on("change", listener);
@@ -294,12 +473,13 @@ export class StigmergyField {
 
   private adjustTotal(nodeId: string, delta: number, timestamp: number): NodeTotal {
     const current = this.totals.get(nodeId) ?? { intensity: 0, updatedAt: timestamp };
-    const nextIntensity = Math.max(0, current.intensity + delta);
-    if (nextIntensity <= EPSILON) {
+    const nextIntensity = current.intensity + delta;
+    if (nextIntensity <= this.evictionThreshold) {
       this.totals.delete(nodeId);
       return { intensity: 0, updatedAt: timestamp };
     }
-    const updated: NodeTotal = { intensity: nextIntensity, updatedAt: timestamp };
+    const clamped = Math.min(this.maxIntensity, nextIntensity);
+    const updated: NodeTotal = { intensity: clamped, updatedAt: timestamp };
     this.totals.set(nodeId, updated);
     return updated;
   }
@@ -311,6 +491,69 @@ export class StigmergyField {
   private makeKey(nodeId: string, type: string): string {
     return `${nodeId}::${type}`;
   }
+
+  private applyEntryMutation(payload: {
+    nodeId: string;
+    type: string;
+    key: string;
+    delta: number;
+    timestamp: number;
+  }): { snapshot: StigmergyPointSnapshot; total: NodeTotal } {
+    const existing = this.entries.get(payload.key);
+    const previousIntensity = existing?.intensity ?? 0;
+    const nextRaw = previousIntensity + payload.delta;
+    const clamped = this.clampIntensity(nextRaw);
+    const finalIntensity = clamped <= this.evictionThreshold ? 0 : clamped;
+    const delta = finalIntensity - previousIntensity;
+
+    if (finalIntensity <= this.evictionThreshold) {
+      this.entries.delete(payload.key);
+    } else {
+      const entry: StigmergyEntry = {
+        nodeId: payload.nodeId,
+        type: payload.type,
+        intensity: finalIntensity,
+        updatedAt: payload.timestamp,
+      };
+      this.entries.set(payload.key, entry);
+    }
+
+    const total = this.adjustTotal(payload.nodeId, delta, payload.timestamp);
+    const snapshot = finalIntensity <= this.evictionThreshold
+      ? { nodeId: payload.nodeId, type: payload.type, intensity: 0, updatedAt: payload.timestamp }
+      : this.cloneEntry(this.entries.get(payload.key)!);
+    return { snapshot, total };
+  }
+
+  private clampIntensity(value: number): number {
+    return Math.min(this.maxIntensity, Math.max(0, value));
+  }
+
+  private normaliseIntensity(value: number, ceiling: number): number {
+    const effectiveMax = ceiling;
+    const span = effectiveMax - this.minIntensity;
+    if (!Number.isFinite(span) || span <= 0) {
+      return value > this.minIntensity ? 1 : 0;
+    }
+    if (value <= this.minIntensity) {
+      return 0;
+    }
+    if (value >= effectiveMax) {
+      return 1;
+    }
+    return (value - this.minIntensity) / span;
+  }
+
+  private resolveNormalisationCeiling(intensities: number[]): number {
+    if (Number.isFinite(this.maxIntensity)) {
+      return this.maxIntensity;
+    }
+    let observedMax = this.minIntensity;
+    for (const value of intensities) {
+      observedMax = Math.max(observedMax, value);
+    }
+    return observedMax === this.minIntensity ? this.minIntensity + 1 : observedMax;
+  }
 }
 
 function normaliseType(raw: string): string {
@@ -319,4 +562,87 @@ function normaliseType(raw: string): string {
     throw new StigmergyInvalidTypeError(raw);
   }
   return trimmed.toLowerCase();
+}
+
+/** Single pre-formatted row describing a pheromone bound. */
+export interface StigmergySummaryRow {
+  /** Human friendly label (e.g. "Min intensity"). */
+  label: string;
+  /** Already formatted value ready to be surfaced in dashboards. */
+  value: string;
+  /** Optional explanatory tooltip attached to the row. */
+  tooltip?: string | null;
+}
+
+/**
+ * Summary block combining the normalised bounds and the rows rendered in tables
+ * or tooltips. Consumers (dashboard SSE, autoscaler UI, Contract-Net exports)
+ * rely on the pre-formatted values to avoid duplicating formatting logic.
+ */
+export interface StigmergySummary {
+  /** Canonical normalised bounds derived from the field. */
+  bounds: NormalisedPheromoneBounds | null;
+  /** Rows displayed in UI tables alongside the autoscaler metrics. */
+  rows: StigmergySummaryRow[];
+}
+
+/** Formats an intensity bound into a concise human readable representation. */
+export function formatPheromoneBoundValue(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "∞";
+  }
+  const rounded = Number(value.toFixed(3));
+  const normalised = Object.is(rounded, -0) ? 0 : rounded;
+  return normalised.toString();
+}
+
+/** Builds the tooltip displayed when hovering the pheromone heatmap. */
+export function formatPheromoneBoundsTooltip(bounds: NormalisedPheromoneBounds | null): string | null {
+  if (!bounds) {
+    return null;
+  }
+  const min = formatPheromoneBoundValue(bounds.min_intensity);
+  const max = formatPheromoneBoundValue(bounds.max_intensity);
+  const ceiling = formatPheromoneBoundValue(bounds.normalisation_ceiling);
+  return `Min ${min} • Max ${max} • Ceiling ${ceiling}`;
+}
+
+/**
+ * Generates pre-formatted rows describing the current pheromone bounds so
+ * dashboards and autoscaler views can surface the data without reimplementing
+ * formatting helpers.
+ */
+export function buildStigmergySummary(bounds: NormalisedPheromoneBounds | null): StigmergySummary {
+  if (!bounds) {
+    const tooltip = "Les bornes ne sont pas encore disponibles : le champ n'a pas été initialisé.";
+    return {
+      bounds: null,
+      rows: [
+        { label: "Min intensity", value: "n/a", tooltip },
+        { label: "Max intensity", value: "n/a", tooltip },
+        { label: "Normalisation ceiling", value: "n/a", tooltip },
+      ],
+    };
+  }
+
+  return {
+    bounds,
+    rows: [
+      {
+        label: "Min intensity",
+        value: formatPheromoneBoundValue(bounds.min_intensity),
+        tooltip: "Borne basse appliquée avant normalisation (évite les valeurs négatives).",
+      },
+      {
+        label: "Max intensity",
+        value: formatPheromoneBoundValue(bounds.max_intensity),
+        tooltip: "Borne haute appliquée avant normalisation (∞ signifie pas de plafond fixe).",
+      },
+      {
+        label: "Normalisation ceiling",
+        value: formatPheromoneBoundValue(bounds.normalisation_ceiling),
+        tooltip: "Plafond utilisé pour calculer la valeur normalisée des cellules heatmap.",
+      },
+    ],
+  };
 }

--- a/src/events/bridges.ts
+++ b/src/events/bridges.ts
@@ -19,6 +19,10 @@ import type {
   ContractNetEventListener,
 } from "../coord/contractNet.js";
 import {
+  ContractNetWatcherTelemetryRecorder,
+  type ContractNetWatcherTelemetrySnapshot,
+} from "../coord/contractNetWatchers.js";
+import {
   subscribeConsensusEvents,
   type ConsensusEvent,
   type ConsensusEventListener,
@@ -117,6 +121,7 @@ export function bridgeStigmergyEvents(options: StigmergyBridgeOptions): () => vo
 
   const detach = field.onChange((event) => {
     const correlation = resolveCorrelation?.(event) ?? {};
+    const bounds = field.getIntensityBounds();
     bus.publish({
       cat: "stigmergy",
       level: "info",
@@ -133,6 +138,11 @@ export function bridgeStigmergyEvents(options: StigmergyBridgeOptions): () => vo
         intensity: event.intensity,
         totalIntensity: event.totalIntensity,
         updatedAt: event.updatedAt,
+        bounds: {
+          minIntensity: bounds.minIntensity,
+          maxIntensity: Number.isFinite(bounds.maxIntensity) ? bounds.maxIntensity : null,
+          normalisationCeiling: bounds.normalisationCeiling,
+        },
       },
     });
   });
@@ -178,6 +188,63 @@ export interface ContractNetBridgeOptions {
   subscribe?: (listener: ContractNetEventListener) => () => void;
   /** Optional resolver enriching emitted events with correlation hints. */
   resolveCorrelation?: (event: ContractNetEvent) => EventCorrelationHints | void;
+}
+
+/**
+ * Options consumed when publishing Contract-Net watcher telemetry to the unified
+ * event bus. The helper produces an `onTelemetry` listener compatible with
+ * {@link watchContractNetPheromoneBounds} so servers can both persist the
+ * counters in a recorder and emit structured events for streaming consumers.
+ */
+export interface ContractNetWatcherTelemetryBridgeOptions {
+  /** Event bus receiving structured telemetry events. */
+  bus: EventBus;
+  /** Optional recorder storing the latest watcher snapshot. */
+  recorder?: ContractNetWatcherTelemetryRecorder;
+  /** Optional resolver deriving correlation hints for emitted events. */
+  resolveCorrelation?: (snapshot: ContractNetWatcherTelemetrySnapshot) => EventCorrelationHints | void;
+}
+
+/**
+ * Creates a Contract-Net watcher telemetry listener that records incoming
+ * snapshots and forwards them to the unified event bus. The returned callback
+ * is safe to feed directly into {@link watchContractNetPheromoneBounds}.
+ */
+export function createContractNetWatcherTelemetryListener(
+  options: ContractNetWatcherTelemetryBridgeOptions,
+): (snapshot: ContractNetWatcherTelemetrySnapshot) => void {
+  const { bus, recorder, resolveCorrelation } = options;
+
+  return (snapshot: ContractNetWatcherTelemetrySnapshot) => {
+    recorder?.record(snapshot);
+    const correlation = resolveCorrelation?.(snapshot) ?? {};
+    bus.publish({
+      cat: "contract_net",
+      level: "info",
+      jobId: correlation.jobId ?? null,
+      runId: correlation.runId ?? null,
+      opId: correlation.opId ?? null,
+      graphId: correlation.graphId ?? null,
+      nodeId: correlation.nodeId ?? null,
+      childId: correlation.childId ?? null,
+      msg: "cnp_watcher_telemetry",
+      data: {
+        reason: snapshot.reason,
+        received_updates: snapshot.receivedUpdates,
+        coalesced_updates: snapshot.coalescedUpdates,
+        skipped_refreshes: snapshot.skippedRefreshes,
+        applied_refreshes: snapshot.appliedRefreshes,
+        flushes: snapshot.flushes,
+        last_bounds: snapshot.lastBounds
+          ? {
+              min_intensity: snapshot.lastBounds.min_intensity,
+              max_intensity: snapshot.lastBounds.max_intensity,
+              normalisation_ceiling: snapshot.lastBounds.normalisation_ceiling,
+            }
+          : null,
+      },
+    });
+  };
 }
 
 /** Options consumed when bridging consensus events to the {@link EventBus}. */
@@ -424,6 +491,19 @@ export function bridgeContractNetEvents(options: ContractNetBridgeOptions): () =
       case "call_awarded":
         msg = "cnp_call_awarded";
         data = { call: event.call, decision: event.decision };
+        break;
+      case "call_bounds_updated":
+        msg = "cnp_call_bounds_updated";
+        data = {
+          call: event.call,
+          bounds: event.bounds,
+          refresh: {
+            requested: event.refresh.requested,
+            includeNewAgents: event.refresh.includeNewAgents,
+            autoBidRefreshed: event.refresh.autoBidRefreshed,
+            refreshedAgents: [...event.refresh.refreshedAgents],
+          },
+        };
         break;
       case "call_completed":
         msg = "cnp_call_completed";

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,0 +1,16 @@
+/**
+ * Serialises an arbitrary payload so it can be written on a single `data:` line
+ * in a Server-Sent Events (SSE) stream. JSON encoding leaves Unicode line
+ * separators (U+2028/U+2029) untouched which breaks the SSE contract by
+ * introducing unintended record delimiters. The helper therefore performs an
+ * additional escape pass for carriage returns, line feeds and Unicode line
+ * separators while preserving the ability for consumers to recover the original
+ * data through `JSON.parse`.
+ */
+export function serialiseForSse(payload: unknown): string {
+  return JSON.stringify(payload)
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}

--- a/src/executor/bt/interpreter.ts
+++ b/src/executor/bt/interpreter.ts
@@ -124,7 +124,7 @@ export function buildBehaviorTree(
       case "retry": {
         const id = nextId(`${prefix}-retry`, node.id);
         const child = instantiate(node.child, `${id}-child`);
-        return track(new RetryNode(id, node.max_attempts, child, node.backoff_ms));
+        return track(new RetryNode(id, node.max_attempts, child, node.backoff_ms, node.backoff_jitter_ms));
       }
       case "timeout": {
         const id = nextId(`${prefix}-timeout`, node.id);

--- a/src/executor/bt/nodes.ts
+++ b/src/executor/bt/nodes.ts
@@ -4,8 +4,83 @@ import {
   type BTStatus,
   type BehaviorNode,
   type BehaviorTickResult,
+  type ParallelPolicy,
   type TickRuntime,
 } from "./types.js";
+import { OperationCancelledError } from "../cancel.js";
+
+/**
+ * Error thrown when cooperative cancellation is triggered at runtime.
+ * Exported so callers embedding the Behaviour Tree runtime can detect the
+ * cancellation path without depending on implementation details.
+ */
+export class BehaviorTreeCancellationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "BehaviorTreeCancellationError";
+  }
+}
+
+type CancellationLike = BehaviorTreeCancellationError | OperationCancelledError;
+
+/** Convenience guard ensuring errors raised by cancellation can be identified. */
+function isCancellationError(error: unknown): error is CancellationLike {
+  return error instanceof BehaviorTreeCancellationError || error instanceof OperationCancelledError;
+}
+
+/**
+ * Determine whether the provided value represents an abort signal coming from
+ * an `AbortController`/`AbortSignal` pair. MCP tools may surface these errors
+ * when the orchestrator cancels an in-flight tool invocation.
+ */
+function isAbortLikeError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "AbortError") {
+    return true;
+  }
+  if (error && typeof error === "object") {
+    const candidate = error as { name?: unknown; code?: unknown };
+    if (typeof candidate.name === "string" && candidate.name.toLowerCase() === "aborterror") {
+      return true;
+    }
+    if (typeof candidate.code === "string" && candidate.code.toUpperCase() === "ABORT_ERR") {
+      return true;
+    }
+    if (typeof candidate.code === "number") {
+      const abortCode = typeof DOMException !== "undefined" ? DOMException.ABORT_ERR : 20;
+      if (candidate.code === abortCode) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Standard message surfaced when cancellation preempts a Behaviour Tree run. */
+const DEFAULT_CANCELLATION_MESSAGE = "Behaviour Tree execution cancelled";
+
+/**
+ * Convert arbitrary cancellation reasons into the orchestrator-level error used by
+ * the Behaviour Tree runtime. Preserves the root cause when available.
+ */
+function throwCancellation(cause?: unknown): never {
+  if (cause instanceof BehaviorTreeCancellationError) {
+    throw cause;
+  }
+  if (cause instanceof OperationCancelledError) {
+    throw cause;
+  }
+  if (cause instanceof Error) {
+    const message = cause.message && cause.message.trim().length > 0 ? cause.message : DEFAULT_CANCELLATION_MESSAGE;
+    throw new BehaviorTreeCancellationError(message, { cause });
+  }
+  if (typeof cause === "string") {
+    throw new BehaviorTreeCancellationError(cause);
+  }
+  if (cause !== undefined) {
+    throw new BehaviorTreeCancellationError(DEFAULT_CANCELLATION_MESSAGE, { cause });
+  }
+  throw new BehaviorTreeCancellationError(DEFAULT_CANCELLATION_MESSAGE);
+}
 
 /** Utility constant representing a successful tick result. */
 const SUCCESS_RESULT: BehaviorTickResult = { status: "success" };
@@ -28,7 +103,18 @@ function isTerminal(status: BTStatus): boolean {
 /** Guard helper executing the runtime cancellation callback when available. */
 function ensureNotCancelled(runtime: TickRuntime): void {
   if (typeof runtime.throwIfCancelled === "function") {
-    runtime.throwIfCancelled();
+    try {
+      runtime.throwIfCancelled();
+    } catch (error) {
+      throwCancellation(error);
+    }
+  }
+  if (typeof runtime.isCancelled === "function" && runtime.isCancelled()) {
+    throwCancellation();
+  }
+  const signal = runtime.cancellationSignal;
+  if (signal?.aborted) {
+    throwCancellation(signal.reason);
   }
 }
 
@@ -49,8 +135,28 @@ export class SequenceNode implements BehaviorNode {
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
     while (this.currentIndex < this.children.length) {
       const child = this.children[this.currentIndex];
-      ensureNotCancelled(runtime);
-      const result = await child.tick(runtime);
+      try {
+        ensureNotCancelled(runtime);
+      } catch (error) {
+        if (isCancellationError(error)) {
+          // Cooperative cancellation must rewind the sequence so future ticks start
+          // from the first child instead of resuming mid-way through the cursor.
+          this.reset();
+        }
+        throw error;
+      }
+
+      let result: BehaviorTickResult;
+      try {
+        result = await child.tick(runtime);
+      } catch (error) {
+        if (isCancellationError(error)) {
+          // Child initiated cancellation should leave the composite in a clean state
+          // so orchestrators can safely retry the sequence from scratch.
+          this.reset();
+        }
+        throw error;
+      }
       if (result.status === "running") {
         return result;
       }
@@ -89,8 +195,26 @@ export class SelectorNode implements BehaviorNode {
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
     while (this.currentIndex < this.children.length) {
       const child = this.children[this.currentIndex];
-      ensureNotCancelled(runtime);
-      const result = await child.tick(runtime);
+      try {
+        ensureNotCancelled(runtime);
+      } catch (error) {
+        if (isCancellationError(error)) {
+          // Reset the selector so cancelled runs do not keep their previous cursor.
+          this.reset();
+        }
+        throw error;
+      }
+
+      let result: BehaviorTickResult;
+      try {
+        result = await child.tick(runtime);
+      } catch (error) {
+        if (isCancellationError(error)) {
+          // Cancellation bubbling from the child must clear the selector state.
+          this.reset();
+        }
+        throw error;
+      }
       if (result.status === "running") {
         return result;
       }
@@ -113,15 +237,46 @@ export class SelectorNode implements BehaviorNode {
   }
 }
 
+/**
+ * Normalised parallel policy used internally by {@link ParallelNode}. Using an
+ * explicit discriminant simplifies the tick logic while maintaining backwards
+ * compatibility with legacy string shorthands.
+ */
+type NormalisedParallelPolicy =
+  | { kind: "all" }
+  | { kind: "any" }
+  | { kind: "quota"; successThreshold: number };
+
+/** Convert user provided policy configuration into the internal representation. */
+function normaliseParallelPolicy(
+  policy: ParallelPolicy,
+  childCount: number,
+): NormalisedParallelPolicy {
+  if (policy === "all" || policy === "any") {
+    return { kind: policy };
+  }
+
+  const threshold = Number(policy.threshold);
+  if (!Number.isFinite(threshold) || threshold <= 0) {
+    throw new Error("Parallel quota threshold must be a positive integer");
+  }
+
+  const clamped = Math.max(1, Math.min(childCount, Math.floor(threshold)));
+  return { kind: "quota", successThreshold: clamped };
+}
+
 /** Behaviour Tree parallel composite node. */
 export class ParallelNode implements BehaviorNode {
   private readonly childStates: Map<string, BTStatus> = new Map();
+  private readonly policy: NormalisedParallelPolicy;
 
   constructor(
     public readonly id: string,
-    private readonly policy: "all" | "any",
+    policy: ParallelPolicy,
     private readonly children: BehaviorNode[],
-  ) {}
+  ) {
+    this.policy = normaliseParallelPolicy(policy, children.length);
+  }
 
   /**
    * Execute all children concurrently. The policy controls the aggregation of
@@ -130,48 +285,108 @@ export class ParallelNode implements BehaviorNode {
    * - `any`: success once one child succeeds, failure when all fail
    */
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
-    ensureNotCancelled(runtime);
-    const results = await Promise.all(
-      this.children.map(async (child) => {
-        const previous = this.childStates.get(child.id);
-        if (previous && isTerminal(previous)) {
-          return { status: previous } satisfies BehaviorTickResult;
-        }
-        ensureNotCancelled(runtime);
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        // Cooperative cancellations should rewind cached child states so the next
+        // tick restarts every branch from a clean slate.
+        this.reset();
+      }
+      throw error;
+    }
+
+    const childPromises = this.children.map(async (child) => {
+      const previous = this.childStates.get(child.id);
+      if (previous && isTerminal(previous)) {
+        return { status: previous } satisfies BehaviorTickResult;
+      }
+
+      ensureNotCancelled(runtime);
+
+      try {
         const result = await child.tick(runtime);
         if (isTerminal(result.status)) {
           this.childStates.set(child.id, result.status);
         }
         return result;
-      }),
-    );
+      } catch (error) {
+        if (isCancellationError(error)) {
+          // The composite-level catch will perform the reset once every child
+          // settled to avoid double rewinds while other branches complete.
+        }
+        throw error;
+      }
+    });
+
+    let results: BehaviorTickResult[];
+    try {
+      results = await Promise.all(childPromises);
+    } catch (error) {
+      await Promise.allSettled(childPromises);
+      if (isCancellationError(error)) {
+        // Cancellation should evict cached terminal states to prevent partially
+        // completed runs from being treated as finished once the orchestrator
+        // retries the parallel composite.
+        this.reset();
+      }
+      throw error;
+    }
+
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        this.reset();
+      }
+      throw error;
+    }
 
     const statuses = results.map((result) => result.status);
     const successes = statuses.filter((status) => status === "success").length;
     const failures = statuses.filter((status) => status === "failure").length;
     const running = statuses.filter((status) => status === "running").length;
 
-    if (this.policy === "all") {
-      if (failures > 0) {
-        this.reset();
-        return FAILURE_RESULT;
+    switch (this.policy.kind) {
+      case "all": {
+        if (failures > 0) {
+          this.reset();
+          return FAILURE_RESULT;
+        }
+        if (running === 0 && successes === this.children.length) {
+          this.reset();
+          return SUCCESS_RESULT;
+        }
+        return { status: "running" };
       }
-      if (running === 0 && successes === this.children.length) {
-        this.reset();
-        return SUCCESS_RESULT;
+      case "any": {
+        if (successes > 0) {
+          this.reset();
+          return SUCCESS_RESULT;
+        }
+        if (running === 0 && failures === this.children.length) {
+          this.reset();
+          return FAILURE_RESULT;
+        }
+        return { status: "running" };
       }
-      return { status: "running" };
+      case "quota": {
+        if (successes >= this.policy.successThreshold) {
+          this.reset();
+          return SUCCESS_RESULT;
+        }
+        const remainingPotential = this.children.length - failures;
+        if (remainingPotential < this.policy.successThreshold) {
+          this.reset();
+          return FAILURE_RESULT;
+        }
+        return { status: "running" };
+      }
+      default: {
+        const exhaustive: never = this.policy;
+        throw new Error(`unsupported parallel policy ${(exhaustive as { kind: string }).kind}`);
+      }
     }
-
-    if (successes > 0) {
-      this.reset();
-      return SUCCESS_RESULT;
-    }
-    if (running === 0 && failures === this.children.length) {
-      this.reset();
-      return FAILURE_RESULT;
-    }
-    return { status: "running" };
   }
 
   /** Reset cached statuses and child nodes. */
@@ -192,6 +407,7 @@ export class RetryNode implements BehaviorNode {
     private readonly maxAttempts: number,
     private readonly child: BehaviorNode,
     private readonly backoffMs = 0,
+    private readonly backoffJitterMs = 0,
   ) {}
 
   /**
@@ -199,8 +415,31 @@ export class RetryNode implements BehaviorNode {
    * between attempts.
    */
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
-    ensureNotCancelled(runtime);
-    const result = await this.child.tick(runtime);
+    let childStarted = false;
+    let childReset = false;
+
+    const handleCancellation = (error: unknown): never => {
+      if (isCancellationError(error)) {
+        this.resetAfterCancellation(childStarted, childReset);
+      }
+      throw error;
+    };
+
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      handleCancellation(error);
+      throw error;
+    }
+
+    let result: BehaviorTickResult;
+    try {
+      childStarted = true;
+      result = await this.child.tick(runtime);
+    } catch (error) {
+      handleCancellation(error);
+      throw error;
+    }
     if (result.status === "success") {
       this.reset();
       return result;
@@ -216,10 +455,28 @@ export class RetryNode implements BehaviorNode {
     }
 
     this.child.reset();
+    childReset = true;
     const delayFn = runtime.wait ?? defaultDelay;
-    if (this.backoffMs > 0) {
-      ensureNotCancelled(runtime);
-      await delayFn(this.backoffMs);
+    const delay = this.computeBackoffDelay(runtime);
+    if (delay > 0) {
+      try {
+        ensureNotCancelled(runtime);
+      } catch (error) {
+        handleCancellation(error);
+        throw error;
+      }
+      try {
+        await delayFn(delay);
+      } catch (error) {
+        handleCancellation(error);
+        throw error;
+      }
+      try {
+        ensureNotCancelled(runtime);
+      } catch (error) {
+        handleCancellation(error);
+        throw error;
+      }
     }
     return { status: "running" };
   }
@@ -228,6 +485,44 @@ export class RetryNode implements BehaviorNode {
   reset(): void {
     this.attempts = 0;
     this.child.reset();
+  }
+
+  /**
+   * Restore the retry state after a cooperative cancellation so the next tick starts
+   * from a clean slate without double-resetting children that were already rewound.
+   */
+  private resetAfterCancellation(childStarted: boolean, childAlreadyReset: boolean): void {
+    this.attempts = 0;
+    if (childStarted && !childAlreadyReset) {
+      this.child.reset();
+    }
+  }
+
+  /**
+   * Compute the backoff delay enriched with jitter when configured. Jitter
+   * relies on a runtime-provided pseudo-random source when available to keep
+   * tests deterministic.
+   */
+  private computeBackoffDelay(runtime: TickRuntime): number {
+    const base = Math.max(0, this.backoffMs);
+    const jitter = Math.max(0, this.backoffJitterMs);
+    if (jitter === 0) {
+      return base;
+    }
+
+    const sampler = typeof runtime.random === "function" ? runtime.random : Math.random;
+    let sample: number;
+    try {
+      sample = sampler();
+    } catch {
+      sample = Math.random();
+    }
+    if (!Number.isFinite(sample)) {
+      sample = Math.random();
+    }
+    const boundedSample = Math.min(Math.max(sample, 0), 1);
+    const jitterComponent = Math.round(boundedSample * jitter);
+    return base + jitterComponent;
   }
 }
 
@@ -253,13 +548,30 @@ export class TimeoutNode implements BehaviorNode {
    * duration to the runtime so loop detectors can adjust future budgets.
    */
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
-    ensureNotCancelled(runtime);
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        // Align timeout cancellation semantics with other decorators by rewinding
+        // the child when interrupted before execution begins.
+        this.child.reset();
+      }
+      throw error;
+    }
     const wait = runtime.wait ?? defaultDelay;
     const start = runtime.now ? runtime.now() : Date.now();
     const budget = this.resolveBudget(runtime);
     const timeoutPromise = wait(budget).then(() => TIMEOUT_SENTINEL);
     const childPromise = this.child.tick(runtime);
-    const winner = await Promise.race([timeoutPromise, childPromise]);
+    let winner: typeof TIMEOUT_SENTINEL | BehaviorTickResult;
+    try {
+      winner = (await Promise.race([timeoutPromise, childPromise])) as typeof TIMEOUT_SENTINEL | BehaviorTickResult;
+    } catch (error) {
+      if (isCancellationError(error)) {
+        this.child.reset();
+      }
+      throw error;
+    }
     if (winner === TIMEOUT_SENTINEL) {
       const end = runtime.now ? runtime.now() : Date.now();
       this.recordOutcome(runtime, end - start, false, budget);
@@ -327,16 +639,46 @@ export class GuardNode implements BehaviorNode {
    * does not hold the guard short-circuits with a failure and resets the child.
    */
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
-    ensureNotCancelled(runtime);
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        // Guard decorators do not maintain internal state, yet resetting the child
+        // ensures partially evaluated work is abandoned when cooperative
+        // cancellation interrupts before the condition is read.
+        this.child.reset();
+      }
+      throw error;
+    }
     const actual = runtime.variables[this.conditionKey];
     const matches = this.expected === undefined ? Boolean(actual) : actual === this.expected;
     if (!matches) {
       this.child.reset();
       return FAILURE_RESULT;
     }
-    const result = await this.child.tick(runtime);
+    let result: BehaviorTickResult;
+    try {
+      result = await this.child.tick(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        // The child may surface cancellation while evaluating; reset before
+        // bubbling the error so the next tick starts from a clean slate.
+        this.child.reset();
+      }
+      throw error;
+    }
     if (result.status !== "running") {
       this.reset();
+      return result;
+    }
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        // Running children are rewound when cancellation triggers between ticks.
+        this.child.reset();
+      }
+      throw error;
     }
     return result;
   }
@@ -370,7 +712,19 @@ export class TaskLeaf implements BehaviorNode {
     const rawInput = this.inputKey ? runtime.variables[this.inputKey] : undefined;
     const parsedInput = this.schema ? this.schema.parse(rawInput ?? {}) : rawInput ?? {};
     ensureNotCancelled(runtime);
-    const output = await runtime.invokeTool(this.toolName, parsedInput);
+    let output: unknown;
+    try {
+      output = await runtime.invokeTool(this.toolName, parsedInput);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        throw error;
+      }
+      if (isAbortLikeError(error)) {
+        throwCancellation(error);
+      }
+      throw error;
+    }
+    ensureNotCancelled(runtime);
     return { status: "success", output };
   }
 
@@ -388,11 +742,40 @@ export class CancellableNode implements BehaviorNode {
   ) {}
 
   async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
-    ensureNotCancelled(runtime);
-    const result = await this.child.tick(runtime);
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        this.child.reset();
+      }
+      throw error;
+    }
+
+    let result: BehaviorTickResult;
+    try {
+      result = await this.child.tick(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        this.child.reset();
+      }
+      this.reset();
+      throw error;
+    }
+
     if (result.status !== "running") {
       this.reset();
+      return result;
     }
+
+    try {
+      ensureNotCancelled(runtime);
+    } catch (error) {
+      if (isCancellationError(error)) {
+        this.child.reset();
+      }
+      throw error;
+    }
+
     return result;
   }
 

--- a/src/executor/planLifecycle.ts
+++ b/src/executor/planLifecycle.ts
@@ -317,10 +317,12 @@ export class PlanLifecycleRegistry {
       case "tick":
       case "loop":
       case "node": {
-        if (entry.snapshot.state !== "running") {
-          entry.snapshot.state = "running";
+        if (entry.snapshot.state !== "done" && entry.snapshot.state !== "failed") {
+          if (entry.snapshot.state !== "running") {
+            entry.snapshot.state = "running";
+          }
+          entry.snapshot.paused_at = null;
         }
-        entry.snapshot.paused_at = null;
         break;
       }
       case "complete": {

--- a/src/monitor/dashboard.ts
+++ b/src/monitor/dashboard.ts
@@ -8,7 +8,20 @@ import { GraphState, GraphStateMetrics } from "../graphState.js";
 import type { ChildRuntimeLimits } from "../childRuntime.js";
 import { ChildSupervisor } from "../childSupervisor.js";
 import { StructuredLogger } from "../logger.js";
-import { StigmergyField } from "../coord/stigmergy.js";
+import { serialiseForSse } from "../events/sse.js";
+import type {
+  ContractNetWatcherTelemetryRecorder,
+  ContractNetWatcherTelemetryState,
+} from "../coord/contractNetWatchers.js";
+import {
+  StigmergyField,
+  buildStigmergySummary,
+  formatPheromoneBoundsTooltip,
+  normalisePheromoneBoundsForTelemetry,
+  type NormalisedPheromoneBounds,
+  type StigmergySummary,
+  type StigmergySummaryRow,
+} from "../coord/stigmergy.js";
 import { BehaviorTreeStatusRegistry } from "./btStatusRegistry.js";
 import type { BehaviorTreeStatusSnapshot } from "./btStatusRegistry.js";
 import type { BTStatus } from "../executor/bt/types.js";
@@ -24,10 +37,30 @@ export interface DashboardSnapshot {
   metrics: GraphStateMetrics;
   /** Heatmap-friendly aggregates derived from runtime events. */
   heatmap: DashboardHeatmap;
+  /**
+   * Normalised stigmergy bounds exposed alongside the heatmap so dashboards can
+   * display the same `pheromone_bounds` telemetry as plan tools and scheduler
+   * events without re-implementing normalisation.
+   */
+  pheromoneBounds: NormalisedPheromoneBounds | null;
+  /**
+   * Pre-formatted summary of the stigmergic field used by the dashboard table.
+   * The block mirrors {@link pheromoneBounds} while adding rendered rows and
+   * tooltips for quick operator consumption.
+   */
+  stigmergy: DashboardStigmergySummary;
   /** Latest scheduler backlog and throughput metrics. */
   scheduler: DashboardSchedulerSnapshot;
   /** Latest Behaviour Tree node statuses grouped by tree identifier. */
   behaviorTrees: DashboardBehaviorTreeStatus[];
+  /**
+   * Aggregated counters emitted by the Contract-Net pheromone watcher. The
+   * block mirrors the payload returned by the telemetry MCP tool while keeping
+   * the dashboard aligned with the server’s internal recorder. When telemetry
+   * is unavailable the property is set to `null` so clients can degrade
+   * gracefully.
+   */
+  contractNetWatcherTelemetry: ContractNetWatcherTelemetryState | null;
   /** Lightweight child projections displayed in the dashboard table. */
   children: Array<{
     id: string;
@@ -56,6 +89,18 @@ export interface DashboardHeatmap {
   tokens: DashboardHeatmapCell[];
   /** Aggregated pheromone intensities per node derived from the stigmergic field. */
   pheromones: DashboardHeatmapCell[];
+  /**
+   * Normalised bounds associated with the pheromone heatmap. Consumers rely on
+   * this structure to keep dashboards aligned with `pheromone_bounds` surfaced
+   * through plan and Contract-Net telemetry.
+   */
+  bounds: NormalisedPheromoneBounds | null;
+  /**
+   * Human-friendly summary derived from {@link bounds}. Dashboards surface the
+   * string directly in tooltips so operators can inspect the current
+   * normalisation window without reimplementing formatting logic.
+   */
+  boundsTooltip: string | null;
 }
 
 /** Descriptor of a single heatmap cell. */
@@ -63,6 +108,8 @@ export interface DashboardHeatmapCell {
   childId: string;
   label: string;
   value: number;
+  /** Optional normalised value between 0 and 1 when the source provides bounds. */
+  normalised?: number;
 }
 
 /** Scheduler snapshot surfaced to operators. */
@@ -92,6 +139,16 @@ export interface DashboardBehaviorTreeStatus {
   updatedAt: number;
   nodes: DashboardBehaviorTreeNodeStatus[];
 }
+
+/** Single row rendered in the stigmergy bounds table. */
+export type DashboardStigmergyRow = StigmergySummaryRow;
+
+/**
+ * Summary block rendered in the dashboard table. The block mirrors the
+ * `pheromone_bounds` telemetry while adding pre-formatted rows for immediate
+ * display alongside the scheduler and child statistics.
+ */
+export type DashboardStigmergySummary = StigmergySummary;
 
 /**
  * Handle returned when the dashboard HTTP server is started.
@@ -129,6 +186,8 @@ export interface DashboardServerOptions {
   supervisorAgent?: OrchestratorSupervisor;
   /** Structured logger used for operational diagnostics. */
   logger?: StructuredLogger;
+  /** Optional Contract-Net watcher telemetry recorder surfaced in snapshots. */
+  contractNetWatcherTelemetry?: ContractNetWatcherTelemetryRecorder;
 }
 
 /** Zod schema validating the pause endpoint payload. */
@@ -160,6 +219,7 @@ export interface DashboardRouterOptions {
   stigmergy: StigmergyField;
   btStatusRegistry: BehaviorTreeStatusRegistry;
   supervisorAgent?: OrchestratorSupervisor;
+  contractNetWatcherTelemetry?: ContractNetWatcherTelemetryRecorder;
 }
 
 /** Router returned by {@link createDashboardRouter}. */
@@ -184,6 +244,7 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
   const stigmergy = options.stigmergy;
   const btStatusRegistry = options.btStatusRegistry;
   const supervisorAgent = options.supervisorAgent;
+  const contractNetWatcherTelemetry = options.contractNetWatcherTelemetry;
   const streamIntervalMs = Math.max(250, options.streamIntervalMs ?? 2_000);
   const clients = new Set<ServerResponse>();
   const autoBroadcast = options.autoBroadcast ?? true;
@@ -194,7 +255,16 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
       if (clients.size === 0) {
         return;
       }
-      broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+      broadcast(
+        clients,
+        graphState,
+        eventStore,
+        stigmergy,
+        btStatusRegistry,
+        supervisorAgent,
+        contractNetWatcherTelemetry,
+        logger,
+      );
     }, streamIntervalMs);
   }
 
@@ -208,6 +278,19 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
     const pathname = requestUrl.pathname;
 
     try {
+      if (req.method === "GET" && pathname === "/") {
+        const snapshot = buildSnapshot(
+          graphState,
+          eventStore,
+          stigmergy,
+          btStatusRegistry,
+          supervisorAgent,
+          contractNetWatcherTelemetry,
+        );
+        writeHtml(res, 200, renderDashboardHtml(snapshot));
+        return;
+      }
+
       if (req.method === "GET" && pathname === "/health") {
         writeJson(res, 200, { status: "ok" });
         return;
@@ -217,7 +300,14 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
         writeJson(
           res,
           200,
-          buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent),
+          buildSnapshot(
+            graphState,
+            eventStore,
+            stigmergy,
+            btStatusRegistry,
+            supervisorAgent,
+            contractNetWatcherTelemetry,
+          ),
         );
         return;
       }
@@ -231,6 +321,7 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
           stigmergy,
           btStatusRegistry,
           supervisorAgent,
+          contractNetWatcherTelemetry,
           logger,
           streamIntervalMs,
         );
@@ -239,19 +330,46 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
 
       if (req.method === "POST" && pathname === "/controls/pause") {
         await handlePauseRequest(req, res, graphState, logger);
-        broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+        broadcast(
+          clients,
+          graphState,
+          eventStore,
+          stigmergy,
+          btStatusRegistry,
+          supervisorAgent,
+          contractNetWatcherTelemetry,
+          logger,
+        );
         return;
       }
 
       if (req.method === "POST" && pathname === "/controls/cancel") {
         await handleCancelRequest(req, res, graphState, supervisor, logger);
-        broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+        broadcast(
+          clients,
+          graphState,
+          eventStore,
+          stigmergy,
+          btStatusRegistry,
+          supervisorAgent,
+          contractNetWatcherTelemetry,
+          logger,
+        );
         return;
       }
 
       if (req.method === "POST" && pathname === "/controls/prioritise") {
         await handlePrioritiseRequest(req, res, graphState, logger);
-        broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger);
+        broadcast(
+          clients,
+          graphState,
+          eventStore,
+          stigmergy,
+          btStatusRegistry,
+          supervisorAgent,
+          contractNetWatcherTelemetry,
+          logger,
+        );
         return;
       }
 
@@ -273,7 +391,16 @@ export function createDashboardRouter(options: DashboardRouterOptions): Dashboar
     streamIntervalMs,
     handleRequest: handler,
     broadcast: () =>
-      broadcast(clients, graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent, logger),
+      broadcast(
+        clients,
+        graphState,
+        eventStore,
+        stigmergy,
+        btStatusRegistry,
+        supervisorAgent,
+        contractNetWatcherTelemetry,
+        logger,
+      ),
     async close() {
       if (interval) {
         clearInterval(interval);
@@ -312,6 +439,7 @@ export async function startDashboardServer(options: DashboardServerOptions): Pro
     stigmergy: options.stigmergy,
     btStatusRegistry: options.btStatusRegistry,
     supervisorAgent: options.supervisorAgent,
+    contractNetWatcherTelemetry: options.contractNetWatcherTelemetry,
   });
 
   const server = createServer((req, res) => {
@@ -357,6 +485,16 @@ function writeJson(res: ServerResponse, status: number, payload: unknown): void 
     "Cache-Control": "no-store",
   });
   res.end(json);
+}
+
+/** Serialises a response as HTML with UTF-8 encoding. */
+function writeHtml(res: ServerResponse, status: number, payload: string): void {
+  res.writeHead(status, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Length": Buffer.byteLength(payload),
+    "Cache-Control": "no-store",
+  });
+  res.end(payload);
 }
 
 /** Reads the full request body and parses it as JSON. */
@@ -461,6 +599,7 @@ function handleStreamRequest(
   stigmergy: StigmergyField,
   btStatusRegistry: BehaviorTreeStatusRegistry,
   supervisorAgent: OrchestratorSupervisor | undefined,
+  contractNetWatcherTelemetry: ContractNetWatcherTelemetryRecorder | undefined,
   logger: StructuredLogger,
   streamIntervalMs: number,
 ): void {
@@ -474,8 +613,16 @@ function handleStreamRequest(
   res.on("close", () => {
     clients.delete(res);
   });
-  const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent);
-  res.write(`data: ${JSON.stringify(snapshot)}\n\n`);
+  const snapshot = buildSnapshot(
+    graphState,
+    eventStore,
+    stigmergy,
+    btStatusRegistry,
+    supervisorAgent,
+    contractNetWatcherTelemetry,
+  );
+  const payload = serialiseForSse(snapshot);
+  res.write(`data: ${payload}\n\n`);
   logger.debug("dashboard_stream_connected", { clients: clients.size });
 }
 
@@ -487,13 +634,21 @@ function broadcast(
   stigmergy: StigmergyField,
   btStatusRegistry: BehaviorTreeStatusRegistry,
   supervisorAgent: OrchestratorSupervisor | undefined,
+  contractNetWatcherTelemetry: ContractNetWatcherTelemetryRecorder | undefined,
   logger: StructuredLogger,
 ): void {
   if (clients.size === 0) {
     return;
   }
-  const snapshot = buildSnapshot(graphState, eventStore, stigmergy, btStatusRegistry, supervisorAgent);
-  const payload = `data: ${JSON.stringify(snapshot)}\n\n`;
+  const snapshot = buildSnapshot(
+    graphState,
+    eventStore,
+    stigmergy,
+    btStatusRegistry,
+    supervisorAgent,
+    contractNetWatcherTelemetry,
+  );
+  const payload = `data: ${serialiseForSse(snapshot)}\n\n`;
   for (const client of clients) {
     client.write(payload);
   }
@@ -507,11 +662,14 @@ function buildSnapshot(
   stigmergy: StigmergyField,
   btStatusRegistry: BehaviorTreeStatusRegistry,
   supervisorAgent: OrchestratorSupervisor | undefined,
+  contractNetWatcherTelemetry: ContractNetWatcherTelemetryRecorder | undefined,
 ): DashboardSnapshot {
   const metrics = graphState.collectMetrics();
   const heatmap = computeDashboardHeatmap(graphState, eventStore, stigmergy);
+  const stigmergySummary = buildStigmergySummary(heatmap.bounds);
   const scheduler = buildSchedulerSnapshot(supervisorAgent);
   const behaviorTrees = normaliseBehaviorTreeSnapshots(btStatusRegistry.snapshot());
+  const contractNetWatcherState = contractNetWatcherTelemetry?.snapshot() ?? null;
   const children = graphState.listChildSnapshots().map((child) => {
     const lastActivityAt = child.lastTs ?? child.lastHeartbeatAt ?? child.createdAt;
     return {
@@ -531,8 +689,11 @@ function buildSnapshot(
     timestamp: Date.now(),
     metrics,
     heatmap,
+    pheromoneBounds: heatmap.bounds,
+    stigmergy: stigmergySummary,
     scheduler,
     behaviorTrees,
+    contractNetWatcherTelemetry: contractNetWatcherState,
     children,
   };
 }
@@ -608,17 +769,21 @@ export function computeDashboardHeatmap(
   }
   tokens.sort((a, b) => b.value - a.value);
 
-  const fieldSnapshot = stigmergy.fieldSnapshot();
-  const pheromones: DashboardHeatmapCell[] = fieldSnapshot.totals
-    .filter((total) => total.intensity > 0)
-    .map((total) => ({
-      childId: total.nodeId,
-      label: total.nodeId,
-      value: total.intensity,
+  // Compute the current bounds before normalising cells so we reuse the same
+  // reference across every consumer (heatmap cells, dashboards, telemetry).
+  const bounds = normalisePheromoneBoundsForTelemetry(stigmergy.getIntensityBounds());
+  const boundsTooltip = formatPheromoneBoundsTooltip(bounds);
+  const fieldHeatmap = stigmergy.heatmapSnapshot();
+  const pheromones: DashboardHeatmapCell[] = fieldHeatmap.cells
+    .map((cell) => ({
+      childId: cell.nodeId,
+      label: cell.nodeId,
+      value: cell.totalIntensity,
+      normalised: cell.normalised,
     }))
     .sort((a, b) => b.value - a.value);
 
-  return { idle, errors, tokens, pheromones };
+  return { idle, errors, tokens, pheromones, bounds, boundsTooltip };
 }
 
 /** Builds a scheduler snapshot suitable for dashboard consumption. */
@@ -656,4 +821,452 @@ function normaliseBehaviorTreeSnapshots(
         updatedAt: node.updatedAt,
       })),
     }));
+}
+
+/**
+ * Renders a lightweight HTML dashboard exposing key metrics alongside the
+ * Contract-Net watcher counters. The page is intentionally static so operators
+ * can obtain a quick overview without depending on external tooling.
+ */
+function renderDashboardHtml(snapshot: DashboardSnapshot): string {
+  const watcher = snapshot.contractNetWatcherTelemetry;
+  const watcherSummary = renderMetricsTableHtml(
+    watcher
+      ? [
+          ["Emissions", formatNumber(watcher.emissions)],
+          ["Dernier événement", formatTimestamp(watcher.lastEmittedAtMs)],
+        ]
+      : [],
+    "Aucune télémétrie Contract-Net disponible.",
+  );
+
+  const watcherDetails = renderMetricsTableHtml(
+    watcher?.lastSnapshot
+      ? [
+          ["Raison", watcher.lastSnapshot.reason],
+          ["Notifications reçues", formatNumber(watcher.lastSnapshot.receivedUpdates)],
+          ["Notifications coalescées", formatNumber(watcher.lastSnapshot.coalescedUpdates)],
+          ["Rafraîchissements ignorés", formatNumber(watcher.lastSnapshot.skippedRefreshes)],
+          ["Rafraîchissements appliqués", formatNumber(watcher.lastSnapshot.appliedRefreshes)],
+          ["Flushs", formatNumber(watcher.lastSnapshot.flushes)],
+        ]
+      : [],
+    watcher
+      ? "Le watcher n'a pas encore publié de compteur."
+      : "Aucune télémétrie Contract-Net disponible."
+  );
+
+  const bounds = renderMetricsTableHtml(
+    watcher?.lastSnapshot?.lastBounds
+      ? [
+          ["Min intensity", formatNumber(watcher.lastSnapshot.lastBounds.min_intensity)],
+          [
+            "Max intensity",
+            formatNullableNumber(watcher.lastSnapshot.lastBounds.max_intensity),
+          ],
+          [
+            "Normalisation ceiling",
+            formatNumber(watcher.lastSnapshot.lastBounds.normalisation_ceiling),
+          ],
+        ]
+      : [],
+    watcher?.lastSnapshot
+      ? "Aucune borne normalisée n'a été enregistrée."
+      : "Aucune télémétrie Contract-Net disponible.",
+  );
+
+  const stigSummaryRows = snapshot.stigmergy.rows
+    .map((row) => `<tr><th scope="row">${escapeHtml(row.label)}</th><td>${escapeHtml(row.value)}</td></tr>`)
+    .join("\n");
+
+  const tooltip = snapshot.heatmap.boundsTooltip ?? "";
+
+  const initialSnapshotScriptPayload = serialiseSnapshotForInlineScript(snapshot);
+
+  return `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <title>Orchestrateur – Dashboard</title>
+    <style>
+      body { font-family: system-ui, -apple-system, \"Segoe UI\", sans-serif; margin: 0; padding: 24px; background: #0f172a; color: #e2e8f0; }
+      h1, h2, h3 { margin: 0 0 12px; }
+      section { margin-bottom: 32px; padding: 16px 20px; background: #1e293b; border-radius: 12px; box-shadow: 0 12px 32px rgba(15, 23, 42, 0.35); }
+      .metrics-table { border-collapse: collapse; width: 100%; }
+      .metrics-table th { text-align: left; padding: 8px 12px; font-weight: 600; color: #cbd5f5; width: 55%; }
+      .metrics-table td { padding: 8px 12px; color: #e0f2fe; }
+      .metrics-table tr:nth-child(even) { background: rgba(148, 163, 184, 0.1); }
+      .empty-state { margin: 0; padding: 12px 16px; background: rgba(148, 163, 184, 0.15); border-radius: 8px; color: #f8fafc; }
+      .two-columns { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+      .status { margin: 8px 0 0; font-size: 0.95rem; font-weight: 500; }
+      .status--pending { color: #facc15; }
+      .status--connected { color: #4ade80; }
+      .status--error { color: #f87171; }
+      .dashboard-card { min-height: 40px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Orchestrateur – Tableau de bord</h1>
+      <p>Instantané généré le <strong id="dashboard-timestamp">${formatTimestamp(snapshot.timestamp)}</strong>.</p>
+      <p id="connection-status" class="status status--pending" role="status">SSE : initialisation…</p>
+    </header>
+
+    <section aria-labelledby="contract-net-watcher">
+      <h2 id="contract-net-watcher">Contract-Net Watcher</h2>
+      <div class="two-columns">
+        <article>
+          <h3>Résumé</h3>
+          <div id="contract-net-summary" class="dashboard-card" aria-live="polite">
+            ${watcherSummary}
+          </div>
+        </article>
+        <article>
+          <h3>Derniers compteurs</h3>
+          <div id="contract-net-details" class="dashboard-card" aria-live="polite">
+            ${watcherDetails}
+          </div>
+        </article>
+      </div>
+      <article>
+        <h3>Dernières bornes normalisées</h3>
+        <div id="contract-net-bounds" class="dashboard-card" aria-live="polite">
+          ${bounds}
+        </div>
+      </article>
+    </section>
+
+    <section aria-labelledby="stigmergy-summary">
+      <h2 id="stigmergy-summary">Stigmergie</h2>
+      <table class="metrics-table">
+        <tbody id="stigmergy-summary-rows">
+          ${stigSummaryRows}
+        </tbody>
+      </table>
+      <p id="stigmergy-tooltip">${escapeHtml(tooltip)}</p>
+    </section>
+
+    <section aria-labelledby="scheduler-summary">
+      <h2 id="scheduler-summary">Scheduler</h2>
+      <table class="metrics-table">
+        <tbody>
+          <tr><th scope="row">Tick</th><td><span id="scheduler-tick">${snapshot.scheduler.tick}</span></td></tr>
+          <tr><th scope="row">Backlog</th><td><span id="scheduler-backlog">${snapshot.scheduler.backlog}</span></td></tr>
+          <tr><th scope="row">Tâches complétées</th><td><span id="scheduler-completed">${snapshot.scheduler.completed}</span></td></tr>
+          <tr><th scope="row">Tâches en échec</th><td><span id="scheduler-failed">${snapshot.scheduler.failed}</span></td></tr>
+          <tr><th scope="row">Mise à jour</th><td><span id="scheduler-updated-at">${formatTimestamp(snapshot.scheduler.updatedAt)}</span></td></tr>
+        </tbody>
+      </table>
+    </section>
+    <script>
+${buildDashboardBootstrapScript(initialSnapshotScriptPayload)}
+    </script>
+  </body>
+</html>`;
+}
+
+/** Formats timestamps (epoch milliseconds) into ISO strings or `n/a`. */
+function formatTimestamp(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "n/a";
+  }
+  try {
+    return new Date(value).toISOString();
+  } catch {
+    return String(value);
+  }
+}
+
+/** Formats finite numbers with a compact representation for HTML tables. */
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  if (Math.abs(value) >= 1_000 || Number.isInteger(value)) {
+    return value.toString();
+  }
+  return value.toFixed(3);
+}
+
+/** Formats nullable numbers, returning `n/a` when no value is available. */
+function formatNullableNumber(value: number | null): string {
+  return value === null ? "n/a" : formatNumber(value);
+}
+
+/** Escapes HTML special characters to avoid injection in static strings. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Renders a small table (or fallback paragraph) summarising metrics. The
+ * helper is used for the Contract-Net watcher sections so both the server-side
+ * HTML and the client bootstrap share the same layout.
+ */
+function renderMetricsTableHtml(rows: Array<[string, string]>, emptyMessage: string): string {
+  if (rows.length === 0) {
+    return `<p class="empty-state">${escapeHtml(emptyMessage)}</p>`;
+  }
+  const renderedRows = rows
+    .map(
+      ([label, value]) =>
+        `<tr><th scope="row">${escapeHtml(label)}</th><td>${escapeHtml(value)}</td></tr>`,
+    )
+    .join("\n");
+  return `<table class="metrics-table"><tbody>${renderedRows}</tbody></table>`;
+}
+
+/**
+ * Builds the inline dashboard bootstrap script as a pre-indented block. The helper
+ * mostly uses plain string literals and relies on a single template interpolation
+ * to inject the sanitised snapshot so TypeScript treats the browser code as an
+ * opaque string while still embedding data safely.
+*/
+function buildDashboardBootstrapScript(serialisedSnapshot: string): string {
+  const lines = [
+    "(() => {",
+    "  // Inline bootstrap executed in the dashboard context. The script keeps the",
+    "  // HTML view synchronised with the `/stream` SSE endpoint so operators can",
+    "  // observe metrics without refreshing the page. Values are updated using",
+    "  // DOM APIs (textContent/appendChild) to avoid HTML injection concerns.",
+    `  const initialSnapshot = ${serialisedSnapshot};`,
+    "",
+    "  // Updates the textual status banner displayed below the title.",
+    "  const statusElement = document.getElementById(\"connection-status\");",
+    "  function updateStatus(message, variant) {",
+    "    if (!statusElement) {",
+    "      return;",
+    "    }",
+    "    statusElement.textContent = message;",
+    "    statusElement.classList.remove(\"status--pending\", \"status--connected\", \"status--error\");",
+    "    statusElement.classList.add(\"status--\" + variant);",
+    "  }",
+    "",
+    "  // Formats timestamps (epoch milliseconds) into ISO strings or `n/a`.",
+    "  function formatTimestampForClient(value) {",
+    "    if (typeof value !== \"number\" || !Number.isFinite(value)) {",
+    "      return \"n/a\";",
+    "    }",
+    "    try {",
+    "      return new Date(value).toISOString();",
+    "    } catch (error) {",
+    "      console.warn(\"dashboard_timestamp_parse_failure\", error);",
+    "      return String(value);",
+    "    }",
+    "  }",
+    "",
+    "  // Mirrors the server-side formatting logic for compact numbers.",
+    "  function formatNumberForClient(value) {",
+    "    if (!Number.isFinite(value)) {",
+    "      return \"n/a\";",
+    "    }",
+    "    if (Math.abs(value) >= 1000 || Number.isInteger(value)) {",
+    "      return String(value);",
+    "    }",
+    "    return value.toFixed(3);",
+    "  }",
+    "",
+    "  // Formats nullable numbers, returning `n/a` when empty.",
+    "  function formatNullableNumberForClient(value) {",
+    "    return value === null ? \"n/a\" : formatNumberForClient(value);",
+    "  }",
+    "",
+    "  // Renders a metrics table inside the provided container. When no rows are",
+    "  // available the function falls back to an informative empty state.",
+    "  function renderMetricsTable(containerId, rows, emptyMessage) {",
+    "    const container = document.getElementById(containerId);",
+    "    if (!container) {",
+    "      return;",
+    "    }",
+    "    container.textContent = \"\";",
+    "    if (!rows.length) {",
+    "      const empty = document.createElement(\"p\");",
+    "      empty.className = \"empty-state\";",
+    "      empty.textContent = emptyMessage;",
+    "      container.appendChild(empty);",
+    "      return;",
+    "    }",
+    "    const table = document.createElement(\"table\");",
+    "    table.className = \"metrics-table\";",
+    "    const body = document.createElement(\"tbody\");",
+    "    for (const [label, value] of rows) {",
+    "      const tr = document.createElement(\"tr\");",
+    "      const th = document.createElement(\"th\");",
+    "      th.scope = \"row\";",
+    "      th.textContent = label;",
+    "      const td = document.createElement(\"td\");",
+    "      td.textContent = value;",
+    "      tr.appendChild(th);",
+    "      tr.appendChild(td);",
+    "      body.appendChild(tr);",
+    "    }",
+    "    table.appendChild(body);",
+    "    container.appendChild(table);",
+    "  }",
+    "",
+    "  // Updates the Stigmergy summary table and tooltip.",
+    "  function updateStigmergy(snapshot) {",
+    "    const tbody = document.getElementById(\"stigmergy-summary-rows\");",
+    "    if (tbody) {",
+    "      tbody.textContent = \"\";",
+    "      for (const row of snapshot.stigmergy.rows) {",
+    "        const tr = document.createElement(\"tr\");",
+    "        const th = document.createElement(\"th\");",
+    "        th.scope = \"row\";",
+    "        th.textContent = row.label;",
+    "        const td = document.createElement(\"td\");",
+    "        td.textContent = row.value;",
+    "        tr.appendChild(th);",
+    "        tr.appendChild(td);",
+    "        tbody.appendChild(tr);",
+    "      }",
+    "    }",
+    "    const tooltip = document.getElementById(\"stigmergy-tooltip\");",
+    "    if (tooltip) {",
+    "      tooltip.textContent = snapshot.heatmap.boundsTooltip ?? \"\";",
+    "    }",
+    "  }",
+    "",
+    "  // Updates Contract-Net watcher counters and bounds.",
+    "  function updateContractNet(snapshot) {",
+    "    const watcher = snapshot.contractNetWatcherTelemetry;",
+    "    if (!watcher) {",
+    "      renderMetricsTable(\"contract-net-summary\", [], \"Aucune télémétrie Contract-Net disponible.\");",
+    "      renderMetricsTable(\"contract-net-details\", [], \"Aucune télémétrie Contract-Net disponible.\");",
+    "      renderMetricsTable(\"contract-net-bounds\", [], \"Aucune télémétrie Contract-Net disponible.\");",
+    "      return;",
+    "    }",
+    "    renderMetricsTable(",
+    "      \"contract-net-summary\",",
+    "      [",
+    "        [\"Emissions\", formatNumberForClient(watcher.emissions)],",
+    "        [\"Dernier événement\", formatTimestampForClient(watcher.lastEmittedAtMs)],",
+    "      ],",
+    "      \"Aucune télémétrie Contract-Net disponible.\",",
+    "    );",
+    "",
+    "    const snapshotDetails = watcher.lastSnapshot;",
+    "    renderMetricsTable(",
+    "      \"contract-net-details\",",
+    "      snapshotDetails",
+    "        ? [",
+    "            [\"Raison\", snapshotDetails.reason],",
+    "            [\"Notifications reçues\", formatNumberForClient(snapshotDetails.receivedUpdates)],",
+    "            [\"Notifications coalescées\", formatNumberForClient(snapshotDetails.coalescedUpdates)],",
+    "            [\"Rafraîchissements ignorés\", formatNumberForClient(snapshotDetails.skippedRefreshes)],",
+    "            [\"Rafraîchissements appliqués\", formatNumberForClient(snapshotDetails.appliedRefreshes)],",
+    "            [\"Flushs\", formatNumberForClient(snapshotDetails.flushes)],",
+    "          ]",
+    "        : [],",
+    "      snapshotDetails",
+    "        ? \"Le watcher n'a pas encore publié de compteur.\",",
+    "        : \"Aucune télémétrie Contract-Net disponible.\",",
+    "    );",
+    "",
+    "    const bounds = snapshotDetails?.lastBounds;",
+    "    renderMetricsTable(",
+    "      \"contract-net-bounds\",",
+    "      bounds",
+    "        ? [",
+    "            [\"Min intensity\", formatNumberForClient(bounds.min_intensity)],",
+    "            [\"Max intensity\", formatNullableNumberForClient(bounds.max_intensity)],",
+    "            [\"Normalisation ceiling\", formatNumberForClient(bounds.normalisation_ceiling)],",
+    "          ]",
+    "        : [],",
+    "      bounds",
+    "        ? \"Aucune borne normalisée n'a été enregistrée.\",",
+    "        : \"Aucune télémétrie Contract-Net disponible.\",",
+    "    );",
+    "  }",
+    "",
+    "  // Updates scheduler counters embedded in the HTML table.",
+    "  function updateScheduler(snapshot) {",
+    "    const tick = document.getElementById(\"scheduler-tick\");",
+    "    if (tick) {",
+    "      tick.textContent = String(snapshot.scheduler.tick);",
+    "    }",
+    "    const backlog = document.getElementById(\"scheduler-backlog\");",
+    "    if (backlog) {",
+    "      backlog.textContent = String(snapshot.scheduler.backlog);",
+    "    }",
+    "    const completed = document.getElementById(\"scheduler-completed\");",
+    "    if (completed) {",
+    "      completed.textContent = String(snapshot.scheduler.completed);",
+    "    }",
+    "    const failed = document.getElementById(\"scheduler-failed\");",
+    "    if (failed) {",
+    "      failed.textContent = String(snapshot.scheduler.failed);",
+    "    }",
+    "    const updatedAt = document.getElementById(\"scheduler-updated-at\");",
+    "    if (updatedAt) {",
+    "      updatedAt.textContent = formatTimestampForClient(snapshot.scheduler.updatedAt);",
+    "    }",
+    "  }",
+    "",
+    "  // Synchronises the title timestamp with the latest snapshot.",
+    "  function updateHeader(snapshot) {",
+    "    const timestamp = document.getElementById(\"dashboard-timestamp\");",
+    "    if (timestamp) {",
+    "      timestamp.textContent = formatTimestampForClient(snapshot.timestamp);",
+    "    }",
+    "  }",
+    "",
+    "  // Applies the provided snapshot to every dashboard section.",
+    "  function applySnapshot(snapshot) {",
+    "    updateHeader(snapshot);",
+    "    updateContractNet(snapshot);",
+    "    updateStigmergy(snapshot);",
+    "    updateScheduler(snapshot);",
+    "  }",
+    "",
+    "  // Render the initial server-provided snapshot immediately.",
+    "  applySnapshot(initialSnapshot);",
+    "",
+    "  if (typeof window === \"undefined\" || !(\"EventSource\" in window)) {",
+    "    updateStatus(\"Flux SSE non supporté par ce navigateur.\", \"error\");",
+    "    return;",
+    "  }",
+    "",
+    "  updateStatus(\"Connexion SSE en cours…\", \"pending\");",
+    "  const source = new EventSource(\"stream\");",
+    "  source.onopen = () => {",
+    "    updateStatus(\"Flux SSE connecté\", \"connected\");",
+    "  };",
+    "  source.onmessage = (event) => {",
+    "    try {",
+    "      const parsed = JSON.parse(event.data);",
+    "      applySnapshot(parsed);",
+    "    } catch (error) {",
+    "      console.error(\"dashboard_stream_parse_failure\", error);",
+    "      updateStatus(\"Flux SSE : parsing JSON invalide.\", \"error\");",
+    "    }",
+    "  };",
+    "  source.onerror = () => {",
+    "    updateStatus(\"Flux SSE déconnecté – reconnexion automatique…\", \"error\");",
+    "  };",
+    "})();",
+  ];
+  return lines
+    .map((line) => (line.length > 0 ? `      ${line}` : ""))
+    .join("\n");
+}
+
+
+/**
+ * Serialises a snapshot for inclusion in the inline dashboard bootstrap. The
+ * payload escapes characters that could prematurely terminate the script tag
+ * (such as `</script>` or U+2028 line separators).
+ */
+function serialiseSnapshotForInlineScript(snapshot: DashboardSnapshot): string {
+  return JSON.stringify(snapshot)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }

--- a/src/resources/sse.ts
+++ b/src/resources/sse.ts
@@ -1,0 +1,123 @@
+import type { ResourceChildLogEntry, ResourceRunEvent, ResourceWatchResult } from "./registry.js";
+import { serialiseForSse } from "../events/sse.js";
+
+/**
+ * Shape of a Server-Sent Events (SSE) record emitted when streaming a
+ * `resources_watch` page. Each record corresponds to a single event/log entry
+ * so consumers can resume from the associated identifier.
+ */
+export interface ResourceWatchSseMessage {
+  /** Unique identifier for the SSE record (resource URI + monotonous sequence). */
+  id: string;
+  /** SSE event name discriminating run events, child logs or keep-alives. */
+  event: "resource_run_event" | "resource_child_log" | "resource_keep_alive";
+  /** JSON payload normalised for SSE transport (single `data:` line). */
+  data: string;
+}
+
+/**
+ * Normalises a run event for transport by switching to `snake_case` keys and
+ * removing `undefined` values. The helper keeps the original payload intact so
+ * downstream tools receive the same structure as `resources_watch`.
+ */
+function normaliseRunEvent(event: ResourceRunEvent) {
+  return {
+    type: "run_event" as const,
+    seq: event.seq,
+    ts: event.ts,
+    kind: event.kind,
+    level: event.level,
+    job_id: event.jobId ?? null,
+    run_id: event.runId,
+    op_id: event.opId ?? null,
+    graph_id: event.graphId ?? null,
+    node_id: event.nodeId ?? null,
+    child_id: event.childId ?? null,
+    payload: event.payload ?? null,
+  };
+}
+
+/**
+ * Normalises a child log entry for SSE transport. Optional fields are coerced to
+ * `null` so JSON serialisation stays stable and consumers can rely on explicit
+ * keys when decoding the stream.
+ */
+function normaliseChildLog(entry: ResourceChildLogEntry) {
+  return {
+    type: "child_log" as const,
+    seq: entry.seq,
+    ts: entry.ts,
+    stream: entry.stream,
+    message: entry.message,
+    job_id: entry.jobId ?? null,
+    run_id: entry.runId ?? null,
+    op_id: entry.opId ?? null,
+    graph_id: entry.graphId ?? null,
+    node_id: entry.nodeId ?? null,
+    child_id: entry.childId,
+    raw: entry.raw ?? null,
+    parsed: entry.parsed ?? null,
+  };
+}
+
+/**
+ * Builds the JSON payload transported on the SSE `data:` line. The payload
+ * includes the resource URI and `next_seq` pointer so reconnecting clients can
+ * resume a watch operation without additional bookkeeping.
+ */
+function buildPayload(
+  result: ResourceWatchResult,
+  record: ReturnType<typeof normaliseRunEvent> | ReturnType<typeof normaliseChildLog> | { type: "keep_alive" },
+) {
+  return {
+    uri: result.uri,
+    kind: result.kind,
+    next_seq: result.nextSeq,
+    record,
+  };
+}
+
+/**
+ * Serialises a `resources_watch` page into SSE records. Run events and child log
+ * entries are emitted individually while empty pages produce a keep-alive so the
+ * transport stays active and clients retain the `next_seq` cursor.
+ */
+export function serialiseResourceWatchResultForSse(result: ResourceWatchResult): ResourceWatchSseMessage[] {
+  if (result.events.length === 0) {
+    const keepAlivePayload = buildPayload(result, { type: "keep_alive" });
+    return [
+      {
+        id: `${result.uri}:${result.nextSeq}`,
+        event: "resource_keep_alive",
+        data: serialiseForSse(keepAlivePayload),
+      },
+    ];
+  }
+
+  return result.events.map((event) => {
+    if (result.kind === "run_events") {
+      const payload = buildPayload(result, normaliseRunEvent(event as ResourceRunEvent));
+      return {
+        id: `${result.uri}:${(event as ResourceRunEvent).seq}`,
+        event: "resource_run_event" as const,
+        data: serialiseForSse(payload),
+      };
+    }
+
+    const payload = buildPayload(result, normaliseChildLog(event as ResourceChildLogEntry));
+    return {
+      id: `${result.uri}:${(event as ResourceChildLogEntry).seq}`,
+      event: "resource_child_log" as const,
+      data: serialiseForSse(payload),
+    };
+  });
+}
+
+/**
+ * Renders SSE messages into a wire-ready string. Tests and upcoming HTTP
+ * handlers share this helper to keep the framing (`id/event/data` + blank line)
+ * consistent with the other SSE endpoints.
+ */
+export function renderResourceWatchSseMessages(messages: ResourceWatchSseMessage[]): string {
+  return messages.map((message) => `id: ${message.id}\nevent: ${message.event}\ndata: ${message.data}\n\n`).join("");
+}

--- a/tests/bt.composites.cancel.test.ts
+++ b/tests/bt.composites.cancel.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, describe, it } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+  BehaviorTreeCancellationError,
+  SelectorNode,
+  SequenceNode,
+} from "../src/executor/bt/nodes.js";
+import { OperationCancelledError } from "../src/executor/cancel.js";
+import type {
+  BehaviorNode,
+  BehaviorNodeSnapshot,
+  BehaviorTickResult,
+  TickRuntime,
+} from "../src/executor/bt/types.js";
+
+/**
+ * Lightweight scripted node used by the composite cancellation tests. Each reset
+ * advances to the next scripted run so the scenarios can model retries after
+ * cooperative cancellation rewinds the tree.
+ */
+class ScriptedCompositeChild implements BehaviorNode {
+  private runIndex = 0;
+  private stepIndex = 0;
+  public readonly id: string;
+  private readonly runs: BehaviorTickResult[][];
+  public resets = 0;
+  private status: BehaviorNodeSnapshot["status"] = "idle";
+
+  constructor(id: string, runs: BehaviorTickResult[][]) {
+    this.id = id;
+    this.runs = runs;
+  }
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const run = this.runs[Math.min(this.runIndex, this.runs.length - 1)];
+    const currentIndex = Math.min(this.stepIndex, run.length - 1);
+    const result = run[currentIndex];
+    this.stepIndex = Math.min(run.length - 1, this.stepIndex + 1);
+    this.status = result.status === "running" ? "running" : result.status;
+    return result;
+  }
+
+  reset(): void {
+    this.stepIndex = 0;
+    if (this.runIndex < this.runs.length - 1) {
+      this.runIndex += 1;
+    }
+    this.resets += 1;
+    this.status = "idle";
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "scripted-composite-child",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: {
+        runIndex: this.runIndex,
+        stepIndex: this.stepIndex,
+        resets: this.resets,
+      },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "scripted-composite-child") {
+      throw new Error(`expected scripted-composite-child snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { runIndex?: number; stepIndex?: number; resets?: number } | undefined;
+    this.runIndex = typeof state?.runIndex === "number" ? state.runIndex : 0;
+    this.stepIndex = typeof state?.stepIndex === "number" ? state.stepIndex : 0;
+    this.resets = typeof state?.resets === "number" ? state.resets : 0;
+    this.status = snapshot.status;
+  }
+
+  getProgress(): number {
+    const run = this.runs[Math.min(this.runIndex, this.runs.length - 1)] ?? [];
+    if (run.length === 0) {
+      return 1;
+    }
+    const completed = Math.min(this.stepIndex, run.length);
+    return completed / run.length;
+  }
+}
+
+describe("behaviour tree composites", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("SequenceNode", () => {
+    it("rewinds all children when cancellation occurs between ticks", async () => {
+      const first = new ScriptedCompositeChild("first", [
+        [{ status: "success" }],
+        [{ status: "success" }],
+      ]);
+      const second = new ScriptedCompositeChild("second", [
+        [{ status: "running" }, { status: "success" }],
+        [{ status: "success" }],
+      ]);
+      const node = new SequenceNode("sequence", [first, second]);
+
+      let cancellationChecks = 0;
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        variables: {},
+        throwIfCancelled: () => {
+          cancellationChecks += 1;
+          if (cancellationChecks === 3) {
+            throw new BehaviorTreeCancellationError("sequence cancelled");
+          }
+        },
+      };
+
+      const firstTick = await node.tick(runtime);
+      expect(firstTick.status).to.equal("running");
+      expect(first.resets).to.equal(0);
+      expect(second.resets).to.equal(0);
+
+      await node.tick(runtime).then(
+        () => {
+          expect.fail("SequenceNode should propagate the cancellation before resuming the running child");
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+        },
+      );
+
+      expect(first.resets).to.equal(1);
+      expect(second.resets).to.equal(1);
+
+      const cleanRuntime: TickRuntime = {
+        ...runtime,
+        throwIfCancelled: undefined,
+      };
+      const completion = await node.tick(cleanRuntime);
+      expect(completion.status).to.equal("success");
+      expect(first.resets).to.equal(2);
+      expect(second.resets).to.equal(2);
+    });
+
+    it("resets children when a running child surfaces cancellation", async () => {
+      class CancellingChild implements BehaviorNode {
+        public readonly id = "cancel";
+        public resets = 0;
+        private primed = false;
+        private status: BehaviorNodeSnapshot["status"] = "idle";
+
+        async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+          if (!this.primed) {
+            this.status = "failure";
+            throw new OperationCancelledError({
+              opId: "op-seq",
+              runId: "run-seq",
+              jobId: null,
+              graphId: null,
+              nodeId: null,
+              childId: null,
+              reason: "sequence child cancel",
+            });
+          }
+          this.status = "success";
+          return { status: "success" };
+        }
+
+        reset(): void {
+          this.resets += 1;
+          this.primed = true;
+          this.status = "idle";
+        }
+
+        snapshot(): BehaviorNodeSnapshot {
+          return {
+            id: this.id,
+            type: "sequence-cancelling-child",
+            status: this.status,
+            progress: this.getProgress() * 100,
+            state: { primed: this.primed, resets: this.resets },
+          } satisfies BehaviorNodeSnapshot;
+        }
+
+        restore(snapshot: BehaviorNodeSnapshot): void {
+          if (snapshot.type !== "sequence-cancelling-child") {
+            throw new Error(`expected sequence-cancelling-child snapshot for ${this.id}, received ${snapshot.type}`);
+          }
+          const state = snapshot.state as { primed?: boolean; resets?: number } | undefined;
+          this.primed = state?.primed ?? false;
+          this.resets = typeof state?.resets === "number" ? state.resets : 0;
+          this.status = snapshot.status;
+        }
+
+        getProgress(): number {
+          return this.primed ? 1 : 0;
+        }
+      }
+
+      const child = new CancellingChild();
+      const node = new SequenceNode("sequence-cancel", [child]);
+      const runtime: TickRuntime = { invokeTool: async () => null, variables: {} };
+
+      await node.tick(runtime).then(
+        () => {
+          expect.fail("SequenceNode should surface cancellation errors emitted by children");
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(OperationCancelledError);
+        },
+      );
+
+      expect(child.resets).to.equal(1);
+
+      const completion = await node.tick(runtime);
+      expect(completion.status).to.equal("success");
+      expect(child.resets).to.equal(2);
+    });
+  });
+
+  describe("SelectorNode", () => {
+    it("rewinds to the first child when cancellation preempts the next candidate", async () => {
+      const first = new ScriptedCompositeChild("first-selector", [
+        [{ status: "failure" }],
+        [{ status: "failure" }],
+      ]);
+      const second = new ScriptedCompositeChild("second-selector", [
+        [{ status: "running" }, { status: "success" }],
+        [{ status: "success" }],
+      ]);
+      const node = new SelectorNode("selector", [first, second]);
+
+      let cancellationChecks = 0;
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        variables: {},
+        throwIfCancelled: () => {
+          cancellationChecks += 1;
+          if (cancellationChecks === 3) {
+            throw new BehaviorTreeCancellationError("selector cancelled");
+          }
+        },
+      };
+
+      const firstTick = await node.tick(runtime);
+      expect(firstTick.status).to.equal("running");
+      expect(first.resets).to.equal(0);
+      expect(second.resets).to.equal(0);
+
+      await node.tick(runtime).then(
+        () => {
+          expect.fail("SelectorNode should propagate cancellation before retrying the running child");
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+        },
+      );
+
+      expect(first.resets).to.equal(1);
+      expect(second.resets).to.equal(1);
+
+      const cleanRuntime: TickRuntime = {
+        ...runtime,
+        throwIfCancelled: undefined,
+      };
+      const completion = await node.tick(cleanRuntime);
+      expect(completion.status).to.equal("success");
+      expect(first.resets).to.equal(2);
+      expect(second.resets).to.equal(2);
+    });
+
+    it("resets the failing child when cancellation is thrown mid-execution", async () => {
+      class CancellingSelectorChild implements BehaviorNode {
+        public readonly id = "selector-cancel";
+        public resets = 0;
+        private allowSuccess = false;
+        private status: BehaviorNodeSnapshot["status"] = "idle";
+
+        async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+          if (!this.allowSuccess) {
+            this.status = "failure";
+            throw new OperationCancelledError({
+              opId: "op-selector",
+              runId: "run-selector",
+              jobId: null,
+              graphId: null,
+              nodeId: null,
+              childId: null,
+              reason: "selector child cancel",
+            });
+          }
+          this.status = "success";
+          return { status: "success" };
+        }
+
+        reset(): void {
+          this.resets += 1;
+          this.allowSuccess = true;
+          this.status = "idle";
+        }
+
+        snapshot(): BehaviorNodeSnapshot {
+          return {
+            id: this.id,
+            type: "selector-cancelling-child",
+            status: this.status,
+            progress: this.getProgress() * 100,
+            state: { allowSuccess: this.allowSuccess, resets: this.resets },
+          } satisfies BehaviorNodeSnapshot;
+        }
+
+        restore(snapshot: BehaviorNodeSnapshot): void {
+          if (snapshot.type !== "selector-cancelling-child") {
+            throw new Error(`expected selector-cancelling-child snapshot for ${this.id}, received ${snapshot.type}`);
+          }
+          const state = snapshot.state as { allowSuccess?: boolean; resets?: number } | undefined;
+          this.allowSuccess = state?.allowSuccess ?? false;
+          this.resets = typeof state?.resets === "number" ? state.resets : 0;
+          this.status = snapshot.status;
+        }
+
+        getProgress(): number {
+          return this.allowSuccess ? 1 : 0;
+        }
+      }
+
+      const failing = new ScriptedCompositeChild("always-fail", [
+        [{ status: "failure" }],
+        [{ status: "failure" }],
+      ]);
+      const cancelling = new CancellingSelectorChild();
+      const node = new SelectorNode("selector-cancel", [failing, cancelling]);
+      const runtime: TickRuntime = { invokeTool: async () => null, variables: {} };
+
+      await node.tick(runtime).then(
+        () => {
+          expect.fail("SelectorNode should surface cancellation errors raised by children");
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(OperationCancelledError);
+        },
+      );
+
+      expect(failing.resets).to.equal(1);
+      expect(cancelling.resets).to.equal(1);
+
+      const completion = await node.tick(runtime);
+      expect(completion.status).to.equal("success");
+      expect(failing.resets).to.equal(2);
+      expect(cancelling.resets).to.equal(2);
+    });
+  });
+});
+

--- a/tests/bt.decorators.retry-timeout-cancel.test.ts
+++ b/tests/bt.decorators.retry-timeout-cancel.test.ts
@@ -1,0 +1,650 @@
+import { afterEach, describe, it } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+  BehaviorTreeCancellationError,
+  CancellableNode,
+  GuardNode,
+  RetryNode,
+  TimeoutNode,
+} from "../src/executor/bt/nodes.js";
+import { OperationCancelledError } from "../src/executor/cancel.js";
+import type {
+  BehaviorNode,
+  BehaviorNodeSnapshot,
+  BehaviorTickResult,
+  TickRuntime,
+} from "../src/executor/bt/types.js";
+
+/**
+ * Deterministic behaviour node returning scripted results across ticks while tracking
+ * invocations and resets for assertions. Each reset advances to the next scripted
+ * run so tests can express sequences of outcomes across retries.
+ */
+class ScriptedNode implements BehaviorNode {
+  private runIndex = 0;
+  private stepIndex = 0;
+  public readonly id: string;
+  private readonly runs: BehaviorTickResult[][];
+  public readonly calls: BehaviorTickResult[] = [];
+  public resets = 0;
+  private status: BehaviorNodeSnapshot["status"] = "idle";
+
+  constructor(id: string, runs: BehaviorTickResult[][]) {
+    this.id = id;
+    this.runs = runs;
+  }
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const run = this.runs[Math.min(this.runIndex, this.runs.length - 1)];
+    const currentIndex = Math.min(this.stepIndex, run.length - 1);
+    const result = run[currentIndex];
+    this.calls.push(result);
+    this.stepIndex = Math.min(run.length - 1, this.stepIndex + 1);
+    this.status = result.status === "running" ? "running" : result.status;
+    return result;
+  }
+
+  reset(): void {
+    this.stepIndex = 0;
+    if (this.runIndex < this.runs.length - 1) {
+      this.runIndex += 1;
+    }
+    this.resets += 1;
+    this.status = "idle";
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "scripted-node",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: {
+        runIndex: this.runIndex,
+        stepIndex: this.stepIndex,
+        resets: this.resets,
+      },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "scripted-node") {
+      throw new Error(`expected scripted-node snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { runIndex?: number; stepIndex?: number; resets?: number } | undefined;
+    this.runIndex = typeof state?.runIndex === "number" ? state.runIndex : 0;
+    this.stepIndex = typeof state?.stepIndex === "number" ? state.stepIndex : 0;
+    this.resets = typeof state?.resets === "number" ? state.resets : 0;
+    this.status = snapshot.status;
+  }
+
+  getProgress(): number {
+    const run = this.runs[Math.min(this.runIndex, this.runs.length - 1)] ?? [];
+    if (run.length === 0) {
+      return 1;
+    }
+    const completed = Math.min(this.stepIndex, run.length);
+    return completed / run.length;
+  }
+}
+
+describe("behaviour tree decorators", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("RetryNode", () => {
+    it("waits with jitter between attempts and resets on success", async () => {
+      const child = new ScriptedNode("flaky", [[{ status: "failure" }], [{ status: "success" }]]);
+      const waitSpy = sinon.spy(async (_ms: number) => {});
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: waitSpy,
+        random: () => 0.4,
+        variables: {},
+      };
+      const node = new RetryNode("retry", 3, child, 10, 5);
+
+      const firstTick = await node.tick(runtime);
+      expect(firstTick.status).to.equal("running");
+      expect(waitSpy.callCount).to.equal(1);
+      expect(waitSpy.firstCall.args[0]).to.equal(12);
+      expect(child.resets).to.equal(1);
+
+      const secondTick = await node.tick(runtime);
+      expect(secondTick.status).to.equal("success");
+      expect(child.resets).to.equal(2);
+    });
+
+    it("fails once the attempt budget is exhausted", async () => {
+      const child = new ScriptedNode("always-fail", [[{ status: "failure" }]]);
+      const waitSpy = sinon.spy(async (_ms: number) => {});
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: waitSpy,
+        variables: {},
+      };
+      const node = new RetryNode("retry-budget", 2, child, 5, 0);
+
+      const firstTick = await node.tick(runtime);
+      expect(firstTick.status).to.equal("running");
+      expect(waitSpy.callCount).to.equal(1);
+
+      const secondTick = await node.tick(runtime);
+      expect(secondTick.status).to.equal("failure");
+      expect(waitSpy.callCount).to.equal(1);
+      expect(child.resets).to.equal(2);
+    });
+
+    it("propagates cancellation raised before the first attempt without rewinding the child", async () => {
+      const child = new ScriptedNode("cancel-before", [[{ status: "success" }]]);
+      const cancellationError = new OperationCancelledError({
+        opId: "op-retry-pre",
+        runId: "run-retry",
+        jobId: null,
+        graphId: null,
+        nodeId: null,
+        childId: null,
+        reason: "pre",
+      });
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        wait: async () => {},
+        variables: {},
+        throwIfCancelled: () => {
+          throw cancellationError;
+        },
+      };
+      const node = new RetryNode("retry-cancel-before", 3, child, 0, 0);
+
+      const raised = await node.tick(runtime).then(
+        () => {
+          expect.fail("RetryNode should surface the cancellation before invoking the child");
+          return null as never;
+        },
+        (error) => {
+          expect(error).to.equal(cancellationError);
+          return error;
+        },
+      );
+
+      expect(raised).to.equal(cancellationError);
+      expect(child.calls).to.deep.equal([]);
+      expect(child.resets).to.equal(0);
+
+      // Remove the cancellation hook to ensure the subsequent tick can run normally.
+      const cleanRuntime: TickRuntime = { ...runtime, throwIfCancelled: undefined };
+      const result = await node.tick(cleanRuntime);
+      expect(result.status).to.equal("success");
+    });
+
+    it("resets state when cancellation surfaces from the child during execution", async () => {
+      class CancellingChild implements BehaviorNode {
+        public readonly id = "cancel-child";
+        public resets = 0;
+        private attempts = 0;
+        private status: BehaviorNodeSnapshot["status"] = "idle";
+
+        async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+          this.attempts += 1;
+          if (this.attempts === 1) {
+            this.status = "failure";
+            throw new OperationCancelledError({
+              opId: "op-retry-child",
+              runId: "run-retry-child",
+              jobId: null,
+              graphId: null,
+              nodeId: null,
+              childId: null,
+              reason: "child-cancel",
+            });
+          }
+          this.status = "success";
+          return { status: "success" };
+        }
+
+        reset(): void {
+          this.resets += 1;
+          this.status = "idle";
+        }
+
+        snapshot(): BehaviorNodeSnapshot {
+          return {
+            id: this.id,
+            type: "retry-cancelling-child",
+            status: this.status,
+            progress: this.getProgress() * 100,
+            state: { attempts: this.attempts, resets: this.resets },
+          } satisfies BehaviorNodeSnapshot;
+        }
+
+        restore(snapshot: BehaviorNodeSnapshot): void {
+          if (snapshot.type !== "retry-cancelling-child") {
+            throw new Error(`expected retry-cancelling-child snapshot for ${this.id}, received ${snapshot.type}`);
+          }
+          const state = snapshot.state as { attempts?: number; resets?: number } | undefined;
+          this.attempts = typeof state?.attempts === "number" ? state.attempts : 0;
+          this.resets = typeof state?.resets === "number" ? state.resets : 0;
+          this.status = snapshot.status;
+        }
+
+        getProgress(): number {
+          return this.attempts > 1 ? 1 : this.attempts > 0 ? 0.5 : 0;
+        }
+      }
+
+      const child = new CancellingChild();
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        wait: async () => {},
+        variables: {},
+      };
+      const node = new RetryNode("retry-child-cancel", 2, child, 0, 0);
+
+      await node.tick(runtime).then(
+        () => {
+          expect.fail("RetryNode should propagate the cancellation error raised by the child");
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(OperationCancelledError);
+        },
+      );
+
+      expect(child.resets).to.equal(1);
+
+      // After cancellation the retry decorator should restart from a clean slate.
+      const second = await node.tick(runtime);
+      expect(second.status).to.equal("success");
+      expect(child.resets).to.equal(2);
+    });
+
+    it("cleans up after cancellation triggered during retry backoff", async () => {
+      const child = new ScriptedNode("cancel-wait", [
+        [{ status: "failure" }],
+        [{ status: "success" }],
+      ]);
+      const cancellationError = new BehaviorTreeCancellationError("cancel wait");
+      let callCount = 0;
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        wait: async () => {},
+        variables: {},
+        throwIfCancelled: () => {
+          callCount += 1;
+          // The second cooperative check mimics a cancellation happening during the
+          // retry delay, after the child has already been rewound.
+          if (callCount === 2) {
+            throw cancellationError;
+          }
+        },
+      };
+      const node = new RetryNode("retry-wait-cancel", 3, child, 5, 0);
+
+      await node.tick(runtime).then(
+        () => {
+          expect.fail("RetryNode should propagate cancellation during backoff");
+        },
+        (error) => {
+          expect(error).to.equal(cancellationError);
+        },
+      );
+
+      expect(child.resets).to.equal(1);
+
+      const resumed = await node.tick({ ...runtime, throwIfCancelled: undefined });
+      expect(resumed.status).to.equal("success");
+      expect(child.resets).to.equal(2);
+    });
+  });
+
+  describe("TimeoutNode", () => {
+    let clock: sinon.SinonFakeTimers | null = null;
+
+    afterEach(() => {
+      if (clock) {
+        clock.restore();
+        clock = null;
+      }
+    });
+
+    it("fails when the child execution exceeds the configured budget", async () => {
+      clock = sinon.useFakeTimers();
+      let resets = 0;
+      const telemetry: Array<{ durationMs: number; success: boolean; budgetMs: number }> = [];
+      const child: BehaviorNode = {
+        id: "slow",
+        async tick(runtime: TickRuntime): Promise<BehaviorTickResult> {
+          await runtime.wait(100);
+          return { status: "success" };
+        },
+        reset(): void {
+          resets += 1;
+        },
+      };
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => (clock ? clock.now : Date.now()),
+        wait: async (ms: number) => {
+          if (!clock) {
+            return;
+          }
+          await clock.tickAsync(ms);
+        },
+        variables: {},
+        recordTimeoutOutcome: (_category, payload) => {
+          telemetry.push(payload);
+        },
+      };
+      const node = new TimeoutNode("timeout", 50, child, { category: "io" });
+
+      const resultPromise = node.tick(runtime);
+      await clock.tickAsync(60);
+      const result = await resultPromise;
+
+      expect(result.status).to.equal("failure");
+      expect(resets).to.equal(2);
+      expect(telemetry).to.deep.equal([{ durationMs: 50, success: false, budgetMs: 50 }]);
+    });
+
+    it("rewinds the child and wraps custom cancellation causes before execution", async () => {
+      const child = new ScriptedNode("guarded-by-timeout", [[{ status: "success" }]]);
+      const cancellationCause = new Error("network stalled");
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: {},
+        throwIfCancelled: () => {
+          throw cancellationCause;
+        },
+      };
+      const node = new TimeoutNode("timeout-cancel", 100, child);
+
+      const cancellation = await node.tick(runtime).then(
+        () => {
+          expect.fail("TimeoutNode should surface cancellation");
+          return null as never;
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+          return error as BehaviorTreeCancellationError & { cause?: unknown };
+        },
+      );
+      expect(cancellation.message).to.equal("network stalled");
+      expect(cancellation.cause).to.equal(cancellationCause);
+      expect(child.calls.length).to.equal(0);
+      expect(child.resets).to.equal(1);
+    });
+
+    it("propagates OperationCancelledError surfaced by the child while resetting state", async () => {
+      let resets = 0;
+      let calls = 0;
+      const cancellationError = new OperationCancelledError({
+        opId: "op-timeout-cancel",
+        runId: "run-timeout",
+        jobId: null,
+        graphId: null,
+        nodeId: null,
+        childId: null,
+        reason: "manual abort",
+      });
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => new Promise(() => {}),
+        variables: {},
+        throwIfCancelled: () => {
+          calls += 1;
+          if (calls >= 2) {
+            throw cancellationError;
+          }
+        },
+      };
+      const child: BehaviorNode = {
+        id: "cancellable-child",
+        async tick(innerRuntime: TickRuntime): Promise<BehaviorTickResult> {
+          innerRuntime.throwIfCancelled?.();
+          return { status: "success" };
+        },
+        reset(): void {
+          resets += 1;
+        },
+      };
+      const node = new TimeoutNode("timeout-child-cancel", 200, child);
+
+      const cancellation = await node.tick(runtime).then(
+        () => {
+          expect.fail("TimeoutNode should propagate the cancellation error");
+          return null as never;
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(OperationCancelledError);
+          return error as OperationCancelledError;
+        },
+      );
+      expect(cancellation).to.equal(cancellationError);
+      expect(cancellation.details.reason).to.equal("manual abort");
+      expect(resets).to.equal(1);
+    });
+  });
+
+  describe("GuardNode", () => {
+    it("short-circuits when the condition does not hold", async () => {
+      const child = new ScriptedNode("guarded", [[{ status: "success" }]]);
+      const guard = new GuardNode("guard", "flag", true, child);
+
+      const failingRuntime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: { flag: false },
+      };
+
+      const failure = await guard.tick(failingRuntime);
+      expect(failure.status).to.equal("failure");
+      expect(child.calls.length).to.equal(0);
+      expect(child.resets).to.equal(1);
+
+      const passingRuntime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: { flag: true },
+      };
+
+      const success = await guard.tick(passingRuntime);
+      expect(success.status).to.equal("success");
+      expect(child.calls.length).to.equal(1);
+      expect(child.resets).to.equal(2);
+    });
+
+    it("wraps cancellation causes raised before evaluating the guard", async () => {
+      const child = new ScriptedNode("guarded", [[{ status: "success" }]]);
+      const cancellationCause = new Error("external cancellation");
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: { flag: true },
+        throwIfCancelled: () => {
+          throw cancellationCause;
+        },
+      };
+      const guard = new GuardNode("guard-cancel", "flag", true, child);
+
+      const cancellation = await guard.tick(runtime).then(
+        () => {
+          expect.fail("GuardNode should surface cancellation");
+          return null as never;
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+          return error as BehaviorTreeCancellationError & { cause?: unknown };
+        },
+      );
+      expect(cancellation.message).to.equal("external cancellation");
+      expect(cancellation.cause).to.equal(cancellationCause);
+      expect(child.calls.length).to.equal(0);
+      expect(child.resets).to.equal(1);
+    });
+
+    it("propagates OperationCancelledError when cancellation triggers after a running tick", async () => {
+      const child = new ScriptedNode("guarded-running", [[{ status: "running" }]]);
+      const cancellationError = new OperationCancelledError({
+        opId: "guard-op",
+        runId: "guard-run",
+        jobId: null,
+        graphId: null,
+        nodeId: null,
+        childId: null,
+        reason: "late cancel",
+      });
+      const cancellations: Array<Error | undefined> = [undefined, undefined, cancellationError];
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: { flag: true },
+        throwIfCancelled: () => {
+          const next = cancellations.shift();
+          if (next) {
+            throw next;
+          }
+        },
+      };
+      const guard = new GuardNode("guard-running-cancel", "flag", true, child);
+
+      const running = await guard.tick(runtime);
+      expect(running.status).to.equal("running");
+      expect(child.calls.length).to.equal(1);
+      expect(child.resets).to.equal(0);
+
+      const cancellation = await guard.tick(runtime).then(
+        () => {
+          expect.fail("GuardNode should propagate the cancellation error");
+          return null as never;
+        },
+        (error) => {
+          expect(error).to.be.instanceOf(OperationCancelledError);
+          return error as OperationCancelledError;
+        },
+      );
+      expect(cancellation).to.equal(cancellationError);
+      expect(cancellation.details.reason).to.equal("late cancel");
+      expect(child.resets).to.equal(1);
+    });
+  });
+
+  describe("CancellableNode", () => {
+    it("propagates cancellations as errors while resetting the child", async () => {
+      const child = new ScriptedNode("cancellable", [
+        [{ status: "running" }],
+        [{ status: "running" }, { status: "success" }],
+      ]);
+      let cancelled = false;
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: {},
+        isCancelled: () => cancelled,
+      };
+      const node = new CancellableNode("cancellable-node", child);
+
+      const firstTick = await node.tick(runtime);
+      expect(firstTick.status).to.equal("running");
+      expect(child.calls.length).to.equal(1);
+
+      cancelled = true;
+      let caught: unknown;
+      try {
+        await node.tick(runtime);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).to.not.equal(undefined);
+      if (caught instanceof OperationCancelledError) {
+        expect(caught.code).to.equal("E-CANCEL-OP");
+      } else {
+        expect(caught).to.be.instanceOf(Error);
+        expect((caught as Error).name).to.equal("BehaviorTreeCancellationError");
+      }
+      expect(child.resets).to.be.at.least(1);
+
+      cancelled = false;
+      const resumed = await node.tick(runtime);
+      expect(resumed.status).to.equal("running");
+      const final = await node.tick(runtime);
+      expect(final.status).to.equal("success");
+    });
+
+    it("wraps arbitrary throwIfCancelled errors into BehaviorTreeCancellationError", async () => {
+      const child = new ScriptedNode("cancellable", [[{ status: "success" }]]);
+      const cancellationCause = new Error("custom cancellation");
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: {},
+        throwIfCancelled: () => {
+          throw cancellationCause;
+        },
+      };
+      const node = new CancellableNode("cancellable-node", child);
+
+      let caught: unknown;
+      try {
+        await node.tick(runtime);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(child.calls.length).to.equal(0);
+      expect(child.resets).to.equal(1);
+      expect(caught).to.be.instanceOf(BehaviorTreeCancellationError);
+      expect((caught as BehaviorTreeCancellationError).cause).to.equal(cancellationCause);
+      expect((caught as Error).message).to.equal("custom cancellation");
+    });
+
+    it("resets the child when cancellation occurs after a running tick", async () => {
+      const child = new ScriptedNode("cancellable", [[{ status: "running" }]]);
+      const cancellationCause = new Error("late cancellation");
+      let cancelled = false;
+      const runtime: TickRuntime = {
+        invokeTool: async () => null,
+        now: () => 0,
+        wait: async () => {},
+        variables: {},
+        throwIfCancelled: () => {
+          if (cancelled) {
+            throw cancellationCause;
+          }
+        },
+      };
+      const node = new CancellableNode("cancellable-node", child);
+
+      const running = await node.tick(runtime);
+      expect(running.status).to.equal("running");
+      expect(child.calls.length).to.equal(1);
+      expect(child.resets).to.equal(0);
+
+      cancelled = true;
+
+      let caught: unknown;
+      try {
+        await node.tick(runtime);
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(child.resets).to.equal(1);
+      expect(caught).to.be.instanceOf(BehaviorTreeCancellationError);
+      expect((caught as BehaviorTreeCancellationError).cause).to.equal(cancellationCause);
+      expect((caught as Error).message).to.equal("late cancellation");
+    });
+  });
+});

--- a/tests/bt.parallel.cancel.test.ts
+++ b/tests/bt.parallel.cancel.test.ts
@@ -1,0 +1,314 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BehaviorTreeCancellationError, ParallelNode } from "../src/executor/bt/nodes.js";
+import { OperationCancelledError } from "../src/executor/cancel.js";
+import type {
+  BehaviorNode,
+  BehaviorNodeSnapshot,
+  BehaviorTickResult,
+  TickRuntime,
+} from "../src/executor/bt/types.js";
+
+/**
+ * Scenario-based scripted child used by the parallel cancellation tests. Each reset
+ * progresses to the next scripted run so the suite can assert that cancellations
+ * rewind branch-specific state before the composite retries.
+ */
+class ScriptedParallelChild implements BehaviorNode {
+  private runIndex = 0;
+  private stepIndex = 0;
+  public readonly id: string;
+  private readonly runs: ScriptedStep[][];
+  public resets = 0;
+  private status: BehaviorNodeSnapshot["status"] = "idle";
+
+  constructor(id: string, runs: ScriptedStep[][]) {
+    this.id = id;
+    this.runs = runs;
+  }
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const run = this.runs[Math.min(this.runIndex, this.runs.length - 1)];
+    const currentStep = run[Math.min(this.stepIndex, run.length - 1)];
+    this.stepIndex = Math.min(run.length - 1, this.stepIndex + 1);
+    if (currentStep.kind === "throw") {
+      this.status = "failure";
+      throw currentStep.error;
+    }
+    this.status = currentStep.status === "running" ? "running" : currentStep.status;
+    return currentStep;
+  }
+
+  reset(): void {
+    this.stepIndex = 0;
+    if (this.runIndex < this.runs.length - 1) {
+      this.runIndex += 1;
+    }
+    this.resets += 1;
+    this.status = "idle";
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "scripted-parallel-child",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: {
+        runIndex: this.runIndex,
+        stepIndex: this.stepIndex,
+        resets: this.resets,
+      },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "scripted-parallel-child") {
+      throw new Error(`expected scripted-parallel-child snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { runIndex?: number; stepIndex?: number; resets?: number } | undefined;
+    this.runIndex = typeof state?.runIndex === "number" ? state.runIndex : 0;
+    this.stepIndex = typeof state?.stepIndex === "number" ? state.stepIndex : 0;
+    this.resets = typeof state?.resets === "number" ? state.resets : 0;
+    this.status = snapshot.status;
+  }
+
+  getProgress(): number {
+    const run = this.runs[Math.min(this.runIndex, this.runs.length - 1)] ?? [];
+    if (run.length === 0) {
+      return 1;
+    }
+    const completed = Math.min(this.stepIndex, run.length);
+    return completed / run.length;
+  }
+}
+
+interface ThrowStep {
+  readonly kind: "throw";
+  readonly error: Error;
+}
+
+type ScriptedStep = BehaviorTickResult | ThrowStep;
+
+const idleRuntime: TickRuntime = { invokeTool: async () => null, variables: {} };
+
+describe("ParallelNode cancellation", () => {
+  it("resets cached statuses when a child surfaces cancellation", async () => {
+    const first = new ScriptedParallelChild("first", [
+      [{ status: "success" }],
+      [{ status: "success" }],
+    ]);
+    const second = new ScriptedParallelChild("second", [
+      [
+        { status: "running" },
+        { kind: "throw", error: new BehaviorTreeCancellationError("child cancelled") },
+      ],
+      [{ status: "running" }, { status: "success" }],
+    ]);
+    const third = new ScriptedParallelChild("third", [
+      [{ status: "running" }, { status: "success" }],
+      [{ status: "running" }, { status: "success" }],
+    ]);
+    const node = new ParallelNode("parallel-quota-cancel", { mode: "quota", threshold: 2 }, [
+      first,
+      second,
+      third,
+    ]);
+
+    const firstTick = await node.tick(idleRuntime);
+    expect(firstTick.status).to.equal("running");
+    expect(first.resets).to.equal(0);
+    expect(second.resets).to.equal(0);
+    expect(third.resets).to.equal(0);
+
+    await node.tick(idleRuntime).then(
+      () => {
+        expect.fail("ParallelNode should propagate the cancellation surfaced by the child");
+      },
+      (error) => {
+        expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+      },
+    );
+
+    expect(first.resets).to.equal(1);
+    expect(second.resets).to.equal(1);
+    expect(third.resets).to.equal(1);
+
+    const retryTick = await node.tick(idleRuntime);
+    expect(retryTick.status).to.equal("running");
+    expect(first.resets).to.equal(1);
+    expect(second.resets).to.equal(1);
+    expect(third.resets).to.equal(1);
+
+    const completion = await node.tick(idleRuntime);
+    expect(completion.status).to.equal("success");
+    expect(first.resets).to.equal(2);
+    expect(second.resets).to.equal(2);
+    expect(third.resets).to.equal(2);
+  });
+
+  it("propagates runtime cancellations and clears per-branch state", async () => {
+    const first = new ScriptedParallelChild("first-runtime", [
+      [{ status: "success" }],
+      [{ status: "success" }],
+    ]);
+    const second = new ScriptedParallelChild("second-runtime", [
+      [{ status: "running" }, { status: "success" }],
+      [{ status: "running" }, { status: "success" }],
+    ]);
+    const third = new ScriptedParallelChild("third-runtime", [
+      [{ status: "running" }, { status: "success" }],
+      [{ status: "running" }, { status: "success" }],
+    ]);
+    const node = new ParallelNode("parallel-runtime-cancel", { mode: "quota", threshold: 2 }, [
+      first,
+      second,
+      third,
+    ]);
+
+    const initialTick = await node.tick(idleRuntime);
+    expect(initialTick.status).to.equal("running");
+
+    let cancellationChecks = 0;
+    const runtimeCancellation = new OperationCancelledError({
+      opId: "op-parallel",
+      runId: "run-parallel",
+      jobId: null,
+      graphId: null,
+      nodeId: null,
+      childId: null,
+      reason: "runtime cancelled",
+    });
+    const cancellingRuntime: TickRuntime = {
+      ...idleRuntime,
+      throwIfCancelled: () => {
+        cancellationChecks += 1;
+        if (cancellationChecks === 3) {
+          throw runtimeCancellation;
+        }
+      },
+    };
+
+    await node.tick(cancellingRuntime).then(
+      () => {
+        expect.fail("ParallelNode should surface runtime cancellations");
+      },
+      (error) => {
+        expect(error).to.equal(runtimeCancellation);
+      },
+    );
+
+    expect(first.resets).to.equal(1);
+    expect(second.resets).to.equal(1);
+    expect(third.resets).to.equal(1);
+
+    const resumedTick = await node.tick(idleRuntime);
+    expect(resumedTick.status).to.equal("running");
+
+    const resumedCompletion = await node.tick(idleRuntime);
+    expect(resumedCompletion.status).to.equal("success");
+    expect(first.resets).to.equal(2);
+    expect(second.resets).to.equal(2);
+    expect(third.resets).to.equal(2);
+  });
+
+  it("replays every branch under all-mode when a child cancels", async () => {
+    const first = new ScriptedParallelChild("all-first", [
+      [{ status: "running" }, { status: "success" }],
+      [{ status: "success" }],
+    ]);
+    const second = new ScriptedParallelChild("all-second", [
+      [
+        { status: "running" },
+        { kind: "throw", error: new BehaviorTreeCancellationError("all child cancelled") },
+      ],
+      [{ status: "running" }, { status: "success" }],
+    ]);
+    const third = new ScriptedParallelChild("all-third", [
+      [{ status: "running" }, { status: "success" }],
+      [{ status: "running" }, { status: "success" }],
+    ]);
+    const node = new ParallelNode("parallel-all-cancel", "all", [first, second, third]);
+
+    const initialTick = await node.tick(idleRuntime);
+    expect(initialTick.status).to.equal("running");
+
+    await node.tick(idleRuntime).then(
+      () => {
+        expect.fail("ParallelNode should propagate cancellation surfaced by a child when running in all-mode");
+      },
+      (error) => {
+        expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+      },
+    );
+
+    expect(first.resets).to.equal(1);
+    expect(second.resets).to.equal(1);
+    expect(third.resets).to.equal(1);
+
+    const resumedTick = await node.tick(idleRuntime);
+    expect(resumedTick.status).to.equal("running");
+
+    const completion = await node.tick(idleRuntime);
+    expect(completion.status).to.equal("success");
+    expect(first.resets).to.equal(2);
+    expect(second.resets).to.equal(2);
+    expect(third.resets).to.equal(2);
+  });
+
+  it("forgets cached successes when runtime cancellation interrupts any-mode", async () => {
+    const first = new ScriptedParallelChild("any-first", [
+      [{ status: "running" }, { status: "success" }],
+      [{ status: "success" }],
+    ]);
+    const second = new ScriptedParallelChild("any-second", [
+      [{ status: "running" }, { status: "failure" }],
+      [{ status: "failure" }],
+      [{ status: "success" }],
+    ]);
+    const third = new ScriptedParallelChild("any-third", [
+      [{ status: "running" }, { status: "failure" }],
+      [{ status: "failure" }],
+      [{ status: "failure" }],
+    ]);
+    const node = new ParallelNode("parallel-any-cancel", "any", [first, second, third]);
+
+    const firstTick = await node.tick(idleRuntime);
+    expect(firstTick.status).to.equal("running");
+
+    let cancellationChecks = 0;
+    const runtimeCancellation = new BehaviorTreeCancellationError("runtime requested cancellation");
+    const cancellingRuntime: TickRuntime = {
+      ...idleRuntime,
+      throwIfCancelled: () => {
+        cancellationChecks += 1;
+        // The parallel node performs five cooperative cancellation checks per tick
+        // (entry, pre-child ×3, post-children). Raise on the final guard so the
+        // children have completed and cached their results before the abort.
+        if (cancellationChecks === 5) {
+          throw runtimeCancellation;
+        }
+      },
+    };
+
+    await node.tick(cancellingRuntime).then(
+      () => {
+        expect.fail("ParallelNode should surface runtime cancellations even if a child already succeeded under any-mode");
+      },
+      (error) => {
+        expect(error).to.equal(runtimeCancellation);
+      },
+    );
+
+    expect(first.resets).to.equal(1);
+    expect(second.resets).to.equal(1);
+    expect(third.resets).to.equal(1);
+
+    const resumed = await node.tick(idleRuntime);
+    expect(resumed.status).to.equal("success");
+    expect(first.resets).to.equal(2);
+    expect(second.resets).to.equal(2);
+    expect(third.resets).to.equal(2);
+  });
+});

--- a/tests/bt.parallel.quota.test.ts
+++ b/tests/bt.parallel.quota.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ParallelNode } from "../src/executor/bt/nodes.js";
+import type {
+  BehaviorNode,
+  BehaviorNodeSnapshot,
+  BehaviorTickResult,
+  TickRuntime,
+} from "../src/executor/bt/types.js";
+
+/**
+ * Deterministic behaviour node returning scripted results across ticks. The
+ * implementation keeps the script immutable so {@link ParallelNode.reset}
+ * reliably restarts the node from its initial state.
+ */
+class ScriptedNode implements BehaviorNode {
+  private index = 0;
+  private status: BehaviorNodeSnapshot["status"] = "idle";
+
+  constructor(
+    public readonly id: string,
+    private readonly script: BehaviorTickResult[],
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const currentIndex = Math.min(this.index, this.script.length - 1);
+    const result = this.script[currentIndex];
+    this.index = Math.min(this.script.length, this.index + 1);
+    this.status = result.status === "running" ? "running" : result.status;
+    return result;
+  }
+
+  reset(): void {
+    this.index = 0;
+    this.status = "idle";
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "scripted-node",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: { index: this.index, status: this.status },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "scripted-node") {
+      throw new Error(`expected scripted-node snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { index?: number; status?: BehaviorNodeSnapshot["status"] } | undefined;
+    this.index = typeof state?.index === "number" ? state.index : 0;
+    this.status = state?.status ?? "idle";
+  }
+
+  getProgress(): number {
+    if (this.script.length === 0) {
+      return 1;
+    }
+    const consumed = Math.min(this.index, this.script.length);
+    return consumed / this.script.length;
+  }
+}
+
+const idleRuntime: TickRuntime = {
+  invokeTool: async () => null,
+  now: () => 0,
+  wait: async () => {},
+  variables: {},
+};
+
+/**
+ * The quota policy should resolve successfully once a subset of children reach
+ * the configured threshold, even if other branches fail.
+ */
+describe("parallel node quota policy", () => {
+  it("completes once the success threshold is met", async () => {
+    const node = new ParallelNode(
+      "quota",
+      { mode: "quota", threshold: 2 },
+      [
+        new ScriptedNode("a", [{ status: "success" }]),
+        new ScriptedNode("b", [{ status: "failure" }]),
+        new ScriptedNode("c", [{ status: "running" }, { status: "success" }]),
+      ],
+    );
+
+    const firstTick = await node.tick(idleRuntime);
+    expect(firstTick.status).to.equal("running");
+
+    const secondTick = await node.tick(idleRuntime);
+    expect(secondTick.status).to.equal("success");
+  });
+
+  it("fails when remaining branches cannot satisfy the threshold", async () => {
+    const node = new ParallelNode(
+      "quota-fail",
+      { mode: "quota", threshold: 3 },
+      [
+        new ScriptedNode("a", [{ status: "success" }]),
+        new ScriptedNode("b", [{ status: "failure" }]),
+        new ScriptedNode("c", [{ status: "failure" }]),
+      ],
+    );
+
+    const result = await node.tick(idleRuntime);
+    expect(result.status).to.equal("failure");
+  });
+});

--- a/tests/bt.tasks.cancel.test.ts
+++ b/tests/bt.tasks.cancel.test.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+import sinon from "sinon";
+
+import { BehaviorTreeCancellationError, TaskLeaf } from "../src/executor/bt/nodes.js";
+import { OperationCancelledError } from "../src/executor/cancel.js";
+import type { TickRuntime } from "../src/executor/bt/types.js";
+
+/**
+ * Cancellation-focused coverage for TaskLeaf nodes to ensure orchestrator tools
+ * invoked via `invokeTool` respect cooperative cancellation semantics even when
+ * the runtime signals aborts mid-flight.
+ */
+describe("behaviour tree task leaves", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("does not invoke tools when cancellation triggers before resolution", async () => {
+    const invokeTool = sinon.stub();
+    let cancellationChecks = 0;
+    const runtime: TickRuntime = {
+      invokeTool,
+      variables: { payload: { value: 42 } },
+      throwIfCancelled: () => {
+        cancellationChecks += 1;
+        if (cancellationChecks === 1) {
+          throw new BehaviorTreeCancellationError("pre-invocation cancel");
+        }
+      },
+    };
+
+    const leaf = new TaskLeaf("cancelled-task", "noop", { inputKey: "payload" });
+
+    await leaf.tick(runtime).then(
+      () => {
+        expect.fail("TaskLeaf should not invoke tools when cancellation is detected upfront");
+      },
+      (error) => {
+        expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+      },
+    );
+    expect(invokeTool.callCount).to.equal(0);
+  });
+
+  it("propagates OperationCancelledError raised by invokeTool", async () => {
+    const cancellation = new OperationCancelledError({
+      opId: "op-task",
+      runId: "run-task",
+      jobId: null,
+      graphId: null,
+      nodeId: null,
+      childId: null,
+      reason: "tool cancellation",
+    });
+
+    const invokeTool = sinon.stub().rejects(cancellation);
+    const runtime: TickRuntime = {
+      invokeTool,
+      variables: {},
+    };
+
+    const leaf = new TaskLeaf("tool-cancel", "noop");
+
+    await leaf.tick(runtime).then(
+      () => {
+        expect.fail("TaskLeaf should propagate cancellation raised by invokeTool");
+      },
+      (error) => {
+        expect(error).to.equal(cancellation);
+      },
+    );
+  });
+
+  it("wraps abort-like errors from invokeTool as BehaviourTreeCancellationError", async () => {
+    const abortError = new Error("aborted by orchestrator");
+    abortError.name = "AbortError";
+
+    const invokeTool = sinon.stub().rejects(abortError);
+    const runtime: TickRuntime = {
+      invokeTool,
+      variables: {},
+    };
+
+    const leaf = new TaskLeaf("abort-task", "noop");
+
+    await leaf.tick(runtime).then(
+      () => {
+        expect.fail("TaskLeaf should convert abort signals into cancellation errors");
+      },
+      (error) => {
+        expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+        expect(error.cause).to.equal(abortError);
+      },
+    );
+  });
+
+  it("checks for cancellation after tool completion", async () => {
+    const invokeTool = sinon.stub().resolves({ ok: true });
+    let cancellationChecks = 0;
+    const runtime: TickRuntime = {
+      invokeTool,
+      variables: {},
+      throwIfCancelled: () => {
+        cancellationChecks += 1;
+        if (cancellationChecks === 3) {
+          throw new BehaviorTreeCancellationError("post-tool cancel");
+        }
+      },
+    };
+
+    const leaf = new TaskLeaf("post-cancel", "noop");
+
+    await leaf.tick(runtime).then(
+      () => {
+        expect.fail("TaskLeaf should surface cancellations raised after invokeTool resolves");
+      },
+      (error) => {
+        expect(error).to.be.instanceOf(BehaviorTreeCancellationError);
+      },
+    );
+
+    sinon.assert.calledOnceWithExactly(invokeTool, "noop", {});
+  });
+});

--- a/tests/concurrency.child-logs-backpressure.test.ts
+++ b/tests/concurrency.child-logs-backpressure.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Validates that child log pagination remains lossless even when consumers
+ * request very small pages. The scenarios emulate the backpressure handling we
+ * need for the future SSE bridge so slow clients can resume draining logs
+ * without missing entries.
+ */
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ResourceRegistry } from "../src/resources/registry.js";
+
+/** Number of log entries seeded in the main pagination scenario. */
+const CHILD_LOG_ENTRY_COUNT = 9;
+
+/**
+ * Helper generating deterministic log payloads so the assertions can focus on
+ * the pagination guarantees. Each log increments both `ts` and the sequence the
+ * registry maintains for the targeted child.
+ */
+function seedChildLogs(registry: ResourceRegistry, childId: string, count: number): void {
+  for (let index = 0; index < count; index += 1) {
+    registry.recordChildLogEntry(childId, {
+      ts: index + 1,
+      stream: index % 2 === 0 ? "stdout" : "stderr",
+      message: `log-${childId}-${index + 1}`,
+      jobId: index % 3 === 0 ? `job-${childId}` : null,
+      runId: `run-${childId}`,
+      opId: index % 2 === 0 ? `op-${index + 1}` : null,
+      graphId: null,
+      nodeId: null,
+      raw: null,
+      parsed: { position: index + 1 },
+    });
+  }
+}
+
+describe("child log pagination backpressure", () => {
+  it("pages child logs without dropping entries across keep-alives", () => {
+    const registry = new ResourceRegistry({ childLogHistoryLimit: 100 });
+    const childId = "child-backpressure";
+    seedChildLogs(registry, childId, CHILD_LOG_ENTRY_COUNT);
+
+    const limit = 3;
+    let cursor = 0;
+    const seen: number[] = [];
+    const uri = `sc://children/${childId}/logs`;
+
+    while (seen.length < CHILD_LOG_ENTRY_COUNT) {
+      const page = registry.watch(uri, { fromSeq: cursor, limit });
+      expect(page.kind).to.equal("child_logs");
+      expect(page.uri).to.equal(uri);
+      expect(page.events.length).to.be.greaterThan(0);
+      expect(page.events.length).to.be.at.most(limit);
+
+      for (const event of page.events) {
+        expect(event.seq).to.be.greaterThan(cursor);
+        expect(event.childId).to.equal(childId);
+        expect(event.message).to.equal(`log-${childId}-${event.seq}`);
+        seen.push(event.seq);
+      }
+
+      cursor = page.nextSeq;
+    }
+
+    const expected = Array.from({ length: CHILD_LOG_ENTRY_COUNT }, (_, index) => index + 1);
+    expect(seen).to.deep.equal(expected);
+
+    const keepAlive = registry.watch(uri, { fromSeq: cursor, limit });
+    expect(keepAlive.events).to.have.length(0);
+    expect(keepAlive.nextSeq).to.equal(CHILD_LOG_ENTRY_COUNT);
+
+    registry.recordChildLogEntry(childId, {
+      ts: CHILD_LOG_ENTRY_COUNT + 1,
+      stream: "meta",
+      message: `log-${childId}-${CHILD_LOG_ENTRY_COUNT + 1}`,
+      jobId: null,
+      runId: `run-${childId}`,
+      opId: null,
+      graphId: null,
+      nodeId: null,
+      raw: null,
+      parsed: { position: CHILD_LOG_ENTRY_COUNT + 1 },
+    });
+    const resumed = registry.watch(uri, { fromSeq: cursor, limit });
+    expect(resumed.events.map((entry) => entry.seq)).to.deep.equal([CHILD_LOG_ENTRY_COUNT + 1]);
+    expect(resumed.nextSeq).to.equal(CHILD_LOG_ENTRY_COUNT + 1);
+  });
+
+  it("isolates pagination state between different children", () => {
+    const registry = new ResourceRegistry({ childLogHistoryLimit: 50 });
+    const children = ["alpha", "beta"] as const;
+
+    // Interleave the entries so we prove that each child maintains an independent
+    // sequence and that pagination does not leak entries across buckets.
+    for (let round = 0; round < 4; round += 1) {
+      for (const childId of children) {
+        registry.recordChildLogEntry(childId, {
+          ts: round * children.length + (childId === "alpha" ? 1 : 2),
+          stream: "stdout",
+          message: `round-${round + 1}-${childId}`,
+        });
+      }
+    }
+
+    const limit = 2;
+    for (const childId of children) {
+      let cursor = 0;
+      const seen: number[] = [];
+      const uri = `sc://children/${childId}/logs`;
+
+      while (seen.length < 4) {
+        const page = registry.watch(uri, { fromSeq: cursor, limit });
+        expect(page.kind).to.equal("child_logs");
+        expect(page.uri).to.equal(uri);
+        expect(page.events).to.have.length.at.most(limit);
+
+        for (const entry of page.events) {
+          expect(entry.childId).to.equal(childId);
+          expect(entry.seq).to.equal(seen.length + 1);
+          expect(entry.message).to.equal(`round-${entry.seq}-${childId}`);
+          seen.push(entry.seq);
+        }
+
+        cursor = page.nextSeq;
+      }
+
+      expect(seen).to.deep.equal([1, 2, 3, 4]);
+
+      const keepAlive = registry.watch(uri, { fromSeq: cursor, limit });
+      expect(keepAlive.events).to.have.length(0);
+      expect(keepAlive.nextSeq).to.equal(4);
+    }
+  });
+});

--- a/tests/concurrency.events-backpressure.test.ts
+++ b/tests/concurrency.events-backpressure.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Validates that event pagination paths remain lossless when clients fetch
+ * events in small chunks. The scenarios emulate backpressure handling for both
+ * the unified event bus (`events_subscribe`) and the resource registry
+ * (`resources_watch`) so slow consumers can drain buffers without dropping
+ * envelopes.
+ */
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { EventBus } from "../src/events/bus.js";
+import { ResourceRegistry } from "../src/resources/registry.js";
+
+/** Utility building a deterministic clock for reproducible timestamps. */
+function buildDeterministicClock(): () => number {
+  let tick = 0;
+  return () => ++tick;
+}
+
+describe("stream pagination backpressure", () => {
+  it("pages the event bus without dropping envelopes", () => {
+    const bus = new EventBus({ historyLimit: 100, now: buildDeterministicClock() });
+    const limit = 3;
+    let cursor = 0;
+    let published = 0;
+    const collected: number[] = [];
+
+    // Publish events in bursts that never exceed the configured limit so a slow
+    // consumer can poll repeatedly without losing entries between iterations.
+    const bursts = [3, 2, 3, 1];
+    for (const [burstIndex, burstSize] of bursts.entries()) {
+      for (let offset = 0; offset < burstSize; offset += 1) {
+        published += 1;
+        bus.publish({
+          cat: burstIndex % 2 === 0 ? "plan" : "child",
+          runId: `run-${burstIndex + 1}`,
+          msg: `event-${published}`,
+        });
+      }
+
+      const page = bus.list({ afterSeq: cursor, limit });
+      expect(page.length).to.equal(burstSize);
+      const expectedSeqs = Array.from({ length: burstSize }, (_, index) => cursor + index + 1);
+      expect(page.map((event) => event.seq)).to.deep.equal(expectedSeqs);
+
+      cursor = page[page.length - 1]!.seq;
+      collected.push(...page.map((event) => event.seq));
+    }
+
+    const expected = Array.from({ length: collected.length }, (_, index) => index + 1);
+    expect(collected).to.deep.equal(expected);
+
+    // A keep-alive request should return no events yet preserve the cursor so a
+    // client can wait for additional pages without missing new publications.
+    const keepAlive = bus.list({ afterSeq: cursor, limit });
+    expect(keepAlive).to.have.length(0);
+
+    const resumed = bus.publish({ cat: "plan", runId: "run-keepalive", msg: "resume" });
+    const replay = bus.list({ afterSeq: cursor, limit });
+    expect(replay.map((event) => event.seq)).to.deep.equal([resumed.seq]);
+  });
+
+  it("pages resource watch results deterministically for run events", () => {
+    const registry = new ResourceRegistry({ runHistoryLimit: 100, childLogHistoryLimit: 50 });
+    const runId = "run-backpressure";
+    const totalEvents = 11;
+
+    for (let index = 0; index < totalEvents; index += 1) {
+      registry.recordRunEvent(runId, {
+        seq: index + 1,
+        ts: index + 1,
+        kind: index % 2 === 0 ? "plan" : "child",
+        level: "info",
+        runId,
+        msg: `payload-${index + 1}`,
+      });
+    }
+
+    const limit = 4;
+    let cursor = 0;
+    const seen: number[] = [];
+    const uri = `sc://runs/${runId}/events`;
+
+    while (seen.length < totalEvents) {
+      const page = registry.watch(uri, { fromSeq: cursor, limit });
+      expect(page.events.length).to.be.greaterThan(0);
+      expect(page.events.length).to.be.at.most(limit);
+      expect(page.kind).to.equal("run_events");
+      expect(page.uri).to.equal(uri);
+
+      for (const event of page.events) {
+        expect(event.seq).to.be.greaterThan(cursor);
+        seen.push(event.seq);
+      }
+
+      cursor = page.nextSeq;
+    }
+
+    const expected = Array.from({ length: totalEvents }, (_, index) => index + 1);
+    expect(seen).to.deep.equal(expected);
+
+    const keepAlive = registry.watch(uri, { fromSeq: cursor, limit });
+    expect(keepAlive.events).to.have.length(0);
+    expect(keepAlive.nextSeq).to.equal(totalEvents);
+
+    const resumedSeq = totalEvents + 1;
+    registry.recordRunEvent(runId, {
+      seq: resumedSeq,
+      ts: resumedSeq,
+      kind: "plan",
+      level: "info",
+      runId,
+      msg: "resume",
+    });
+
+    const resumed = registry.watch(uri, { fromSeq: cursor, limit });
+    expect(resumed.events.map((event) => event.seq)).to.deep.equal([resumedSeq]);
+    expect(resumed.nextSeq).to.equal(resumedSeq);
+  });
+});

--- a/tests/coord.contractnet.pheromone-bounds.test.ts
+++ b/tests/coord.contractnet.pheromone-bounds.test.ts
@@ -1,0 +1,691 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import {
+  ContractNetCoordinator,
+  computePheromonePressure,
+  type ContractNetEvent,
+} from "../src/coord/contractNet.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import { StructuredLogger } from "../src/logger.js";
+import {
+  CnpAnnounceInputSchema,
+  CnpRefreshBoundsInputSchema,
+  CnpWatcherTelemetryInputSchema,
+  handleCnpAnnounce,
+  handleCnpRefreshBounds,
+  handleCnpWatcherTelemetry,
+  type CoordinationToolContext,
+} from "../src/tools/coordTools.js";
+import {
+  ContractNetWatcherTelemetryRecorder,
+  watchContractNetPheromoneBounds,
+  type ContractNetWatcherTelemetrySnapshot,
+} from "../src/coord/contractNetWatchers.js";
+
+class ManualClock {
+  private current = 0;
+
+  now(): number {
+    return this.current;
+  }
+
+  advance(ms: number): void {
+    this.current += ms;
+  }
+}
+
+describe("coordination contract-net pheromone bounds", () => {
+  it("captures evolving pheromone bounds for announcements", () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+    const context: CoordinationToolContext = {
+      blackboard: new BlackboardStore(),
+      stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+    };
+
+    contractNet.registerAgent("agent-alpha", { baseCost: 4, reliability: 0.9 });
+    contractNet.registerAgent("agent-beta", { baseCost: 6, reliability: 0.95 });
+
+    // Seed the stigmergic field so the initial bounds reflect an observed ceiling.
+    stigmergy.mark("triage", "load", 2);
+    clock.advance(5);
+
+    const first = handleCnpAnnounce(
+      context,
+      CnpAnnounceInputSchema.parse({ task_id: "survey-1", auto_bid: true }),
+    );
+
+    expect(first.pheromone_bounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 2,
+    });
+    const storedFirst = contractNet.getCall(first.call_id);
+    expect(storedFirst?.pheromoneBounds).to.deep.equal(first.pheromone_bounds);
+
+    // Increase the highest observed intensity so the normalisation ceiling changes.
+    stigmergy.mark("analysis", "load", 6);
+    clock.advance(5);
+
+    const second = handleCnpAnnounce(
+      context,
+      CnpAnnounceInputSchema.parse({ task_id: "survey-2", auto_bid: true }),
+    );
+
+    expect(second.pheromone_bounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 6,
+    });
+    expect(second.pheromone_bounds).to.not.deep.equal(first.pheromone_bounds);
+
+    const storedSecond = contractNet.getCall(second.call_id);
+    expect(storedSecond?.pheromoneBounds).to.deep.equal(second.pheromone_bounds);
+  });
+
+  it("honours configured maxima when resolving pheromone bounds", () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now(), maxIntensity: 5 });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+    const context: CoordinationToolContext = {
+      blackboard: new BlackboardStore(),
+      stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+    };
+
+    contractNet.registerAgent("agent", { baseCost: 5, reliability: 1 });
+    stigmergy.mark("review", "latency", 12);
+
+    const announcement = handleCnpAnnounce(
+      context,
+      CnpAnnounceInputSchema.parse({ task_id: "bounded", auto_bid: true }),
+    );
+
+    expect(announcement.pheromone_bounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: 5,
+      normalisation_ceiling: 5,
+    });
+  });
+
+  it("scales busy penalties with pheromone pressure to favour idle agents under heavy load", () => {
+    const clock = new ManualClock();
+    const coordinator = new ContractNetCoordinator({ now: () => clock.now() });
+
+    coordinator.registerAgent("alpha", { baseCost: 10, reliability: 1 });
+    coordinator.registerAgent("beta", { baseCost: 10, reliability: 0.95 });
+
+    // Pretend the beta agent is already working on another assignment so the
+    // busy penalty applies during the auction. Casting keeps the tests aligned
+    // with the coordinator internals while documenting the expected shape.
+    const internals = coordinator as unknown as { activeAssignments: Map<string, number> };
+    internals.activeAssignments.set("beta", 1);
+
+    const heuristics = {
+      preferAgents: ["beta"],
+      agentBias: {},
+      busyPenalty: 4,
+      preferenceBonus: 3,
+    };
+
+    const lowLoad = coordinator.announce({
+      taskId: "low-load",
+      autoBid: false,
+      heuristics,
+      pheromoneBounds: { min_intensity: 0, max_intensity: 10, normalisation_ceiling: 1 },
+    });
+
+    coordinator.bid(lowLoad.callId, "alpha", 11.5);
+    coordinator.bid(lowLoad.callId, "beta", 10);
+
+    const lowDecision = coordinator.award(lowLoad.callId);
+    expect(lowDecision.agentId).to.equal("beta");
+
+    const lowSnapshot = coordinator.getCall(lowLoad.callId);
+    expect(lowSnapshot?.pheromoneBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: 10,
+      normalisation_ceiling: 1,
+    });
+    const lowPressure = computePheromonePressure(lowSnapshot?.pheromoneBounds ?? null);
+    expect(lowPressure).to.be.closeTo(1.1, 1e-6);
+    const lowBusyAfterAward = internals.activeAssignments.get("beta") ?? 0;
+    expect(lowBusyAfterAward).to.be.greaterThan(0);
+    expect(lowDecision.effectiveCost).to.be.closeTo(10 + 4 * lowBusyAfterAward * lowPressure - 3, 1e-6);
+
+    // Reset the busy counter for beta so the next auction starts with a single
+    // ongoing assignment once again.
+    internals.activeAssignments.set("beta", 1);
+
+    const highLoad = coordinator.announce({
+      taskId: "high-load",
+      autoBid: false,
+      heuristics,
+      pheromoneBounds: { min_intensity: 0, max_intensity: 10, normalisation_ceiling: 9 },
+    });
+
+    coordinator.bid(highLoad.callId, "alpha", 11.5);
+    coordinator.bid(highLoad.callId, "beta", 10);
+
+    const betaBusyBeforeHigh = internals.activeAssignments.get("beta") ?? 0;
+    const alphaBusyBeforeHigh = internals.activeAssignments.get("alpha") ?? 0;
+    const highDecision = coordinator.award(highLoad.callId);
+    expect(highDecision.agentId).to.equal("alpha");
+
+    const highSnapshot = coordinator.getCall(highLoad.callId);
+    const highPressure = computePheromonePressure(highSnapshot?.pheromoneBounds ?? null);
+    expect(highPressure).to.be.closeTo(1.9, 1e-6);
+    const betaEffective = 10 + 4 * betaBusyBeforeHigh * highPressure - 3;
+    const alphaEffective = 11.5 + 4 * alphaBusyBeforeHigh * highPressure;
+    expect(betaEffective).to.be.greaterThan(alphaEffective);
+  });
+
+  it("refreshes heuristic bids when pheromone bounds are updated under load", () => {
+    const clock = new ManualClock();
+    const coordinator = new ContractNetCoordinator({ now: () => clock.now() });
+
+    coordinator.registerAgent("alpha", { baseCost: 8, reliability: 0.9 });
+    coordinator.registerAgent("beta", { baseCost: 6, reliability: 1 });
+
+    const announced = coordinator.announce({
+      taskId: "refresh-load",
+      heuristics: { busyPenalty: 3 },
+      pheromoneBounds: { min_intensity: 0, max_intensity: 20, normalisation_ceiling: 2 },
+    });
+    expect(announced.autoBidEnabled).to.equal(true);
+
+    const initialAlpha = announced.bids.find((bid) => bid.agentId === "alpha");
+    expect(initialAlpha).to.not.equal(undefined);
+    expect(initialAlpha?.kind).to.equal("heuristic");
+    const initialAlphaMetadata = initialAlpha?.metadata as Record<string, unknown>;
+    expect(initialAlphaMetadata).to.deep.include({ reason: "auto" });
+    expect(initialAlphaMetadata).to.have.property("pheromone_pressure");
+    expect(initialAlphaMetadata.pheromone_pressure).to.be.closeTo(1.1, 1e-6);
+
+    coordinator.bid(announced.callId, "beta", 5, { metadata: { reason: "manual" } });
+    const manualBeforeRefresh = coordinator.getCall(announced.callId);
+    const manualBid = manualBeforeRefresh?.bids.find((bid) => bid.agentId === "beta");
+    expect(manualBid?.kind).to.equal("manual");
+    const manualMetadata = manualBid?.metadata as Record<string, unknown> | undefined;
+    expect(manualMetadata).to.deep.equal({ reason: "manual" });
+
+    clock.advance(10);
+
+    coordinator.registerAgent("gamma", { baseCost: 7, reliability: 0.95 });
+
+    const refreshed = coordinator.updateCallPheromoneBounds(announced.callId, {
+      min_intensity: 0,
+      max_intensity: 20,
+      normalisation_ceiling: 9,
+    });
+
+    expect(refreshed.pheromoneBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: 20,
+      normalisation_ceiling: 9,
+    });
+    expect(refreshed.autoBidRefreshed).to.equal(true);
+    expect(refreshed.refreshedAgents).to.have.members(["alpha", "gamma"]);
+    const refreshedAlpha = refreshed.bids.find((bid) => bid.agentId === "alpha");
+    expect(refreshedAlpha?.kind).to.equal("heuristic");
+    const refreshedAlphaMetadata = refreshedAlpha?.metadata as Record<string, unknown>;
+    expect(refreshedAlphaMetadata).to.deep.include({ reason: "auto_refresh" });
+    const expectedPressure = computePheromonePressure(refreshed.pheromoneBounds);
+    expect(refreshedAlphaMetadata).to.have.property("pheromone_pressure", expectedPressure);
+    expect(refreshedAlpha?.submittedAt).to.be.greaterThan(initialAlpha?.submittedAt ?? 0);
+
+    const refreshedGamma = refreshed.bids.find((bid) => bid.agentId === "gamma");
+    expect(refreshedGamma?.kind).to.equal("heuristic");
+    const refreshedGammaMetadata = refreshedGamma?.metadata as Record<string, unknown>;
+    expect(refreshedGammaMetadata).to.deep.include({ reason: "auto_refresh" });
+    expect(refreshedGammaMetadata).to.have.property("pheromone_pressure", expectedPressure);
+
+    const postManualBid = refreshed.bids.find((bid) => bid.agentId === "beta");
+    expect(postManualBid?.kind).to.equal("manual");
+    const postManualMetadata = postManualBid?.metadata as Record<string, unknown> | undefined;
+    expect(postManualMetadata).to.deep.equal({ reason: "manual" });
+    expect(postManualBid?.submittedAt).to.equal(manualBid?.submittedAt);
+  });
+
+  it("allows callers to update bounds without refreshing heuristic bids", () => {
+    const clock = new ManualClock();
+    const coordinator = new ContractNetCoordinator({ now: () => clock.now() });
+
+    coordinator.registerAgent("alpha", { baseCost: 5, reliability: 1 });
+
+    const call = coordinator.announce({
+      taskId: "no-refresh",
+      pheromoneBounds: { min_intensity: 0, max_intensity: null, normalisation_ceiling: 3 },
+    });
+
+    const initialBid = call.bids.find((bid) => bid.agentId === "alpha");
+    const initialMetadata = initialBid?.metadata as Record<string, unknown> | undefined;
+    expect(initialMetadata).to.deep.include({ reason: "auto" });
+    const initialSubmittedAt = initialBid?.submittedAt ?? 0;
+
+    clock.advance(5);
+    coordinator.registerAgent("beta", { baseCost: 9, reliability: 0.9 });
+
+    const snapshot = coordinator.updateCallPheromoneBounds(
+      call.callId,
+      { min_intensity: 0, max_intensity: null, normalisation_ceiling: 7 },
+      { refreshAutoBids: false },
+    );
+
+    expect(snapshot.pheromoneBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+    expect(snapshot.autoBidRefreshed).to.equal(false);
+    expect(snapshot.refreshedAgents).to.deep.equal([]);
+    const unchangedBid = snapshot.bids.find((bid) => bid.agentId === "alpha");
+    expect(unchangedBid?.submittedAt).to.equal(initialSubmittedAt);
+    const unchangedMetadata = unchangedBid?.metadata as Record<string, unknown> | undefined;
+    expect(unchangedMetadata).to.deep.include({ reason: "auto" });
+
+    const missingBeta = snapshot.bids.find((bid) => bid.agentId === "beta");
+    expect(missingBeta).to.equal(undefined);
+  });
+
+  it("emits structured events when pheromone bounds are refreshed", () => {
+    const clock = new ManualClock();
+    const coordinator = new ContractNetCoordinator({ now: () => clock.now() });
+
+    coordinator.registerAgent("alpha", { baseCost: 5, reliability: 1 });
+    coordinator.registerAgent("beta", { baseCost: 6, reliability: 0.9 });
+
+    const events: ContractNetEvent[] = [];
+    const dispose = coordinator.observe((event) => {
+      events.push(event);
+    });
+
+    const call = coordinator.announce({ taskId: "event" });
+    clock.advance(1);
+    coordinator.updateCallPheromoneBounds(
+      call.callId,
+      { min_intensity: 0, max_intensity: 10, normalisation_ceiling: 4 },
+      { includeNewAgents: true },
+    );
+
+    const boundsEvents = events.filter((event) => event.kind === "call_bounds_updated");
+    expect(boundsEvents).to.have.lengthOf(1);
+    const [updated] = boundsEvents as Array<Extract<ContractNetEvent, { kind: "call_bounds_updated" }>>;
+    expect(updated.refresh.requested).to.equal(true);
+    expect(updated.refresh.includeNewAgents).to.equal(true);
+    expect(updated.refresh.refreshedAgents).to.include("alpha");
+    expect(updated.bounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: 10,
+      normalisation_ceiling: 4,
+    });
+
+    dispose();
+  });
+
+  it("refreshes pheromone bounds via the coordination tool when none are provided", () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+    const context: CoordinationToolContext = {
+      blackboard: new BlackboardStore(),
+      stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+    };
+
+    contractNet.registerAgent("alpha", { baseCost: 4, reliability: 0.95 });
+    const call = contractNet.announce({ taskId: "tool-refresh", autoBid: true });
+
+    // Increase the field pressure so the tool picks up a different ceiling.
+    stigmergy.mark("tool", "load", 7);
+    clock.advance(2);
+
+    const result = handleCnpRefreshBounds(
+      context,
+      CnpRefreshBoundsInputSchema.parse({ call_id: call.callId }),
+    );
+
+    expect(result.auto_bid_refreshed).to.equal(true);
+    expect(result.refresh.requested).to.equal(true);
+    expect(result.refreshed_agents).to.deep.equal(["alpha"]);
+    expect(result.pheromone_bounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+
+    const stored = contractNet.getCall(call.callId);
+    expect(stored?.pheromoneBounds).to.deep.equal(result.pheromone_bounds);
+  });
+
+  it("automatically refreshes open calls when stigmergy bounds evolve", async () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+
+    contractNet.registerAgent("alpha", { baseCost: 3, reliability: 1 });
+    const call = contractNet.announce({ taskId: "auto", autoBid: true });
+
+    const events: ContractNetEvent[] = [];
+    const disposeEvents = contractNet.observe((event) => events.push(event));
+
+    const disposeWatcher = watchContractNetPheromoneBounds({
+      field: stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+    });
+
+    // Initial synchronisation triggers an update even without prior pressure.
+    const initialBoundsEvents = events.filter((event) => event.kind === "call_bounds_updated");
+    expect(initialBoundsEvents).to.have.lengthOf(1);
+    expect(initialBoundsEvents[0]?.refresh.refreshedAgents).to.include("alpha");
+
+    // Raise the normalisation ceiling by marking a stronger pheromone trail.
+    stigmergy.mark("auto", "load", 12);
+    clock.advance(1);
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const subsequentEvents = events.filter((event) => event.kind === "call_bounds_updated");
+    expect(subsequentEvents).to.have.lengthOf.at.least(2);
+    const latest = subsequentEvents[subsequentEvents.length - 1] as Extract<
+      ContractNetEvent,
+      { kind: "call_bounds_updated" }
+    >;
+    expect(latest.bounds?.normalisation_ceiling).to.equal(12);
+    expect(latest.refresh.refreshedAgents).to.include("alpha");
+
+    const snapshot = contractNet.getCall(call.callId);
+    expect(snapshot?.pheromoneBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 12,
+    });
+
+    disposeWatcher();
+    disposeEvents();
+  });
+
+  it("coalesces rapid stigmergy updates before refreshing open calls", async () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+
+    contractNet.registerAgent("alpha", { baseCost: 4, reliability: 1 });
+    const call = contractNet.announce({ taskId: "coalesce", autoBid: true });
+
+    const events: Extract<ContractNetEvent, { kind: "call_bounds_updated" }>[] = [];
+    const disposeEvents = contractNet.observe((event) => {
+      if (event.kind === "call_bounds_updated") {
+        events.push(event);
+      }
+    });
+
+    const telemetry: ContractNetWatcherTelemetrySnapshot[] = [];
+    const disposeWatcher = watchContractNetPheromoneBounds({
+      field: stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+      coalesceWindowMs: 25,
+      onTelemetry: (snapshot) => telemetry.push(snapshot),
+    });
+
+    expect(events).to.have.lengthOf(1);
+    expect(telemetry).to.have.lengthOf(1);
+    expect(telemetry[0]).to.include({
+      reason: "initial",
+      receivedUpdates: 0,
+      coalescedUpdates: 0,
+      skippedRefreshes: 0,
+      appliedRefreshes: 1,
+      flushes: 0,
+    });
+    expect(telemetry[0].lastBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 1,
+    });
+
+    stigmergy.mark("coalesce-a", "load", 3);
+    stigmergy.mark("coalesce-b", "load", 5);
+    stigmergy.mark("coalesce-c", "load", 7);
+    clock.advance(1);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    expect(events).to.have.lengthOf(2);
+    const latest = events[events.length - 1];
+    expect(latest.bounds?.normalisation_ceiling).to.equal(7);
+    expect(latest.refresh.refreshedAgents).to.include("alpha");
+
+    expect(telemetry).to.have.lengthOf(2);
+    expect(telemetry[1]).to.include({
+      reason: "flush",
+      receivedUpdates: 3,
+      coalescedUpdates: 2,
+      skippedRefreshes: 0,
+      appliedRefreshes: 2,
+      flushes: 1,
+    });
+    expect(telemetry[1].lastBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+
+    const snapshot = contractNet.getCall(call.callId);
+    expect(snapshot?.pheromoneBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+
+    disposeWatcher();
+    expect(telemetry).to.have.lengthOf(3);
+    expect(telemetry[2]).to.include({
+      reason: "detach",
+      receivedUpdates: 3,
+      coalescedUpdates: 2,
+      skippedRefreshes: 0,
+      appliedRefreshes: 2,
+      flushes: 1,
+    });
+    expect(telemetry[2].lastBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+    disposeEvents();
+  });
+
+  it("reports telemetry when pheromone updates reuse the existing bounds", () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+
+    contractNet.registerAgent("alpha", { baseCost: 3, reliability: 1 });
+    const call = contractNet.announce({ taskId: "stable", autoBid: true });
+
+    const events: Extract<ContractNetEvent, { kind: "call_bounds_updated" }>[] = [];
+    const disposeEvents = contractNet.observe((event) => {
+      if (event.kind === "call_bounds_updated") {
+        events.push(event);
+      }
+    });
+
+    const telemetry: ContractNetWatcherTelemetrySnapshot[] = [];
+    const disposeWatcher = watchContractNetPheromoneBounds({
+      field: stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+      coalesceWindowMs: 0,
+      onTelemetry: (snapshot) => telemetry.push(snapshot),
+    });
+
+    expect(events).to.have.lengthOf(1);
+    expect(telemetry).to.have.lengthOf(1);
+
+    stigmergy.mark("stable", "load", 7);
+
+    expect(events).to.have.lengthOf(2);
+    expect(telemetry).to.have.lengthOf(2);
+    expect(telemetry[1]).to.include({
+      reason: "flush",
+      receivedUpdates: 1,
+      coalescedUpdates: 0,
+      skippedRefreshes: 0,
+      appliedRefreshes: 2,
+      flushes: 1,
+    });
+    expect(telemetry[1].lastBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+
+    stigmergy.mark("stable-secondary", "load", 2);
+
+    expect(events).to.have.lengthOf(2);
+    expect(telemetry).to.have.lengthOf(3);
+    expect(telemetry[2]).to.include({
+      reason: "flush",
+      receivedUpdates: 2,
+      coalescedUpdates: 0,
+      skippedRefreshes: 1,
+      appliedRefreshes: 2,
+      flushes: 1,
+    });
+    expect(telemetry[2].lastBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+
+    disposeWatcher();
+    expect(telemetry).to.have.lengthOf(4);
+    expect(telemetry[3]).to.include({
+      reason: "detach",
+      receivedUpdates: 2,
+      coalescedUpdates: 0,
+      skippedRefreshes: 1,
+      appliedRefreshes: 2,
+      flushes: 1,
+    });
+    expect(telemetry[3].lastBounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 7,
+    });
+    disposeEvents();
+  });
+});
+
+describe("contract-net watcher telemetry tool", () => {
+  it("reports telemetry as disabled when the recorder is unavailable", () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+    const context: CoordinationToolContext = {
+      blackboard: new BlackboardStore(),
+      stigmergy,
+      contractNet,
+      logger: new StructuredLogger(),
+    };
+
+    const result = handleCnpWatcherTelemetry(
+      context,
+      CnpWatcherTelemetryInputSchema.parse({}),
+    );
+
+    expect(result.telemetry_enabled).to.equal(false);
+    expect(result.emissions).to.equal(0);
+    expect(result.last_snapshot).to.equal(null);
+  });
+
+  it("surfaces the latest watcher snapshot with emission metadata", () => {
+    const clock = new ManualClock();
+    const stigmergy = new StigmergyField({ now: () => clock.now() });
+    const contractNet = new ContractNetCoordinator({ now: () => clock.now() });
+    const logger = new StructuredLogger();
+    const recorder = new ContractNetWatcherTelemetryRecorder(() => clock.now());
+    const context: CoordinationToolContext = {
+      blackboard: new BlackboardStore(),
+      stigmergy,
+      contractNet,
+      logger,
+      contractNetWatcherTelemetry: recorder,
+    };
+
+    contractNet.registerAgent("alpha", { baseCost: 3, reliability: 1 });
+    contractNet.announce({
+      taskId: "inspect", 
+      autoBid: true,
+      heuristics: { busyPenalty: 1 },
+      pheromoneBounds: { min_intensity: 0, max_intensity: null, normalisation_ceiling: 0 },
+    });
+
+    const disposeWatcher = watchContractNetPheromoneBounds({
+      field: stigmergy,
+      contractNet,
+      logger,
+      coalesceWindowMs: 0,
+      onTelemetry: (snapshot) => recorder.record(snapshot),
+    });
+
+    clock.advance(5);
+    stigmergy.mark("node-1", "load", 2);
+
+    clock.advance(10);
+    disposeWatcher();
+
+    const result = handleCnpWatcherTelemetry(
+      context,
+      CnpWatcherTelemetryInputSchema.parse({}),
+    );
+
+    expect(result.telemetry_enabled).to.equal(true);
+    expect(result.emissions).to.equal(3);
+    expect(result.last_emitted_at_ms).to.equal(15);
+    expect(result.last_emitted_at_iso).to.equal(new Date(15).toISOString());
+    expect(result.last_snapshot).to.deep.include({
+      reason: "detach",
+      received_updates: 1,
+      coalesced_updates: 0,
+      skipped_refreshes: 0,
+      applied_refreshes: 2,
+      flushes: 1,
+    });
+    expect(result.last_snapshot?.last_bounds).to.deep.equal({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 2,
+    });
+  });
+});
+
+describe("contract-net pheromone pressure helper", () => {
+  it("uses logarithmic growth when the stigmergic field is unbounded", () => {
+    const pressure = computePheromonePressure({
+      min_intensity: 0,
+      max_intensity: null,
+      normalisation_ceiling: 15,
+    });
+    expect(pressure).to.be.closeTo(1 + Math.log1p(15), 1e-6);
+  });
+
+  it("returns neutral pressure when bounds are missing or inactive", () => {
+    expect(computePheromonePressure(null)).to.equal(1);
+    expect(
+      computePheromonePressure({
+        min_intensity: 5,
+        max_intensity: 10,
+        normalisation_ceiling: 4,
+      }),
+    ).to.equal(1);
+  });
+});

--- a/tests/coord.stigmergy.field.test.ts
+++ b/tests/coord.stigmergy.field.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 
+import { BlackboardStore } from "../src/coord/blackboard.js";
+import { ContractNetCoordinator } from "../src/coord/contractNet.js";
 import { StigmergyField } from "../src/coord/stigmergy.js";
+import { StructuredLogger } from "../src/logger.js";
+import { handleStigSnapshot } from "../src/tools/coordTools.js";
 
 /** Manual clock mirroring {@link Date.now} so evaporation stays deterministic. */
 class ManualClock {
@@ -56,5 +60,116 @@ describe("coordination stigmergy field", () => {
 
     unsubscribe();
     expect(events.length).to.be.greaterThan(0);
+  });
+
+  it("applies default half-life and intensity bounds", () => {
+    const clock = new ManualClock();
+    const field = new StigmergyField({
+      now: () => clock.now(),
+      defaultHalfLifeMs: 2_000,
+      minIntensity: 0.5,
+      maxIntensity: 5,
+    });
+
+    const first = field.mark("alpha", "load", 2);
+    expect(first.intensity).to.equal(2);
+
+    const second = field.mark("alpha", "load", 4);
+    expect(second.intensity).to.equal(5, "intensity should clamp at maxIntensity");
+
+    clock.advance(1_000);
+    const [decayed] = field.evaporate();
+    expect(decayed?.intensity ?? 0).to.be.closeTo(5 * Math.pow(0.5, 0.5), 1e-6);
+
+    clock.advance(200_000);
+    const [vanished] = field.evaporate();
+    expect(vanished?.intensity).to.equal(0);
+    expect(field.getNodeIntensity("alpha")).to.equal(undefined);
+  });
+
+  it("exposes configured and effective intensity bounds", () => {
+    const clock = new ManualClock();
+    const field = new StigmergyField({ now: () => clock.now(), minIntensity: 0.25 });
+
+    const emptyBounds = field.getIntensityBounds();
+    expect(emptyBounds.minIntensity).to.equal(0.25);
+    expect(emptyBounds.maxIntensity).to.equal(Number.POSITIVE_INFINITY);
+    expect(emptyBounds.normalisationCeiling).to.equal(1.25);
+
+    field.mark("alpha", "load", 0.5);
+    field.mark("beta", "load", 1.5);
+
+    const populatedBounds = field.getIntensityBounds();
+    expect(populatedBounds.minIntensity).to.equal(0.25);
+    expect(populatedBounds.maxIntensity).to.equal(Number.POSITIVE_INFINITY);
+    expect(populatedBounds.normalisationCeiling).to.equal(1.5);
+
+    const boundedField = new StigmergyField({ now: () => clock.now(), minIntensity: 0, maxIntensity: 4 });
+    boundedField.mark("node", "signal", 2);
+    const bounded = boundedField.getIntensityBounds();
+    expect(bounded.maxIntensity).to.equal(4);
+    expect(bounded.normalisationCeiling).to.equal(4);
+  });
+
+  it("produces heatmap snapshots with normalised intensities", () => {
+    const clock = new ManualClock();
+    const field = new StigmergyField({ now: () => clock.now(), minIntensity: 1, maxIntensity: 10 });
+
+    field.mark("alpha", "load", 2);
+    clock.advance(10);
+    field.mark("alpha", "alert", 1);
+    clock.advance(10);
+    field.mark("beta", "load", 8);
+
+    const snapshot = field.heatmapSnapshot();
+    expect(snapshot.minIntensity).to.equal(1);
+    expect(snapshot.maxIntensity).to.equal(10);
+    expect(snapshot.cells).to.have.length(2);
+    expect(snapshot.cells[0]?.nodeId).to.equal("beta");
+    expect(snapshot.cells[0]?.normalised ?? 0).to.be.closeTo(7 / 9, 1e-6);
+    expect(snapshot.cells[0]?.points).to.have.length(1);
+    expect(snapshot.cells[0]?.points[0]?.normalised ?? 0).to.be.closeTo(7 / 9, 1e-6);
+
+    const alphaCell = snapshot.cells.find((cell) => cell.nodeId === "alpha");
+    expect(alphaCell?.points).to.have.length(2);
+    expect(alphaCell?.points[0]?.type).to.equal("load");
+    expect(alphaCell?.points[0]?.normalised ?? 0).to.be.closeTo(1 / 9, 1e-6);
+    expect(alphaCell?.points[1]?.type).to.equal("alert");
+    expect(alphaCell?.points[1]?.normalised).to.equal(0);
+  });
+
+  it("surfaces formatted bounds and summary rows in stig_snapshot", () => {
+    const clock = new ManualClock();
+    const field = new StigmergyField({ now: () => clock.now(), minIntensity: 0.25, maxIntensity: 5 });
+
+    field.mark("alpha", "load", 1.5);
+    clock.advance(10);
+    field.mark("beta", "latency", 3);
+
+    const context = {
+      blackboard: new BlackboardStore(),
+      stigmergy: field,
+      contractNet: new ContractNetCoordinator({ now: () => clock.now() }),
+      logger: new StructuredLogger(),
+    } as const;
+
+    const result = handleStigSnapshot(context, {});
+
+    expect(result.pheromone_bounds).to.deep.equal({
+      min_intensity: 0.25,
+      max_intensity: 5,
+      normalisation_ceiling: 5,
+    });
+    expect(result.summary.bounds).to.deep.equal(result.pheromone_bounds);
+    expect(result.summary.tooltip).to.equal("Min 0.25 • Max 5 • Ceiling 5");
+
+    const rows = Object.fromEntries(result.summary.rows.map((row) => [row.label, row]));
+    expect(rows["Min intensity"]?.value).to.equal("0.25");
+    expect(rows["Max intensity"]?.value).to.equal("5");
+    expect(rows["Normalisation ceiling"]?.value).to.equal("5");
+    expect(rows["Min intensity"]?.tooltip).to.be.a("string");
+
+    expect(result.heatmap.bounds).to.deep.equal(result.pheromone_bounds);
+    expect(result.heatmap.bounds_tooltip).to.equal(result.summary.tooltip);
   });
 });

--- a/tests/events.subscribe.sse-escaping.test.ts
+++ b/tests/events.subscribe.sse-escaping.test.ts
@@ -1,0 +1,119 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import {
+  server,
+  graphState,
+  childSupervisor,
+  getRuntimeFeatures,
+  configureRuntimeFeatures,
+} from "../src/server.js";
+import {
+  registerCancellation,
+  requestCancellation,
+  resetCancellationRegistry,
+} from "../src/executor/cancel.js";
+import { parseSseStream } from "./helpers/sse.js";
+
+/**
+ * Integration coverage asserting that the SSE variant of `events_subscribe`
+ * keeps `data:` lines single-line even when cancellation reasons include raw
+ * carriage returns or Unicode line separators. The scenario seeds a cancellation
+ * handle directly so the emitted bus event contains the crafted reason and then
+ * fetches the SSE stream to verify both the transport encoding and payload
+ * fidelity.
+ */
+describe("events subscribe SSE escaping", () => {
+  it("keeps SSE data lines single-line while preserving cancellation payloads", async () => {
+    const baselineGraph = graphState.serialize();
+    const baselineChildren = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "events-subscribe-sse-escaping-test", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      configureRuntimeFeatures({ ...baselineFeatures, enableEventsBus: true, enableCancellation: true });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "events-subscribe-sse" } });
+      childSupervisor.childrenIndex.restore({});
+      resetCancellationRegistry();
+
+      const baselineResponse = await client.callTool({ name: "events_subscribe", arguments: { limit: 1 } });
+      expect(baselineResponse.isError ?? false).to.equal(false);
+      const baselineContent = baselineResponse.structuredContent as { next_seq: number | null };
+      const cursor = baselineContent?.next_seq ?? 0;
+
+      const opId = "cancel-sse-op";
+      const runId = "cancel-sse-run";
+      const jobId = "cancel-sse-job";
+      registerCancellation(opId, { runId, jobId, graphId: "cancel-sse-graph", nodeId: "cancel-sse-node" });
+
+      const reason = "line\r\nseparator\u2028mix\u2029end";
+      const outcome = requestCancellation(opId, { reason, at: Date.now() });
+      expect(outcome).to.equal("requested");
+
+      // Allow the event bus microtask queue to settle before querying the stream.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const response = await client.callTool({
+        name: "events_subscribe",
+        arguments: {
+          from_seq: cursor,
+          cats: ["cancel"],
+          format: "sse",
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+
+      const structured = response.structuredContent as {
+        stream: string;
+        events: Array<{
+          data?: { reason?: string | null } | null;
+        }>;
+      };
+
+      const cancelEvents = structured.events.filter((event) => event.data?.reason === reason);
+      expect(cancelEvents.length).to.be.greaterThan(0);
+
+      expect(structured.stream.includes("\u2028"), "stream should escape U+2028").to.equal(false);
+      expect(structured.stream.includes("\u2029"), "stream should escape U+2029").to.equal(false);
+
+      // Parse the SSE stream as an EventSource client would so we can assert the
+      // record-level framing in addition to inspecting raw `data:` lines.
+      const parsedStream = parseSseStream(structured.stream);
+      expect(parsedStream.length).to.be.greaterThan(0);
+
+      let decodedReasonCount = 0;
+      for (const event of parsedStream) {
+        expect(event.data.length).to.be.greaterThan(0);
+        for (const payload of event.data) {
+          expect(payload).to.not.include("\r");
+          expect(payload).to.not.include("\n");
+          expect(payload).to.not.include("\u2028");
+          expect(payload).to.not.include("\u2029");
+
+          const decoded = JSON.parse(payload) as { data?: { reason?: string | null } };
+          if (decoded.data?.reason === reason) {
+            decodedReasonCount += 1;
+          }
+        }
+      }
+      expect(decodedReasonCount, "decoded payload should retain the original reason").to.be.greaterThan(0);
+    } finally {
+      resetCancellationRegistry();
+      configureRuntimeFeatures(baselineFeatures);
+      childSupervisor.childrenIndex.restore(baselineChildren);
+      graphState.resetFromSnapshot(baselineGraph);
+      await childSupervisor.disposeAll().catch(() => {});
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+});

--- a/tests/executor.loop.reconciler.test.ts
+++ b/tests/executor.loop.reconciler.test.ts
@@ -26,6 +26,7 @@ describe("executor loop reconcilers", () => {
 
     const reconcilers: LoopReconciler[] = [
       {
+        id: "primary",
         async reconcile(context) {
           observedContexts.push(context);
         },
@@ -53,6 +54,63 @@ describe("executor loop reconcilers", () => {
 
     expect(observedContexts.map((ctx) => ctx.tickIndex)).to.deep.equal([0, 1]);
     expect(observedContexts.every((ctx) => ctx.startedAt <= clock)).to.equal(true);
+
+    await loop.stop();
+  });
+
+  it("surfaces reconciler telemetry via the afterTick hook", async () => {
+    const timer = new ManualTimer();
+    const recorded: Array<{ ids: string[]; statuses: string[]; errors: Array<string | null> }> = [];
+    const observedErrors: unknown[] = [];
+    let clock = 0;
+
+    const reconcilers: LoopReconciler[] = [
+      {
+        id: "alpha",
+        async reconcile() {
+          clock += 2;
+        },
+      },
+      {
+        id: "bravo",
+        async reconcile() {
+          clock += 3;
+          throw new Error("bravo failed");
+        },
+      },
+    ];
+
+    const loop = new ExecutionLoop({
+      intervalMs: 1,
+      tick: () => {
+        clock += 5;
+      },
+      now: () => clock,
+      setIntervalFn: (handler, _interval) => timer.schedule(handler),
+      clearIntervalFn: () => timer.clear(),
+      reconcilers,
+      onError: (error) => {
+        observedErrors.push(error);
+      },
+      afterTick: (details) => {
+        recorded.push({
+          ids: details.reconcilers.map((item) => item.id),
+          statuses: details.reconcilers.map((item) => item.status),
+          errors: details.reconcilers.map((item) => item.errorMessage ?? null),
+        });
+      },
+    });
+
+    loop.start();
+    timer.handler?.();
+    await loop.whenIdle();
+
+    expect(recorded).to.have.length(1);
+    const snapshot = recorded[0]!;
+    expect(snapshot.ids).to.deep.equal(["alpha", "bravo"]);
+    expect(snapshot.statuses).to.deep.equal(["ok", "error"]);
+    expect(snapshot.errors).to.deep.equal([null, "bravo failed"]);
+    expect(observedErrors).to.have.length(1);
 
     await loop.stop();
   });

--- a/tests/executor.scheduler.budgets.test.ts
+++ b/tests/executor.scheduler.budgets.test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BehaviorTreeInterpreter } from "../src/executor/bt/interpreter.js";
+import { ReactiveScheduler } from "../src/executor/reactiveScheduler.js";
+import { BusyNode, ManualClock, ScriptedNode } from "./helpers/reactiveSchedulerTestUtils.js";
+
+/**
+ * Cooperative budgeting should cap the number of ticks executed per microtask
+ * while still allowing operators to disable the guardrails when a benchmark
+ * needs to run as fast as possible. These tests focus on the batch accounting
+ * surfaced through {@link ReactiveScheduler}'s `onTick` hook.
+ */
+describe("reactive scheduler budgets", () => {
+  it("resets batch telemetry after yielding because maxBatchTicks was hit", async () => {
+    const clock = new ManualClock();
+    const node = new BusyNode("busy", [4, 4, 4, 4], clock);
+    const interpreter = new BehaviorTreeInterpreter(node);
+
+    const batches: number[] = [];
+    const ticksPerBatch: number[] = [];
+    const elapsedPerTick: number[] = [];
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      batchQuantumMs: 1000,
+      maxBatchTicks: 2,
+      onTick: ({ batchIndex, ticksInBatch, batchElapsedMs }) => {
+        batches.push(batchIndex);
+        ticksPerBatch.push(ticksInBatch);
+        elapsedPerTick.push(batchElapsedMs);
+      },
+    });
+
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+
+    const result = await scheduler.runUntilSettled();
+
+    expect(result.status).to.equal("success");
+    expect(batches).to.deep.equal([0, 0, 1, 1]);
+    expect(ticksPerBatch).to.deep.equal([1, 2, 1, 2]);
+    expect(elapsedPerTick).to.deep.equal([4, 8, 4, 8]);
+    scheduler.stop();
+  });
+
+  it("keeps draining a batch when cooperative budgets are disabled", async () => {
+    const clock = new ManualClock();
+    const node = new BusyNode("busy", [3, 3, 3], clock);
+    const interpreter = new BehaviorTreeInterpreter(node);
+
+    const batches: number[] = [];
+    const ticksPerBatch: number[] = [];
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      batchQuantumMs: 0,
+      maxBatchTicks: Number.POSITIVE_INFINITY,
+      onTick: ({ batchIndex, ticksInBatch }) => {
+        batches.push(batchIndex);
+        ticksPerBatch.push(ticksInBatch);
+      },
+    });
+
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+
+    const result = await scheduler.runUntilSettled();
+
+    expect(result.status).to.equal("success");
+    expect(batches).to.deep.equal([0, 0, 0]);
+    expect(ticksPerBatch).to.deep.equal([1, 2, 3]);
+    scheduler.stop();
+  });
+
+  it("yields and resumes cleanly when new work arrives mid-batch", async () => {
+    const clock = new ManualClock();
+    const node = new ScriptedNode("script", [
+      { status: "running" },
+      { status: "running" },
+      { status: "running" },
+      { status: "success" },
+    ]);
+    const interpreter = new BehaviorTreeInterpreter(node);
+
+    const batches: number[] = [];
+    const pendingCounts: number[] = [];
+    let injectedExtra = false; // Guarantees we only enqueue the extra work once.
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      batchQuantumMs: 10,
+      maxBatchTicks: 2,
+      onTick: ({ batchIndex, pendingAfter }) => {
+        batches.push(batchIndex);
+        pendingCounts.push(pendingAfter);
+        if (!injectedExtra && pendingAfter === 0 && batchIndex === 0) {
+          injectedExtra = true;
+          // Enqueue fresh work so the next batch resumes cleanly with new events.
+          scheduler.emit("taskReady", { nodeId: "script", criticality: 1 });
+          scheduler.emit("taskReady", { nodeId: "script", criticality: 1 });
+        }
+      },
+    });
+
+    // Seed the queue with two ticks so the first batch drains before extra events arrive.
+    scheduler.emit("taskReady", { nodeId: "script", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "script", criticality: 1 });
+
+    const result = await scheduler.runUntilSettled();
+
+    expect(result.status).to.equal("success");
+    expect(batches).to.deep.equal([0, 0, 1, 1]);
+    expect(pendingCounts).to.deep.equal([1, 0, 1, 0]);
+    scheduler.stop();
+  });
+});

--- a/tests/executor.scheduler.prio-aging.test.ts
+++ b/tests/executor.scheduler.prio-aging.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { BehaviorTreeInterpreter } from "../src/executor/bt/interpreter.js";
+import { ReactiveScheduler } from "../src/executor/reactiveScheduler.js";
+import {
+  BusyNode,
+  ManualClock,
+  ScriptedNode,
+} from "./helpers/reactiveSchedulerTestUtils.js";
+
+/**
+ * Prioritisation and cooperative budgeting safeguards must keep aged events
+ * moving forward while allowing sustained bursts to yield back to the loop.
+ */
+describe("reactive scheduler fairness", () => {
+  it("promotes aged low-priority events even under a steady urgent flood", async () => {
+    const clock = new ManualClock();
+    const node = new ScriptedNode("script", [
+      { status: "running" },
+      { status: "running" },
+      { status: "running" },
+      { status: "running" },
+      { status: "running" },
+      { status: "running" },
+      { status: "success" },
+    ]);
+    const interpreter = new BehaviorTreeInterpreter(node);
+
+    const processed: string[] = [];
+    let sawStigmergy = false;
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      ageWeight: 0,
+      agingHalfLifeMs: 250,
+      agingFairnessBoost: 80,
+      batchQuantumMs: 48,
+      maxBatchTicks: 32,
+      onTick: ({ event }) => {
+        processed.push(event);
+        if (event === "stigmergyChanged") {
+          sawStigmergy = true;
+          return;
+        }
+        if (event === "taskReady" && !sawStigmergy) {
+          clock.advance(400);
+          scheduler.emit("taskReady", { nodeId: "dominant", criticality: 12, pheromone: 8 });
+        }
+      },
+    });
+
+    scheduler.emit("stigmergyChanged", { nodeId: "stale", intensity: 1 });
+    clock.advance(500);
+    scheduler.emit("taskReady", { nodeId: "dominant", criticality: 12, pheromone: 8 });
+
+    const result = await scheduler.runUntilSettled();
+
+    expect(result.status).to.equal("success");
+    const firstStigIndex = processed.indexOf("stigmergyChanged");
+    expect(firstStigIndex).to.be.greaterThan(-1);
+    expect(firstStigIndex).to.be.lessThan(processed.length - 1);
+    expect(processed.slice(0, firstStigIndex)).to.satisfy((events: string[]) => events.every((event) => event === "taskReady"));
+
+    scheduler.stop();
+  });
+
+  it("yields once the batch quantum is exhausted so the event loop can breathe", async () => {
+    const clock = new ManualClock();
+    const node = new BusyNode("busy", [12, 12, 12], clock);
+    const interpreter = new BehaviorTreeInterpreter(node);
+
+    const batches: number[] = [];
+
+    const scheduler = new ReactiveScheduler({
+      interpreter,
+      runtime: {
+        invokeTool: async () => undefined,
+        now: () => clock.now(),
+        wait: (ms) => clock.wait(ms),
+        variables: {},
+      },
+      now: () => clock.now(),
+      batchQuantumMs: 20,
+      maxBatchTicks: 2,
+      onTick: ({ batchIndex }) => {
+        batches.push(batchIndex);
+      },
+    });
+
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+    scheduler.emit("taskReady", { nodeId: "busy", criticality: 1 });
+
+    const result = await scheduler.runUntilSettled();
+
+    expect(result.status).to.equal("success");
+    expect(batches).to.deep.equal([0, 0, 1]);
+    scheduler.stop();
+  });
+});

--- a/tests/executor.scheduler.prio.test.ts
+++ b/tests/executor.scheduler.prio.test.ts
@@ -1,7 +1,12 @@
 import { describe, it } from "mocha";
 import { expect } from "chai";
 
-import type { BehaviorNode, BehaviorTickResult, TickRuntime } from "../src/executor/bt/types.js";
+import type {
+  BehaviorNode,
+  BehaviorNodeSnapshot,
+  BehaviorTickResult,
+  TickRuntime,
+} from "../src/executor/bt/types.js";
 import { BehaviorTreeInterpreter } from "../src/executor/bt/interpreter.js";
 import { ReactiveScheduler } from "../src/executor/reactiveScheduler.js";
 
@@ -46,6 +51,7 @@ class ManualClock {
 /** Behaviour node producing scripted results to emulate long-running plans. */
 class ScriptedNode implements BehaviorNode {
   private index = 0;
+  private status: BehaviorNodeSnapshot["status"] = "idle";
 
   constructor(
     public readonly id: string,
@@ -55,11 +61,39 @@ class ScriptedNode implements BehaviorNode {
   async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
     const result = this.results[Math.min(this.index, this.results.length - 1)];
     this.index += 1;
+    this.status = result.status === "running" ? "running" : result.status;
     return result;
   }
 
   reset(): void {
     // Preserve execution history so the interpreter keeps advancing through the script.
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "scripted-node",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: { index: this.index, status: this.status },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "scripted-node") {
+      throw new Error(`expected scripted-node snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { index?: number; status?: BehaviorNodeSnapshot["status"] } | undefined;
+    this.index = typeof state?.index === "number" ? state.index : 0;
+    this.status = state?.status ?? "idle";
+  }
+
+  getProgress(): number {
+    if (this.results.length === 0) {
+      return 1;
+    }
+    const consumed = Math.min(this.index, this.results.length);
+    return consumed / this.results.length;
   }
 }
 

--- a/tests/helpers/reactiveSchedulerTestUtils.ts
+++ b/tests/helpers/reactiveSchedulerTestUtils.ts
@@ -1,0 +1,170 @@
+import type {
+  BehaviorNode,
+  BehaviorNodeSnapshot,
+  BehaviorTickResult,
+  TickRuntime,
+} from "../../src/executor/bt/types.js";
+
+/**
+ * Manual clock mirroring {@link setTimeout} semantics so scheduler tests can
+ * deterministically drive time-based heuristics without relying on real timers.
+ */
+export class ManualClock {
+  private current = 0;
+
+  private readonly scheduled: Array<{ at: number; resolve: () => void }> = [];
+
+  /** Returns the current virtual timestamp. */
+  now(): number {
+    return this.current;
+  }
+
+  /**
+   * Enqueues a virtual timeout resolved once the manual clock reaches the
+   * target timestamp. Tests advance the clock explicitly via {@link advance}.
+   */
+  wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      this.scheduled.push({ at: this.current + ms, resolve });
+    });
+  }
+
+  /** Advances the clock by the requested delta. */
+  advance(ms: number): void {
+    this.advanceTo(this.current + ms);
+  }
+
+  /**
+   * Jumps directly to the provided timestamp and resolves any pending waits
+   * scheduled at or before that instant.
+   */
+  advanceTo(target: number): void {
+    if (target < this.current) {
+      this.current = target;
+      return;
+    }
+    this.current = target;
+    const remaining: Array<{ at: number; resolve: () => void }> = [];
+    for (const entry of this.scheduled) {
+      if (entry.at <= this.current) {
+        entry.resolve();
+      } else {
+        remaining.push(entry);
+      }
+    }
+    this.scheduled.length = 0;
+    this.scheduled.push(...remaining);
+  }
+}
+
+/**
+ * Behaviour node returning a scripted sequence of results so tests can force
+ * the interpreter to execute a predetermined number of ticks.
+ */
+export class ScriptedNode implements BehaviorNode {
+  private index = 0;
+
+  private status: BehaviorNodeSnapshot["status"] = "idle";
+
+  constructor(
+    public readonly id: string,
+    private readonly results: BehaviorTickResult[],
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const result = this.results[Math.min(this.index, this.results.length - 1)];
+    this.index += 1;
+    this.status = result.status === "running" ? "running" : result.status;
+    return result;
+  }
+
+  reset(): void {
+    // Scripted node intentionally keeps its cursor so the interpreter consumes
+    // the configured scenario without restarting from the beginning.
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "scripted-node",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: { index: this.index, status: this.status },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "scripted-node") {
+      throw new Error(`expected scripted-node snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { index?: number; status?: BehaviorNodeSnapshot["status"] } | undefined;
+    this.index = typeof state?.index === "number" ? state.index : 0;
+    this.status = state?.status ?? "idle";
+  }
+
+  getProgress(): number {
+    if (this.results.length === 0) {
+      return 1;
+    }
+    const consumed = Math.min(this.index, this.results.length);
+    return consumed / this.results.length;
+  }
+}
+
+/**
+ * Behaviour node that simulates CPU-bound work by advancing the manual clock
+ * on each tick, letting tests validate batch quantum enforcement.
+ */
+export class BusyNode implements BehaviorNode {
+  private index = 0;
+
+  private status: BehaviorNodeSnapshot["status"] = "idle";
+
+  constructor(
+    public readonly id: string,
+    private readonly durations: number[],
+    private readonly clock: ManualClock,
+  ) {}
+
+  async tick(_runtime: TickRuntime): Promise<BehaviorTickResult> {
+    const duration = this.durations[Math.min(this.index, this.durations.length - 1)];
+    this.clock.advance(duration);
+    this.index += 1;
+    if (this.index >= this.durations.length) {
+      this.status = "success";
+      return { status: "success" };
+    }
+    this.status = "running";
+    return { status: "running" };
+  }
+
+  reset(): void {
+    this.status = "idle";
+  }
+
+  snapshot(): BehaviorNodeSnapshot {
+    return {
+      id: this.id,
+      type: "busy-node",
+      status: this.status,
+      progress: this.getProgress() * 100,
+      state: { index: this.index, status: this.status },
+    } satisfies BehaviorNodeSnapshot;
+  }
+
+  restore(snapshot: BehaviorNodeSnapshot): void {
+    if (snapshot.type !== "busy-node") {
+      throw new Error(`expected busy-node snapshot for ${this.id}, received ${snapshot.type}`);
+    }
+    const state = snapshot.state as { index?: number; status?: BehaviorNodeSnapshot["status"] } | undefined;
+    this.index = typeof state?.index === "number" ? state.index : 0;
+    this.status = state?.status ?? "idle";
+  }
+
+  getProgress(): number {
+    if (this.durations.length === 0) {
+      return 1;
+    }
+    return Math.min(1, this.index / this.durations.length);
+  }
+}

--- a/tests/helpers/sse.ts
+++ b/tests/helpers/sse.ts
@@ -1,0 +1,39 @@
+/**
+ * Parses a Server-Sent Events (SSE) stream payload into individual event
+ * records. The helper mirrors the line-oriented framing performed by
+ * `EventSource`, splitting each record by blank lines and decoding well-known
+ * fields (`id`, `event`, `data`). Data lines are left as raw strings so tests
+ * can further assert transport escaping before running `JSON.parse`.
+ */
+export function parseSseStream(stream: string): Array<{
+  id: string | null;
+  event: string | null;
+  data: string[];
+}> {
+  const events: Array<{ id: string | null; event: string | null; data: string[] }> = [];
+  const records = stream.split("\n\n");
+
+  for (const record of records) {
+    if (!record.trim()) {
+      continue;
+    }
+
+    let id: string | null = null;
+    let event: string | null = null;
+    const data: string[] = [];
+
+    for (const line of record.split("\n")) {
+      if (line.startsWith("id: ")) {
+        id = line.slice("id: ".length);
+      } else if (line.startsWith("event: ")) {
+        event = line.slice("event: ".length);
+      } else if (line.startsWith("data: ")) {
+        data.push(line.slice("data: ".length));
+      }
+    }
+
+    events.push({ id, event, data });
+  }
+
+  return events;
+}

--- a/tests/plan.bt.cancel-normalisation.test.ts
+++ b/tests/plan.bt.cancel-normalisation.test.ts
@@ -1,0 +1,100 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+  PlanRunBTInputSchema,
+  handlePlanRunBT,
+  type PlanToolContext,
+} from "../src/tools/planTools.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import { OperationCancelledError } from "../src/executor/cancel.js";
+import type { EventCorrelationHints } from "../src/events/correlation.js";
+
+interface RecordedEvent {
+  readonly kind: string;
+  readonly payload: Record<string, unknown> | null;
+  readonly correlation: EventCorrelationHints | null;
+}
+
+function buildContext(): { context: PlanToolContext; events: RecordedEvent[]; info: sinon.SinonSpy } {
+  const info = sinon.spy();
+  const logger = {
+    info,
+    warn: sinon.spy(),
+    error: sinon.spy(),
+    debug: sinon.spy(),
+  } as unknown as PlanToolContext["logger"];
+
+  const events: RecordedEvent[] = [];
+  const context: PlanToolContext = {
+    supervisor: {} as PlanToolContext["supervisor"],
+    graphState: {} as PlanToolContext["graphState"],
+    logger,
+    childrenRoot: "/tmp",
+    defaultChildRuntime: "codex",
+    emitEvent: (event) => {
+      const payload =
+        event.payload && typeof event.payload === "object"
+          ? (event.payload as Record<string, unknown>)
+          : null;
+      const correlation = event.correlation ?? null;
+      events.push({ kind: event.kind, payload, correlation });
+    },
+    stigmergy: new StigmergyField(),
+  } satisfies PlanToolContext;
+
+  return { context, events, info };
+}
+
+/**
+ * Behaviour tree cancellations raised by tool invocations must surface as
+ * OperationCancelledError outcomes so orchestrators receive the structured MCP
+ * payload with reason codes and correlation identifiers.
+ */
+describe("plan_run_bt cancellation normalisation", () => {
+  it("normalises Behaviour Tree cancellation errors into OperationCancelledError", async () => {
+    const { context, events, info } = buildContext();
+    const input = PlanRunBTInputSchema.parse({
+      tree: {
+        id: "bt-cancel-normalisation",
+        root: {
+          type: "task",
+          id: "abort-node",
+          node_id: "abort-node",
+          tool: "abort",
+          input_key: "payload",
+        },
+      },
+      variables: { payload: { attempt: 1 } },
+    });
+
+    let caught: unknown;
+    try {
+      await handlePlanRunBT(context, input);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.instanceOf(OperationCancelledError);
+    const cancellationError = caught as OperationCancelledError;
+    expect(cancellationError.details.reason).to.equal("behaviour tool aborted by test");
+
+    expect(info.calledWithMatch("plan_run_bt_cancelled", { reason: "behaviour tool aborted by test" })).to.equal(true);
+
+    const errorEvent = events.find((event) => {
+      if (event.kind !== "BT_RUN" || !event.payload) {
+        return false;
+      }
+      const phase = (event.payload as { phase?: unknown }).phase;
+      return phase === "error";
+    });
+    expect(errorEvent, "expected lifecycle error event").to.exist;
+    const payload = (errorEvent?.payload ?? null) as {
+      status?: unknown;
+      reason?: unknown;
+    } | null;
+    expect(payload?.status).to.equal("cancelled");
+    expect(payload?.reason).to.equal("behaviour tool aborted by test");
+  });
+});

--- a/tests/plan.bt.parallel-cancel.integration.test.ts
+++ b/tests/plan.bt.parallel-cancel.integration.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, beforeEach, afterEach } from "mocha";
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+  PlanRunBTInputSchema,
+  handlePlanRunBT,
+  type PlanToolContext,
+} from "../src/tools/planTools.js";
+import { StigmergyField } from "../src/coord/stigmergy.js";
+import {
+  OperationCancelledError,
+  requestCancellation,
+  resetCancellationRegistry,
+} from "../src/executor/cancel.js";
+import type { BehaviorNodeDefinition, ParallelPolicy } from "../src/executor/bt/types.js";
+import type { EventCorrelationHints } from "../src/events/correlation.js";
+
+/**
+ * Policies exercised by the parallel cancellation integration tests. Each entry
+ * includes the human-readable label used in assertions and the runtime policy
+ * forwarded to the behaviour tree interpreter.
+ */
+const parallelPolicies: Array<{ label: string; policy: ParallelPolicy }> = [
+  { label: "quota", policy: { mode: "quota", threshold: 2 } },
+  { label: "all", policy: "all" },
+  { label: "any", policy: "any" },
+];
+
+interface RecordedEvent {
+  readonly kind: string;
+  readonly payload: Record<string, unknown> | null;
+  readonly correlation: EventCorrelationHints | null;
+}
+
+interface StartEventInfo {
+  readonly opId: string;
+  readonly runId: string;
+  readonly payload: Record<string, unknown>;
+}
+
+/**
+ * Build a retry-based branch that initially fails its guard so the parallel
+ * node observes a running status. The guard is retried with a short backoff so
+ * tests can trigger cancellation while the runtime is waiting on the delay.
+ */
+function buildRetryBranch(name: string): BehaviorNodeDefinition {
+  return {
+    type: "retry",
+    id: `${name}-retry`,
+    max_attempts: 3,
+    backoff_ms: 100,
+    child: {
+      type: "guard",
+      id: `${name}-guard`,
+      condition_key: `${name}_ready`,
+      expected: true,
+      child: {
+        type: "task",
+        id: `${name}-task`,
+        node_id: `${name}-task`,
+        tool: "noop",
+        input_key: `${name}_payload`,
+      },
+    },
+  } satisfies BehaviorNodeDefinition;
+}
+
+/**
+ * Assemble the root parallel definition shared across the cancellation
+ * scenarios so the tests can swap policies without duplicating the structure.
+ */
+function buildParallelRoot(label: string, policy: ParallelPolicy): BehaviorNodeDefinition {
+  return {
+    type: "parallel",
+    id: `parallel-${label}`,
+    policy,
+    children: [buildRetryBranch("alpha"), buildRetryBranch("beta"), buildRetryBranch("gamma")],
+  } satisfies BehaviorNodeDefinition;
+}
+
+function buildPlanContext(): {
+  context: PlanToolContext;
+  events: RecordedEvent[];
+  waitForStart: () => Promise<StartEventInfo>;
+} {
+  const logger = {
+    info: sinon.spy(),
+    warn: sinon.spy(),
+    error: sinon.spy(),
+    debug: sinon.spy(),
+  } as unknown as PlanToolContext["logger"];
+
+  const events: RecordedEvent[] = [];
+  let startInfo: StartEventInfo | null = null;
+  let resolveStart: ((info: StartEventInfo) => void) | null = null;
+  const startPromise = new Promise<StartEventInfo>((resolve) => {
+    resolveStart = resolve;
+  });
+
+  const waitForStart = async () => {
+    if (startInfo) {
+      return startInfo;
+    }
+    return startPromise;
+  };
+
+  const context: PlanToolContext = {
+    supervisor: {} as PlanToolContext["supervisor"],
+    graphState: {} as PlanToolContext["graphState"],
+    logger,
+    childrenRoot: "/tmp",
+    defaultChildRuntime: "codex",
+    emitEvent: (event) => {
+      const payload =
+        event.payload && typeof event.payload === "object"
+          ? (event.payload as Record<string, unknown>)
+          : null;
+      const correlation = event.correlation ?? null;
+      events.push({ kind: event.kind, payload, correlation });
+      if (event.kind === "BT_RUN" && payload?.phase === "start") {
+        const opId = String(payload.op_id ?? "");
+        const runId = String(payload.run_id ?? "");
+        startInfo = { opId, runId, payload };
+        if (resolveStart) {
+          resolveStart(startInfo);
+          resolveStart = null;
+        }
+      }
+    },
+    stigmergy: new StigmergyField(),
+  } satisfies PlanToolContext;
+
+  return { context, events, waitForStart };
+}
+
+/**
+ * Integration coverage ensuring `plan_run_bt` surfaces cancellation across the
+ * different parallel aggregation policies and that the tree can recover cleanly
+ * once the cancellation is lifted.
+ */
+describe("plan_run_bt parallel cancellation integration", () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    resetCancellationRegistry();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  for (const { label, policy } of parallelPolicies) {
+    it(`cancels and recovers cleanly for the ${label} policy`, async () => {
+      const firstRun = buildPlanContext();
+      const initialInput = PlanRunBTInputSchema.parse({
+        tree: {
+          id: `parallel-cancel-${label}`,
+          root: buildParallelRoot(label, policy),
+        },
+        variables: {
+          alpha_payload: { branch: "alpha" },
+          beta_payload: { branch: "beta" },
+          gamma_payload: { branch: "gamma" },
+          alpha_ready: false,
+          beta_ready: false,
+          gamma_ready: false,
+        },
+      });
+
+      const execution = handlePlanRunBT(firstRun.context, initialInput);
+      const start = await firstRun.waitForStart();
+      expect(start.opId).to.have.length.greaterThan(0);
+
+      const cancellationReason = `integration cancel ${label}`;
+      setTimeout(() => {
+        requestCancellation(start.opId, { reason: cancellationReason });
+      }, 10);
+
+      await clock.tickAsync(10);
+
+      let caught: unknown;
+      try {
+        await execution;
+      } catch (error) {
+        caught = error;
+      }
+
+      expect(caught).to.be.instanceOf(OperationCancelledError);
+      const cancellationError = caught as OperationCancelledError;
+      expect(cancellationError.details.reason).to.equal(cancellationReason);
+
+      const cancelEvent = firstRun.events.find(
+        (event) => event.kind === "BT_RUN" && event.payload?.phase === "cancel",
+      );
+      expect(cancelEvent, "expected cancel lifecycle event").to.exist;
+      expect(cancelEvent?.payload?.reason ?? null).to.equal(cancellationReason);
+
+      const errorEvent = firstRun.events.find(
+        (event) => event.kind === "BT_RUN" && event.payload?.phase === "error",
+      );
+      expect(errorEvent, "expected cancellation error lifecycle event").to.exist;
+      expect(errorEvent?.payload?.status).to.equal("cancelled");
+
+      const recoveryRun = buildPlanContext();
+      const recoveryInput = PlanRunBTInputSchema.parse({
+        tree: {
+          id: `parallel-recovery-${label}`,
+          root: buildParallelRoot(label, policy),
+        },
+        variables: {
+          alpha_payload: { branch: "alpha" },
+          beta_payload: { branch: "beta" },
+          gamma_payload: { branch: "gamma" },
+          alpha_ready: true,
+          beta_ready: true,
+          gamma_ready: true,
+        },
+      });
+
+      const recoveryResult = await handlePlanRunBT(recoveryRun.context, recoveryInput);
+
+      expect(recoveryResult.status).to.equal("success");
+      expect(recoveryResult.invocations).to.have.length(3);
+      expect(recoveryResult.invocations.every((entry) => entry.executed)).to.equal(true);
+      expect(recoveryResult.invocations.map((entry) => entry.tool)).to.deep.equal([
+        "noop",
+        "noop",
+        "noop",
+      ]);
+
+      const completionEvent = recoveryRun.events.find(
+        (event) => event.kind === "BT_RUN" && event.payload?.phase === "complete",
+      );
+      expect(completionEvent, "expected completion lifecycle event").to.exist;
+      expect(completionEvent?.payload?.status).to.equal("success");
+    });
+  }
+});

--- a/tests/plan.lifecycle.test.ts
+++ b/tests/plan.lifecycle.test.ts
@@ -87,6 +87,7 @@ describe("plan lifecycle", () => {
     await client.connect(clientTransport);
 
     try {
+      // Désactive la fonctionnalité lifecycle pour vérifier la dégradation à null des champs progress/lifecycle.
       configureRuntimeFeatures({
         ...baselineFeatures,
         enableBT: true,
@@ -194,6 +195,7 @@ describe("plan lifecycle", () => {
     let runPromise: ReturnType<Client["callTool"]> | null = null;
 
     try {
+      // Active la fonctionnalité lifecycle afin que op_cancel puisse relayer le snapshot de progression.
       configureRuntimeFeatures({
         ...baselineFeatures,
         enableBT: true,
@@ -301,6 +303,480 @@ describe("plan lifecycle", () => {
       if (runPromise) {
         await runPromise.catch(() => {});
       }
+    }
+  });
+
+  it("returns lifecycle progress snapshots when plan_cancel aborts a running plan", async function () {
+    this.timeout(10000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "plan-cancel-progress-client", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const planArguments = {
+      tree: {
+        id: "plan-cancel-progress-tree",
+        root: {
+          type: "retry",
+          id: "retry-root",
+          max_attempts: 50,
+          backoff_ms: 500,
+          child: {
+            type: "guard",
+            id: "guard-node",
+            condition_key: "allow",
+            expected: true,
+            child: {
+              type: "task",
+              id: "noop-node",
+              node_id: "noop-node",
+              tool: "noop",
+              input_key: "payload",
+            },
+          },
+        },
+      },
+      variables: { allow: false, payload: { attempt: 1 } },
+      tick_ms: 25,
+      timeout_ms: 5_000,
+      run_id: "plan-cancel-progress-run",
+      op_id: "plan-cancel-progress-op",
+    } as const;
+
+    let runPromise: ReturnType<Client["callTool"]> | null = null;
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enableCancellation: true,
+        enablePlanLifecycle: true,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-cancel" } });
+      childSupervisor.childrenIndex.restore({});
+
+      runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      // Allow the lifecycle registry to register the run before querying status.
+      await clock.tickAsync(0);
+
+      const statusBefore = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(statusBefore.isError ?? false).to.equal(false);
+      const beforeSnapshot = statusBefore.structuredContent as { state: string; progress: number };
+      expect(beforeSnapshot.state).to.equal("running");
+      expect(beforeSnapshot.progress).to.equal(0);
+
+      // Advance the scheduler slightly so ticks accumulate before the cancellation request.
+      await clock.tickAsync(50);
+
+      const cancelResponse = await client.callTool({
+        name: "plan_cancel",
+        arguments: { run_id: planArguments.run_id, reason: "test-progress" },
+      });
+      expect(cancelResponse.isError ?? false).to.equal(false);
+      const cancelContent = cancelResponse.structuredContent as {
+        run_id: string;
+        progress: number | null;
+        lifecycle: { state: string; progress: number; failure: { reason: string | null } | null } | null;
+        operations: Array<{ op_id: string; outcome: string }>;
+      };
+      expect(cancelContent.run_id).to.equal(planArguments.run_id);
+      expect(cancelContent.operations).to.have.lengthOf(1);
+      expect(cancelContent.operations[0]?.op_id).to.equal(planArguments.op_id);
+      expect(cancelContent.operations[0]?.outcome).to.equal("requested");
+      expect(cancelContent.progress).to.equal(100);
+      expect(cancelContent.lifecycle?.state).to.equal("failed");
+      expect(cancelContent.lifecycle?.progress).to.equal(100);
+      expect(cancelContent.lifecycle?.failure?.reason).to.equal("test-progress");
+
+      await clock.tickAsync(50);
+
+      const runResult = await runPromise;
+      expect(runResult.isError ?? false).to.equal(true);
+      const runPayload = JSON.parse(runResult.content?.[0]?.text ?? "{}");
+      expect(runPayload.error).to.equal("E-CANCEL-OP");
+      expect(runPayload.details?.reason).to.equal("test-progress");
+
+      const finalStatus = await client.callTool({ name: "plan_status", arguments: { run_id: planArguments.run_id } });
+      expect(finalStatus.isError ?? false).to.equal(false);
+      const finalSnapshot = finalStatus.structuredContent as {
+        state: string;
+        progress: number;
+        failure: { reason: string | null } | null;
+      };
+      expect(finalSnapshot.state).to.equal("failed");
+      expect(finalSnapshot.progress).to.equal(100);
+      expect(finalSnapshot.failure?.reason).to.equal("test-progress");
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
+      if (runPromise) {
+        await runPromise.catch(() => {});
+      }
+    }
+  });
+
+  it("degrades gracefully when plan_cancel runs without lifecycle snapshots", async function () {
+    this.timeout(10000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "plan-cancel-no-lifecycle", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const planArguments = {
+      tree: {
+        id: "plan-cancel-no-lifecycle-tree",
+        root: {
+          type: "retry",
+          id: "retry-no-lifecycle",
+          max_attempts: 10,
+          backoff_ms: 250,
+          child: {
+            type: "guard",
+            id: "guard-no-lifecycle",
+            condition_key: "allow",
+            expected: true,
+            child: {
+              type: "task",
+              id: "noop-node",
+              node_id: "noop-node",
+              tool: "noop",
+              input_key: "payload",
+            },
+          },
+        },
+      },
+      variables: { allow: false, payload: { attempt: 1 } },
+      tick_ms: 25,
+      timeout_ms: 5_000,
+      run_id: "plan-cancel-no-lifecycle-run",
+      op_id: "plan-cancel-no-lifecycle-op",
+    } as const;
+
+    let runPromise: ReturnType<Client["callTool"]> | null = null;
+
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enableCancellation: true,
+        enablePlanLifecycle: false,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-cancel-no-lifecycle" } });
+      childSupervisor.childrenIndex.restore({});
+
+      runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      await clock.tickAsync(0);
+      await clock.tickAsync(50);
+
+      const cancelResponse = await client.callTool({
+        name: "plan_cancel",
+        arguments: { run_id: planArguments.run_id, reason: "no-lifecycle" },
+      });
+      expect(cancelResponse.isError ?? false).to.equal(false);
+      const cancelContent = cancelResponse.structuredContent as {
+        run_id: string;
+        operations: Array<{ op_id: string; outcome: string }>;
+        progress: number | null;
+        lifecycle: unknown;
+      };
+      expect(cancelContent.run_id).to.equal(planArguments.run_id);
+      expect(cancelContent.operations).to.have.lengthOf(1);
+      expect(cancelContent.operations[0]?.op_id).to.equal(planArguments.op_id);
+      expect(cancelContent.progress).to.equal(null);
+      expect(cancelContent.lifecycle).to.equal(null);
+
+      await clock.tickAsync(50);
+
+      const runResult = await runPromise;
+      expect(runResult.isError ?? false).to.equal(true);
+      const runPayload = JSON.parse(runResult.content?.[0]?.text ?? "{}");
+      expect(runPayload.error).to.equal("E-CANCEL-OP");
+      expect(runPayload.details?.reason).to.equal("no-lifecycle");
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
+      if (runPromise) {
+        await runPromise.catch(() => {});
+      }
+    }
+  });
+
+  it("returns lifecycle progress when op_cancel aborts a running plan", async function () {
+    this.timeout(10000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "op-cancel-progress-client", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const planArguments = {
+      tree: {
+        id: "op-cancel-progress-tree",
+        root: {
+          type: "retry",
+          id: "retry-op-cancel",
+          max_attempts: 25,
+          backoff_ms: 500,
+          child: {
+            type: "guard",
+            id: "guard-op-cancel",
+            condition_key: "allow",
+            expected: true,
+            child: {
+              type: "task",
+              id: "noop-node",
+              node_id: "noop-node",
+              tool: "noop",
+              input_key: "payload",
+            },
+          },
+        },
+      },
+      variables: { allow: false, payload: { attempt: 1 } },
+      tick_ms: 25,
+      timeout_ms: 5_000,
+      run_id: "op-cancel-progress-run",
+      op_id: "op-cancel-progress-op",
+    } as const;
+
+    let runPromise: ReturnType<Client["callTool"]> | null = null;
+
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enableCancellation: true,
+        enablePlanLifecycle: true,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "op-cancel" } });
+      childSupervisor.childrenIndex.restore({});
+
+      runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      await clock.tickAsync(0);
+      await clock.tickAsync(50);
+
+      const cancelResponse = await client.callTool({
+        name: "op_cancel",
+        arguments: { op_id: planArguments.op_id, reason: "op-cancel-test" },
+      });
+      expect(cancelResponse.isError ?? false).to.equal(false);
+      const cancelContent = cancelResponse.structuredContent as {
+        op_id: string;
+        outcome: string;
+        run_id: string | null;
+        progress: number | null;
+        lifecycle: { state: string; progress: number; failure: { reason: string | null } | null } | null;
+      };
+      expect(cancelContent.op_id).to.equal(planArguments.op_id);
+      expect(cancelContent.run_id).to.equal(planArguments.run_id);
+      expect(cancelContent.progress).to.equal(100);
+      expect(cancelContent.lifecycle?.state).to.equal("failed");
+      expect(cancelContent.lifecycle?.progress).to.equal(100);
+      expect(cancelContent.lifecycle?.failure?.reason).to.equal("op-cancel-test");
+
+      await clock.tickAsync(50);
+
+      const runResult = await runPromise;
+      expect(runResult.isError ?? false).to.equal(true);
+      const runPayload = JSON.parse(runResult.content?.[0]?.text ?? "{}");
+      expect(runPayload.error).to.equal("E-CANCEL-OP");
+      expect(runPayload.details?.reason).to.equal("op-cancel-test");
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
+      if (runPromise) {
+        await runPromise.catch(() => {});
+      }
+    }
+  });
+
+  it("catches up lifecycle snapshots when the feature is re-enabled mid-run", async function () {
+    this.timeout(10000);
+
+    const baselineGraphSnapshot = graphState.serialize();
+    const baselineChildrenIndex = childSupervisor.childrenIndex.serialize();
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "plan-lifecycle-reactivation", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enablePlanLifecycle: false,
+      });
+      graphState.resetFromSnapshot({ nodes: [], edges: [], directives: { graph: "plan-lifecycle-reactivation" } });
+      childSupervisor.childrenIndex.restore({});
+
+      const planArguments = {
+        tree: {
+          id: "plan-lifecycle-reactivation-tree",
+          root: { type: "task", id: "noop", node_id: "noop", tool: "noop", input_key: "payload" },
+        },
+        variables: { payload: { scenario: "plan-lifecycle-reactivation" } },
+        tick_ms: 50,
+        timeout_ms: 1000,
+        run_id: "plan-lifecycle-reactivation-run",
+        op_id: "plan-lifecycle-reactivation-op",
+      } as const;
+
+      const runPromise = client.callTool({ name: "plan_run_reactive", arguments: planArguments });
+
+      // Allow the reactive loop to bootstrap without executing ticks yet.
+      await clock.tickAsync(0);
+
+      // Re-enable the lifecycle feature while the run remains active.
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enableBT: true,
+        enableReactiveScheduler: true,
+        enableStigmergy: true,
+        enablePlanLifecycle: true,
+      });
+
+      const statusAfterEnable = await client.callTool({
+        name: "plan_status",
+        arguments: { run_id: planArguments.run_id },
+      });
+      expect(statusAfterEnable.isError ?? false).to.equal(false);
+      const runningSnapshot = statusAfterEnable.structuredContent as { state: string; progress: number };
+      expect(runningSnapshot.state).to.equal("running");
+      expect(runningSnapshot.progress).to.equal(0);
+
+      const pauseResponse = await client.callTool({
+        name: "plan_pause",
+        arguments: { run_id: planArguments.run_id },
+      });
+      expect(pauseResponse.isError ?? false).to.equal(false);
+      const pausedSnapshot = pauseResponse.structuredContent as { state: string; supports_resume: boolean };
+      expect(pausedSnapshot.state).to.equal("paused");
+      expect(pausedSnapshot.supports_resume).to.equal(true);
+
+      const pausedStatus = await client.callTool({
+        name: "plan_status",
+        arguments: { run_id: planArguments.run_id },
+      });
+      expect(pausedStatus.isError ?? false).to.equal(false);
+      const pausedStatusSnapshot = pausedStatus.structuredContent as { state: string };
+      expect(pausedStatusSnapshot.state).to.equal("paused");
+
+      const resumeResponse = await client.callTool({
+        name: "plan_resume",
+        arguments: { run_id: planArguments.run_id },
+      });
+      expect(resumeResponse.isError ?? false).to.equal(false);
+      const resumedSnapshot = resumeResponse.structuredContent as { state: string };
+      expect(resumedSnapshot.state).to.equal("running");
+
+      await clock.tickAsync(50);
+      const runResponse = await runPromise;
+      expect(runResponse.isError ?? false).to.equal(false);
+      const runContent = runResponse.structuredContent as { status: string };
+      expect(runContent.status).to.equal("success");
+
+      const finalStatus = await client.callTool({
+        name: "plan_status",
+        arguments: { run_id: planArguments.run_id },
+      });
+      expect(finalStatus.isError ?? false).to.equal(false);
+      const finalSnapshot = finalStatus.structuredContent as { state: string; progress: number };
+      expect(finalSnapshot.state).to.equal("done");
+      expect(finalSnapshot.progress).to.equal(100);
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      graphState.resetFromSnapshot(baselineGraphSnapshot);
+      childSupervisor.childrenIndex.restore(baselineChildrenIndex);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
+    }
+  });
+
+  it("surfaces explicit lifecycle-disabled errors for status and pause/resume requests", async function () {
+    this.timeout(10000);
+
+    const baselineFeatures = getRuntimeFeatures();
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "plan-lifecycle-disabled-client", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      // Désactive explicitement le registre lifecycle pour vérifier que les outils
+      // de statut/pause/resume signalent l'erreur dédiée et orientent l'opérateur
+      // vers le flag à activer.
+      configureRuntimeFeatures({
+        ...baselineFeatures,
+        enablePlanLifecycle: false,
+      });
+
+      const statusResponse = await client.callTool({ name: "plan_status", arguments: { run_id: "missing" } });
+      expect(statusResponse.isError ?? false).to.equal(true);
+      const statusPayload = JSON.parse(statusResponse.content?.[0]?.text ?? "{}");
+      expect(statusPayload.error).to.equal("E-PLAN-LIFECYCLE-DISABLED");
+      expect(statusPayload.hint).to.equal("enable_plan_lifecycle");
+
+      const pauseResponse = await client.callTool({ name: "plan_pause", arguments: { run_id: "missing" } });
+      expect(pauseResponse.isError ?? false).to.equal(true);
+      const pausePayload = JSON.parse(pauseResponse.content?.[0]?.text ?? "{}");
+      expect(pausePayload.error).to.equal("E-PLAN-LIFECYCLE-DISABLED");
+      expect(pausePayload.hint).to.equal("enable_plan_lifecycle");
+
+      const resumeResponse = await client.callTool({ name: "plan_resume", arguments: { run_id: "missing" } });
+      expect(resumeResponse.isError ?? false).to.equal(true);
+      const resumePayload = JSON.parse(resumeResponse.content?.[0]?.text ?? "{}");
+      expect(resumePayload.error).to.equal("E-PLAN-LIFECYCLE-DISABLED");
+      expect(resumePayload.hint).to.equal("enable_plan_lifecycle");
+    } finally {
+      configureRuntimeFeatures(baselineFeatures);
+      await client.close().catch(() => {});
+      await server.close().catch(() => {});
     }
   });
 });

--- a/tests/resources.watch.sse.test.ts
+++ b/tests/resources.watch.sse.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Validates the SSE serialisation helpers preparing `resources_watch` for
+ * streaming endpoints. The scenarios cover newline/Unicode separators so we can
+ * guarantee the resulting `data:` lines stay single-line and reversible via
+ * `JSON.parse`.
+ */
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import type { ResourceWatchResult } from "../src/resources/registry.js";
+import {
+  renderResourceWatchSseMessages,
+  serialiseResourceWatchResultForSse,
+} from "../src/resources/sse.js";
+import { parseSseStream } from "./helpers/sse.js";
+import { resources, server } from "../src/server.js";
+
+describe("resources_watch SSE serialisation", () => {
+  it("serialises run events with escaped separators", () => {
+    const page: ResourceWatchResult = {
+      uri: "sc://runs/run-escape/events",
+      kind: "run_events",
+      nextSeq: 42,
+      events: [
+        {
+          seq: 42,
+          ts: 9_000,
+          kind: "STATUS",
+          level: "info",
+          jobId: "job-escape",
+          runId: "run-escape",
+          opId: "op-escape",
+          graphId: "graph-escape",
+          nodeId: "node-escape",
+          childId: "child-escape",
+          payload: {
+            note: "line1\nline2\rline3\u2028line4",
+          },
+        },
+      ],
+    };
+
+    const messages = serialiseResourceWatchResultForSse(page);
+    expect(messages).to.have.length(1);
+    expect(messages[0].event).to.equal("resource_run_event");
+    expect(messages[0].id).to.equal("sc://runs/run-escape/events:42");
+
+    const stream = renderResourceWatchSseMessages(messages);
+    const parsed = parseSseStream(stream);
+    expect(parsed).to.have.length(1);
+    expect(parsed[0].event).to.equal("resource_run_event");
+    expect(parsed[0].id).to.equal("sc://runs/run-escape/events:42");
+    expect(parsed[0].data).to.have.length(1);
+    expect(parsed[0].data[0]).to.not.include("\n");
+
+    const payload = JSON.parse(parsed[0].data[0]);
+    expect(payload).to.deep.equal({
+      uri: "sc://runs/run-escape/events",
+      kind: "run_events",
+      next_seq: 42,
+      record: {
+        type: "run_event",
+        seq: 42,
+        ts: 9_000,
+        kind: "STATUS",
+        level: "info",
+        job_id: "job-escape",
+        run_id: "run-escape",
+        op_id: "op-escape",
+        graph_id: "graph-escape",
+        node_id: "node-escape",
+        child_id: "child-escape",
+        payload: {
+          note: "line1\nline2\rline3\u2028line4",
+        },
+      },
+    });
+  });
+
+  it("serialises child log entries while preserving structured payloads", () => {
+    const page: ResourceWatchResult = {
+      uri: "sc://children/child-escape/logs",
+      kind: "child_logs",
+      nextSeq: 7,
+      events: [
+        {
+          seq: 7,
+          ts: 5_500,
+          stream: "stderr",
+          message: "warning line1\nline2\u2029tail",
+          jobId: null,
+          runId: "run-child",
+          opId: null,
+          graphId: "graph-child",
+          nodeId: null,
+          childId: "child-escape",
+          raw: "raw line1\nraw line2",
+          parsed: { structured: true },
+        },
+      ],
+    };
+
+    const messages = serialiseResourceWatchResultForSse(page);
+    expect(messages).to.have.length(1);
+    expect(messages[0].event).to.equal("resource_child_log");
+    expect(messages[0].id).to.equal("sc://children/child-escape/logs:7");
+
+    const stream = renderResourceWatchSseMessages(messages);
+    const parsed = parseSseStream(stream);
+    expect(parsed).to.have.length(1);
+    expect(parsed[0].event).to.equal("resource_child_log");
+    expect(parsed[0].id).to.equal("sc://children/child-escape/logs:7");
+    expect(parsed[0].data).to.have.length(1);
+    expect(parsed[0].data[0]).to.not.include("\n");
+
+    const payload = JSON.parse(parsed[0].data[0]);
+    expect(payload).to.deep.equal({
+      uri: "sc://children/child-escape/logs",
+      kind: "child_logs",
+      next_seq: 7,
+      record: {
+        type: "child_log",
+        seq: 7,
+        ts: 5_500,
+        stream: "stderr",
+        message: "warning line1\nline2\u2029tail",
+        job_id: null,
+        run_id: "run-child",
+        op_id: null,
+        graph_id: "graph-child",
+        node_id: null,
+        child_id: "child-escape",
+        raw: "raw line1\nraw line2",
+        parsed: { structured: true },
+      },
+    });
+  });
+
+  it("emits keep-alives when a page is empty", () => {
+    const page: ResourceWatchResult = {
+      uri: "sc://children/idle/logs",
+      kind: "child_logs",
+      events: [],
+      nextSeq: 11,
+    };
+
+    const messages = serialiseResourceWatchResultForSse(page);
+    expect(messages).to.have.length(1);
+    expect(messages[0]).to.include({
+      id: "sc://children/idle/logs:11",
+      event: "resource_keep_alive",
+    });
+
+    const stream = renderResourceWatchSseMessages(messages);
+    const parsed = parseSseStream(stream);
+    expect(parsed).to.have.length(1);
+    expect(parsed[0].event).to.equal("resource_keep_alive");
+    expect(parsed[0].id).to.equal("sc://children/idle/logs:11");
+    expect(parsed[0].data).to.have.length(1);
+    expect(parsed[0].data[0]).to.not.include("\n");
+
+    const payload = JSON.parse(parsed[0].data[0]);
+    expect(payload).to.deep.equal({
+      uri: "sc://children/idle/logs",
+      kind: "child_logs",
+      next_seq: 11,
+      record: { type: "keep_alive" },
+    });
+  });
+});
+
+describe("resources_watch tool SSE integration", () => {
+  it("returns an SSE stream containing escaped run events", async function () {
+    this.timeout(5000);
+
+    const runId = `run-sse-${Date.now()}`;
+    const now = Date.now();
+    // Seed the registry with a run event carrying control characters so the SSE
+    // serialisation path must escape them before the tool exposes the stream.
+    resources.recordRunEvent(runId, {
+      seq: 1,
+      ts: now,
+      kind: "STATUS",
+      level: "info",
+      jobId: "job-sse",
+      runId,
+      childId: null,
+      payload: { message: "line1\nline2\rline3\u2028line4" },
+    });
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "resources-watch-sse", version: "1.0.0-test" });
+
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const response = await client.callTool({
+        name: "resources_watch",
+        arguments: { uri: `sc://runs/${runId}/events`, format: "sse" },
+      });
+
+      expect(response.isError ?? false).to.equal(false);
+      const structured = response.structuredContent as {
+        format: string;
+        stream: string;
+        messages: Array<{ id: string; event: string; data: string }>;
+        next_seq: number;
+      };
+
+      expect(structured.format).to.equal("sse");
+      expect(structured.next_seq).to.equal(1);
+      expect(structured.messages).to.have.length(1);
+      expect(structured.messages[0]?.event).to.equal("resource_run_event");
+      expect(structured.messages[0]?.data).to.not.include("\n");
+
+      const parsed = parseSseStream(structured.stream);
+      expect(parsed).to.have.length(1);
+      expect(parsed[0]?.event).to.equal("resource_run_event");
+      expect(parsed[0]?.data).to.have.length(1);
+      expect(parsed[0]?.data[0]).to.not.include("\n");
+
+      const payload = JSON.parse(parsed[0]!.data[0]!);
+      expect(payload).to.deep.equal({
+        uri: `sc://runs/${runId}/events`,
+        kind: "run_events",
+        next_seq: 1,
+        record: {
+          type: "run_event",
+          seq: 1,
+          ts: now,
+          kind: "STATUS",
+          level: "info",
+          job_id: "job-sse",
+          run_id: runId,
+          op_id: null,
+          graph_id: null,
+          node_id: null,
+          child_id: null,
+          payload: { message: "line1\nline2\rline3\u2028line4" },
+        },
+      });
+    } finally {
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an optional `format` flag to `resources_watch` so the tool can return SSE-ready messages and a pre-rendered stream when requested
- cover the new `format="sse"` path with an in-memory MCP integration test and export the registry for seeding test data
- refresh the README, MCP API docs, and agent log with the SSE option and note the potential HTTP streaming follow-up

## Testing
- npm run lint
- npm run test:unit -- --exit
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e18fea4870832fb8137815362d02a7