### PR TITLE
Extend gateway hygiene to network modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,472 +1,567 @@
-Parfait. Je me base sur **la version actuelle du dépôt que tu as fournie** (dernière archive dézippée) et sur **l’audit précédent** : les modules “MCP-friendly avancés” que nous avions définis (introspection, events unifiés, cancellation, transactions exposées, diff/patch, locks, idempotency, bulk, lifecycle plan, child ops fines, values explain, assistance KG/causal, resources URIs, logs tail) **ne sont pas encore présents** dans cette archive, et donc **aucun test associé** non plus.
-Voici une **liste de tâches à cocher** ultra-précise, **fichier par fichier**, pour obtenir un code **propre, fonctionnel et robuste**, avec **sous-étapes**, **objectifs**, **critères d’acceptation**, et **règles build/tests** à respecter.
+Parfait. Voici la **checklist exhaustive “à cocher”** (avec cases) pour l’agent, basée sur la **dernière archive auditée** et **toutes** nos analyses. J’ai gardé (et encore précisé) le niveau de détail macro/micro, les critères d’acceptation, les invariants, les exemples E/S, les erreurs codifiées, et les exigences de tests/build.
+Tu peux copier-coller tel quel dans un gestionnaire de tâches : chaque sous-étape possède sa case.
 
 ---
 
-## BRIEF (lis-moi d’abord)
+# 0) Fondations & hygiène
 
-**Objectifs attendus (résumé)**
+* [x] `src/paths.ts` — **Normalisation des chemins & sécurité**
 
-* Offrir à l’agent MCP une surface d’API **complète et ergonomique** : introspection/capabilities, ressources adressables, **event bus unifié** (progress/corrélation), **cancellation** uniforme, **transactions** exposées, **diff/patch** + invariants, **locks**, **idempotency keys**, **opérations bulk**, **lifecycle plan** cohérent, **child ops fines**, **values explain**, **assistance KG/causal**, **logs tail**.
-* Conserver un **comportement déterministe** en test (fake timers, seeds) et une **sécurité de concurrence** (locks/versions/rollback).
-* Zod sur **toutes** les nouvelles tools, codes d’erreurs **normalisés**, chemins **normalisés** (aucune écriture hors dossiers d’exécution contrôlés).
+  * [x] **Macro** : Tous les accès disque passent par ce module. Interdit strict de `..`, chemins hors base.
+  * [x] **Micro**
 
-**Règles Build/Tests (obligatoires)**
+    * [x] `sanitizeFilename(name: string): string` (supprime `..`, `\0`, caractères illégaux, normalise Unicode NFC, limite 120 chars).
+    * [x] `safeJoin(base: string, ...parts: string[]): string` (résout, **rejette** si on sort de `base` → `E-PATHS-ESCAPE`).
+    * [x] `resolveRunDir(runId: string): string` (crée `runs/<runId>` si absent).
+    * [x] `resolveChildDir(childId: string): string` (crée `children/<childId>` si absent).
+  * [x] **Erreurs** : `E-PATHS-ESCAPE`, messages courts + `hint`.
+  * [x] **Tests**
 
-* Install :
+    * [x] `tests/paths.sanitization.test.ts` (cas `..`, Unicode, nom long, caractères spéciaux).
+    * [x] Micro-bench local `<5ms` par appel (hors CI).
 
-  * Si lockfile : `npm ci`
-  * Sinon : `npm install --omit=dev --no-save --no-package-lock`
-* Build : `npm run build` (racine → puis `graph-forge` si séparé)
-* Lint : `npm run lint` (tsc strict, `noEmit`)
-* Tests : `npm test` **offline**, **fake timers** pour tout ce qui attend/timeout ; **aucune dépendance réseau**
-* CI : Node **18/20/22**, artefact coverage ; pas d’appels externes
-* Zod : toutes les nouvelles tools **valident** leur input ; messages d’erreur courts avec **codes** stables
-* FS : n’écrire **que** dans `runs/…` / `children/…` / répertoires temporaires dédiés ; interdire `..` ; normaliser avec un utilitaire `paths`
+* [x] `src/types.ts` — **Types partagés & erreurs**
+
+  * [x] **Macro** : Unifier les IDs/codes d’erreurs et assurer un formatage homogène.
+  * [x] **Micro**
+
+    * [x] Types : `RunId`, `OpId`, `GraphId`, `Version`, `ChildId`.
+    * [x] Codes d’erreurs stables : `E-MCP-*`, `E-RES-*`, `E-EVT-*`, `E-CANCEL-*`, `E-TX-*`, `E-LOCK-*`, `E-PATCH-*`, `E-PLAN-*`, `E-CHILD-*`, `E-VALUES-*`, `E-ASSIST-*`.
+    * [x] Helper `fail(code, message, hint?)` → `{ok:false, code, message, hint?}`.
+  * [x] **Tests**
+
+    * [x] `tests/types.errors-shape.test.ts` (shape, champs obligatoires, stabilité).
+
+* [x] `tsconfig.json` — **Strict & reproductible**
+
+  * [x] `strict:true`, `moduleResolution:"node"`, `target:"ES2022"`, `types:["node"]`.
+  * [x] `baseUrl:"."` + `paths` pour alias : `graph/*`, `executor/*`, `coord/*`, `agents/*`, `knowledge/*`, `values/*`, `monitor/*`, `events/*`, `mcp/*`, `resources/*`, `infra/*`, `state/*`, `viz/*`.
+  * [x] **Accept.** : `tsc --noEmit` passe sans erreur.
+
+* [x] `src/serverOptions.ts` — **Feature flags & paramètres**
+
+  * [x] **Macro** : Activer/désactiver finement les surfaces (exposées dans `mcp_info`).
+  * [x] **Micro**
+
+    * [x] Flags (par défaut `false`) :
+      `enableMcpIntrospection`, `enableResources`, `enableEventsBus`, `enableCancellation`, `enableTx`, `enableBulk`, `enableIdempotency`, `enableLocks`, `enableDiffPatch`, `enablePlanLifecycle`, `enableChildOpsFine`, `enableValuesExplain`, `enableAssist`.
+    * [x] Paramètres : `defaultTimeoutMs`, `btTickMs`, `supervisorStallTicks`, `autoscaleCooldownMs`, `stigHalfLifeMs`.
+  * [x] **Tests**
+
+    * [x] `tests/options.flags.wiring.test.ts` (chaque flag expose/masque ses tools).
 
 ---
 
-## 0) Hygiène et fondations (préparatifs)
+# 1) Introspection MCP & capacités
 
-* [x] **Créer** `src/paths.ts`
+* [x] `src/mcp/info.ts` — **Découverte du serveur**
 
-  * [x] Fonctions : `resolveRunDir(runId)`, `resolveChildDir(childId)`, `sanitizeFilename(name)`, `safeJoin(base, ...parts)` (interdit `..`)
-  * **Accept.** : tous les modules écrivent via `paths.ts`, **pas** d’accès direct `fs` avec chemins relatifs bruts.
+  * [x] **Macro** : Permettre à un client MCP d’inspecter l’API active & les limites.
+  * [x] **Micro**
 
-* [x] **Créer** `src/types.ts` (si absent)
+    * [x] `getMcpInfo(): { server:{name,version}, mcp:{protocol,transport[]}, features:string[], limits:{maxInputBytes,defaultTimeoutMs}, flags:Record<string,boolean> }`
+    * [x] `getMcpCapabilities(): { namespaces:string[], tools:{name,inputSchemaSummary}[] }`
+  * [x] `src/server.ts` — **Tools**
 
-  * [x] Types de base partagés (RunId, OpId, GraphId, Version, ChildId…)
-  * [x] Map des **codes d’erreurs** : `E-MCP-*`, `E-RES-*`, `E-EVT-*`, `E-CANCEL-*`, `E-TX-*`, `E-LOCK-*`, `E-PATCH-*`, `E-PLAN-*`, `E-CHILD-*`, `E-VALUES-*`, `E-ASSIST-*`
-  * **Accept.** : chaque tool retourne `{ok:false, code, message, hint?}` en cas d’échec.
+    * [x] `mcp_info` (input `{}` via Zod), `mcp_capabilities` (input `{}`), activés par `enableMcpIntrospection`.
+  * [x] **Tests**
 
-* [x] **Mettre à jour** `tsconfig.json`
+    * [x] `tests/mcp.info-capabilities.test.ts` (cohérence `flags`, `features`, `limits`, stabilité de shape).
 
-  * [x] `strict:true`, `moduleResolution:"node"`, `target:"ES2022"`, `types:["node"]`
-  * [x] `paths` pour : `graph/*`, `executor/*`, `coord/*`, `agents/*`, `knowledge/*`, `values/*`, `monitor/*`, `events/*`, `mcp/*`, `resources/*`, `infra/*`, `state/*`, `viz/*`.
+---
 
-* [x] **Mettre à jour** `src/serverOptions.ts`
+# 2) Ressources adressables (URIs) & watch
 
-  * [x] **Feature flags** (par défaut **false**) :
-    `enableMcpIntrospection`, `enableResources`, `enableEventsBus`, `enableCancellation`, `enableTx`, `enableBulk`, `enableIdempotency`, `enableLocks`, `enableDiffPatch`, `enablePlanLifecycle`, `enableChildOpsFine`, `enableValuesExplain`, `enableAssist`
-  * [x] Timeouts : `defaultTimeoutMs`, `btTickMs`, `supervisorStallTicks`, `autoscaleCooldownMs`, `stigHalfLifeMs`.
-  * **Accept.** : flags reflétés par `mcp_info`.
+* [x] `src/resources/registry.ts` — **URIs stables**
 
+  * [x] **Macro** : Lister/Lire/Observer des ressources via `sc://` URIs.
+  * [x] **Micro**
+
+    * [x] URIs supportées :
+
+      * [x] `sc://graphs/<graphId>` ; `sc://graphs/<graphId>@v<version>`
+      * [x] `sc://runs/<runId>/events` ; `sc://children/<childId>/logs`
+      * [x] `sc://blackboard/<ns>` ; `sc://snapshots/<graphId>/<txId>`
+    * [x] `list(prefix?) -> {uri, kind, meta?}[]`
+    * [x] `read(uri) -> {mime, data}`
+    * [x] `watch(uri, fromSeq?) -> AsyncIterable<Event>` (events ordonnés par `seq`)
+  * [x] `src/server.ts` — **Tools**
+
+    * [x] `resources_list`, `resources_read`, `resources_watch` (`enableResources`).
+  * [x] **Tests**
+
+    * [x] `tests/resources.list-read-watch.test.ts` (listing filtré, lecture snapshots, `watch` avec `fromSeq`).
+
+---
+
+# 3) Event bus unifié (progress/corrélation)
+
+* [x] `src/events/bus.ts` — **Événements normalisés**
+
+  * [x] **Macro** : Un bus unique avec `seq` monotone et corrélation `runId/opId`.
+  * [x] **Micro**
+
+    * [x] Type `Event` :
+      `{ts, seq, cat:"bt"|"scheduler"|"child"|"graph"|"stig"|"bb"|"cnp"|"consensus"|"values", level:"info"|"warn"|"error", runId?, opId?, graphId?, nodeId?, childId?, msg, data?}`
+    * [x] `emit(e)` ; séquences par stream ; backpressure (tampon + drop `debug` si surcharge).
+  * [x] Intégrations
+
+    * [x] Publier des événements dans `executor/*`, `coord/*`, `agents/*`.
+  * [x] `src/server.ts` — **Tool**
+
+    * [x] `events_subscribe({cats?, runId?}) -> stream` (`enableEventsBus`).
+  * [x] **Tests**
+
+    * [x] `tests/events.subscribe.progress.test.ts` (filtrage `cats/runId`, ordre `seq`, fin de stream).
+    * [x] `tests/events.backpressure.test.ts` (limites & comportement en surcharge).
+
+---
+
+# 4) Annulation uniforme
+
+* [x] `src/executor/cancel.ts` — **Signal d’annulation**
+
+  * [x] **Macro** : Toute op longue est annulable proprement.
+  * [x] **Micro**
+
+    * [x] Store `Map<OpId, {cancelled:boolean, reason?:string}>`
+    * [x] `requestCancel(opId)`, `isCancelled(opId)`, cleanup `finally`.
+    * [x] **Points d’annulation** avant/après chaque `await` critique ; boucles longues coopératives.
+  * [x] `src/server.ts` — **Tools**
+
+    * [x] `op_cancel({opId})`, `plan_cancel({runId})` (cascade).
+  * [x] **Erreurs**
+
+    * [x] `E-CANCEL-NOTFOUND` si inconnu.
+  * [x] **Tests**
+
+    * [x] `tests/cancel.bt.decorator.test.ts` (quand BT dispo): arrêt net, no leak.
+    * [x] `tests/cancel.plan.run.test.ts` (cascade runId → opIds).
+
+---
+
+# 5) Transactions (TX) exposées
+
+* [x] `src/graph/tx.ts` — **TX en mémoire + commit**
+
+  * [x] **Macro** : Grouper des mutations de graphe de façon atomique.
+  * [x] **Micro**
+
+    * [x] `tx_begin(graphId) -> {txId, baseVersion}`
+    * [x] `tx_apply(txId, ops: GraphOp[]) -> {previewVersion, diff: JsonPatch[]}`
+    * [x] `tx_commit(txId) -> {graphId, newVersion}`
+    * [x] `tx_rollback(txId) -> {rolledBack:true}`
+    * [x] `GraphOp`: `AddNode`, `RemoveNode`, `AddEdge`, `RemoveEdge`, `PatchMeta`, `Rewrite{rule,params}`
+    * [x] **Intègre** les invariants (§6) dans `apply/commit`.
+  * [x] `src/server.ts` — **Tools**
+
+    * [x] `tx_begin`, `tx_apply`, `tx_commit`, `tx_rollback` (`enableTx`).
+  * [x] **Erreurs**
+
+    * [x] `E-TX-NOTFOUND`, `E-TX-CONFLICT`, `E-TX-INVALIDOP`.
+  * [x] **Tests**
+
+    * [x] `tests/tx.begin-apply-commit.test.ts` (conflits, rollback idempotent, diffs stables).
+
+---
+
+# 6) Diff/Patch + invariants
+
+* [x] `src/graph/diff.ts` — **JSON Patch**
+
+  * [x] `diffGraphs(a,b): JsonPatch[]` (déterministe, sans bruit).
+* [x] `src/graph/patch.ts` — **Application de patch**
+
+  * [x] `applyPatch(graph, patch)` (rejette si invariants violés).
+
+* [x] `src/graph/invariants.ts` — **Règles**
+
+  * [x] **Macro** : Garantir cohérence structurelle.
+  * [x] **Micro**
+
+    * [x] `check(graph) -> {ok:true}|{ok:false, violations:[{path, code, message}] }`
+    * [x] Règles minimales :
+
+      * [x] Acyclicité (DAG) → `E-PATCH-CYCLE`
+      * [x] Ports/labels requis par type → `E-PATCH-PORTS`
+      * [x] Cardinalités d’arêtes → `E-PATCH-CARD`
+* [x] `src/server.ts` — **Tools**
+
+  * [x] `graph_diff`, `graph_patch` (`enableDiffPatch`).
 * [x] **Tests**
 
-  * [x] `tests/options.flags.wiring.test.ts` (activer/désactiver un flag fait réellement apparaître/disparaître les tools associées)
-  * [x] `tests/paths.sanitization.test.ts` (aucun `..`, normalisation).
+  * [x] `tests/graph.diff-patch.test.ts` (roundtrip).
+  * [x] `tests/graph.invariants.enforced.test.ts` (rejets attendus).
 
 ---
 
-## 1) Introspection MCP & Capacités
+# 7) Locks & Idempotency
 
-* [x] **Créer** `src/mcp/info.ts`
+* [x] `src/graph/locks.ts` — **Verrous**
 
-  * [x] `getMcpInfo() -> { server:{name,version}, mcp:{protocol,transport[]}, features:string[], limits:{maxInputBytes, defaultTimeoutMs}, flags:Record<string,boolean> }`
-  * [x] `getMcpCapabilities() -> { namespaces: string[], tools: {name, inputSchemaSummary}[] }`
-* [x] **Modifier** `src/server.ts`
+  * [x] **Macro** : Sécurité concurrente.
+  * [x] **Micro**
 
-  * [x] Tools : `mcp_info`, `mcp_capabilities` (Zod `{}`)
+    * [x] `graph_lock({graphId, holder, ttlMs}) -> {lockId}`
+    * [x] `graph_unlock({lockId})`, `refresh(lockId)`
+    * [x] Réentrance par `holder`; refus mutations si lock tiers (`E-LOCK-HELD`).
+* [x] `src/infra/idempotency.ts` — **Rejouabilité**
+
+  * [x] **Macro** : Rejouer **exactement** le même résultat sur `idempotencyKey`.
+  * [x] **Micro**
+
+    * [x] Store TTL `(key -> serializedResult)` ; hit → renvoi identical.
+    * [x] Cibler : `child_create`, `plan_run_bt`, `cnp_announce`, `graph_batch_mutate`, `tx_begin`.
+* [x] `src/server.ts`
+
+  * [x] Tools : `graph_lock`, `graph_unlock` (`enableLocks`).
+  * [x] Toutes les tools sensibles acceptent `idempotencyKey?` (`enableIdempotency`).
 * [x] **Tests**
 
-  * [x] `tests/mcp.info-capabilities.test.ts` (cohérence avec `serverOptions`, listage complet, shape stable)
-
-**Accept.** : un client MCP peut découvrir **tout** ce qui est activé et les limites d’entrée.
+  * [x] `tests/graph.locks.concurrent.test.ts` (conflits, expiration, no deadlock).
+  * [x] `tests/idempotency.replay.test.ts` (résultat binaire identique, entêtes idempotency).
 
 ---
 
-## 2) Ressources adressables & lecture/abonnement
+# 8) Opérations bulk atomiques
 
-* [x] **Créer** `src/resources/registry.ts`
+* [x] `src/server.ts` — **Bulk tools** (`enableBulk`)
 
-  * [x] URIs supportées :
-    `sc://graphs/<graphId>`, `sc://graphs/<graphId>@v<version>`,
-    `sc://runs/<runId>/events`, `sc://children/<childId>/logs`,
-    `sc://blackboard/<ns>`, `sc://snapshots/<graphId>/<txId>`
-  * [x] API : `list(prefix?)`, `read(uri) -> {mime,data}`, `watch(uri, fromSeq?) -> AsyncIterable<Event>`
-  * [x] Surveillance `sc://blackboard/<ns>` → événements versionnés (`set/delete/expire`) relayés via watch & SSE.
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools : `resources_list`, `resources_read`, `resources_watch`
+  * [x] `bb_batch_set([{ns, key, value, ttlMs?}])`
+  * [x] `graph_batch_mutate({graphId, ops: GraphOp[]})` (mini-TX interne, rollback total si partiel).
+  * [x] `child_batch_create([{idempotencyKey?, role?, prompt, limits?}])`
+  * [x] `stig_batch([{nodeId, type, intensity}])`
+  * [x] Erreur agrégée `E-BULK-PARTIAL` (avec `failures[]` détaillé).
 * [x] **Tests**
 
-  * [x] `tests/resources.list-read-watch.test.ts` (listing filtré, lecture snapshots/graphes, flux ordonné par `seq`)
-
-**Accept.** : un agent peut **parcourir et suivre** les ressources clés par URI stable.
+  * [x] `tests/bulk.bb-graph-child-stig.test.ts` (atomicité, rollback, diagnostics par item).
 
 ---
 
-## 3) Event bus unifié (progress/corrélation)
+# 9) Lifecycle plan (status/pause/resume/dry-run)
 
-* [x] **Créer** `src/events/bus.ts`
+* [x] `src/executor/planLifecycle.ts` — **FSM de plan**
 
-  * [x] Type `Event {ts, cat:string, level, runId?, opId?, graphId?, nodeId?, childId?, msg, data?, seq}`
-  * [x] EventEmitter global + séquence monotone par stream
-* [x] **Brancher** le bus dans : `src/executor/*`, `src/coord/*`, `src/agents/*` (publication à chaque étape significative)
-* [x] **Modifier** `src/server.ts`
+  * [x] **Macro** : Contrôle de l’exécution.
+  * [x] **Micro**
 
-  * [x] Tool : `events_subscribe({cats?, runId?}) -> stream`
+    * [x] États : `running|paused|done|failed`, `progress:0..100`, `lastEventSeq`.
+    * [x] Transitions légales : `running↔paused`, `running→done|failed` (terminal).
+* [x] `src/server.ts` — **Tools** (`enablePlanLifecycle`)
+
+  * [x] `plan_status({runId})`
+  * [x] `plan_pause({runId})`, `plan_resume({runId})`
+  * [x] `plan_dry_run({graphId|btJson})` (compile si BT dispo, **simulation**, `values_explain`, preview `rewrite` sans effets).
+  * [x] Erreurs : `E-PLAN-STATE` (transition illégale).
 * [x] **Tests**
 
-  * [x] `tests/events.subscribe.progress.test.ts` (filtrage cat/runId, ordre, complétion)
-
-**Accept.** : toute opération longue émet des events **corrélés** par `opId/runId`.
+  * [x] `tests/plan.lifecycle.test.ts` (FSM strict).
+  * [x] `tests/plan.dry-run.test.ts` (`values_explain` → violations + hints).
 
 ---
 
-## 4) Cancellation uniforme
+# 10) Child ops fines
 
-* [x] **Créer** `src/executor/cancel.ts`
+* [x] `src/state/childrenIndex.ts`, `src/childRuntime.ts` — **Gestion enfants**
 
-  * [x] Store `opId -> {cancelled:boolean}` ; `requestCancel(opId)`, `isCancelled(opId)`
-* [x] **Modifier** `src/executor/bt/nodes.ts`, `src/executor/bt/interpreter.ts`, `src/executor/reactiveScheduler.ts`
+  * [x] **Macro** : Une **instance Codex par enfant**, contrôlée.
+  * [x] **Micro**
 
-  * [x] Ajout **points d’annulation** (avant I/O, sleeps, backoff, boucles longues)
-* [x] **Modifier** `src/server.ts`
+    * [x] `child_spawn_codex({role?, prompt, modelHint?, limits?}) -> {childId}`
+    * [x] `child_attach({childId}) -> {ok:true}`
+    * [x] `child_set_role({childId, role})`
+    * [x] `child_set_limits({childId, cpuMs?, memMb?, wallMs?})`
+    * [x] `child_status({childId})` (état, quotas).
+  * [x] `src/server.ts` — **Tools** (`enableChildOpsFine`)
 
-  * [x] Tools : `op_cancel({opId})`, `plan_cancel({runId})` (cascade)
+    * [x] Enregistrer les tools ci-dessus.
+  * [x] **Erreurs**
+
+    * [x] `E-CHILD-NOTFOUND`, `E-CHILD-LIMIT`.
+  * [x] **Tests**
+
+    * [x] `tests/child.spawn-attach-limits.test.ts` (respect limites, idempotence `attach`, collecte et GC).
+
+---
+
+# 11) (Optionnel mais recommandé) BT & Scheduler
+
+* [x] `src/executor/bt/types.ts`, `src/executor/bt/nodes.ts`, `src/executor/bt/interpreter.ts`, `src/executor/bt/compiler.ts`
+
+  * [x] **Macro** : Exécution réactive robuste.
+  * [x] **Micro**
+
+    * [x] Status : `"success"|"failure"|"running"`
+    * [x] Nœuds : `Sequence`, `Selector`, `Parallel(all|any|quota(k))`
+    * [x] Décorateurs : `Retry(n,jitter)`, `Timeout(ms)`, `Guard(cond)`, `Cancellable()`
+    * [x] `interpreter.tick()` async ; persistance état ; `progress` par nœud.
+    * [x] `compiler` : `HierGraph` → BT.
+  * [x] **Tests**
+
+    * [x] `tests/bt.nodes.sequence-selector.test.ts`
+    * [x] `tests/bt.decorators.retry-timeout-cancel.test.ts` (fake timers)
+    * [x] `tests/bt.parallel.quota.test.ts`
+    * [x] `tests/bt.compiler.from-graph.test.ts`
+    * [x] `tests/bt.run.integration.test.ts`
+
+* [x] `src/executor/reactiveScheduler.ts`, `src/executor/loop.ts`
+
+  * [x] **Macro** : Scheduling fair, sans famine.
+  * [x] **Micro**
+
+    * [x] Priorité = f(âge, criticité, stig) ; **aging** anti-starvation ; quantum + **yield** coopératif.
+  * [x] **Tests**
+
+    * [x] `tests/executor.scheduler.prio-aging.test.ts`
+    * [x] `tests/executor.scheduler.budgets.test.ts`
+
+* [x] `src/server.ts`
+
+  * [x] Enregistrer `plan_compile_bt`, `plan_run_bt`, `plan_run_reactive` (si `enablePlanLifecycle`).
+
+---
+
+# 12) Coordination (blackboard, stigmergie, CNP, consensus)
+
+* [x] `src/coord/blackboard.ts`
+
+  * [x] **KV typée** : `bb_set/get/query/watch`, TTL, namespaces.
+  * [x] **Tests** : `tests/coord.blackboard.kv-watch.test.ts`.
+* [x] `src/coord/stigmergy.ts`
+
+  * [x] `mark(nodeId,type,intensity)` ; `decay(halfLifeMs)` ; `snapshot()`.
+  * [x] **Tests** : `tests/coord.stigmergy.field-scheduler.test.ts`.
+* [x] `src/coord/contractNet.ts`, `src/coord/consensus.ts`
+
+  * [x] CNP : `announce/bid/award` (min-cost + tie-break stable).
+  * [x] Consensus : `majority`, `quorum(k)`, `weighted`.
+  * [x] **Tests** : `tests/coord.contractnet.basic.test.ts`, `tests/coord.consensus.modes.test.ts`.
+* [x] `src/server.ts` — **Tools**
+
+  * [x] `bb_set/get/query/watch`, `stig_mark/decay/snapshot`, `cnp_announce`, `consensus_vote`.
+
+---
+
+# 13) Graphe avancé : hiérarchie / hypergraphes / réécriture
+
+* [x] `src/graph/hierarchy.ts`
+
+  * [x] `embed(subgraph, into, atNode)` ; `flatten(hierGraph)` ; **anti-cycles inter-niveaux**.
+  * [x] **Tests** : `tests/graph.hierarchy.flatten-embed.test.ts`.
+* [x] `src/graph/hypergraph.ts`
+
+  * [x] `HyperEdge {sources[], targets[]}` ; projection binaire.
+  * [x] **Tests** : `tests/graph.hyper.project.test.ts`.
+* [x] `src/graph/rewrite.ts`
+
+  * [x] Règles : `split-parallel`, `inline-subgraph`, `reroute-avoid(label|nodeId)` **idempotentes**.
+  * [x] **Tools** : `graph_rewrite_apply`, `graph_subgraph_extract`, `graph_hyper_export` (si utile).
+  * [x] **Tests** : `tests/graph.rewrite.rules.test.ts`.
+
+---
+
+# 14) Mémoire / Assistance / Valeurs
+
+* [x] `src/knowledge/knowledgeGraph.ts`
+
+  * [x] Triplets `{s,p,o,source?,confidence?}` ; index `(s,p)` & `(o,p)`.
+  * [x] **Tools** : `kg_insert/query/export`.
+  * [x] **Tests** : `tests/knowledge.kg.insert-query.test.ts`.
+* [x] `src/knowledge/assist.ts`
+
+  * [x] `kg_suggest_plan({goal,context?}) -> {fragments:HierGraph[], rationale:string[]}`.
+  * [x] **Tests** : `tests/assist.kg.suggest.test.ts` (mocks déterministes).
+* [x] `src/knowledge/causalMemory.ts`
+
+  * [x] `record(event, causes[])`, `explain(outcome)` ; export DAG.
+  * [x] **Tools** : `causal_export`, `causal_explain`.
+  * [x] **Tests** : `tests/knowledge.causal.record-explain.test.ts`.
+* [x] `src/values/valueGraph.ts`
+
+  * [x] `values_set`, `values_score`, `values_filter`, `values_explain(plan) -> violations[{nodeId,value,severity,hint}]`.
+  * [x] **Intégrer** `values_explain` dans `plan_dry_run`.
+  * [x] **Tests** : `tests/values.score-filter-explain.test.ts`.
+
+---
+
+# 15) Observabilité : logs corrélés & dashboard
+
+* [x] `src/monitor/log.ts`
+
+  * [x] JSONL `{ts,level,runId?,opId?,graphId?,childId?,seq,msg,data?}` ; rotation taille/date ; indexation minimale.
+  * [x] **Tool** : `logs_tail({stream:"server"|"run"|"child", id?, limit?, fromSeq?})`.
+  * [x] **Tests** : `tests/logs.tail.filters.test.ts` (filtres, limites, monotonicité).
+* [x] `src/monitor/dashboard.ts`, `src/viz/mermaid.ts`
+
+  * [x] SSE (état BT, heatmap stigmergie, backlog scheduler).
+  * [x] Mermaid overlays : badges RUNNING/OK/KO, intensités par nœud.
+  * [x] **Tests** : `tests/monitor.dashboard.streams.test.ts`, `tests/viz.mermaid.overlays.test.ts`.
+
+---
+
+# 16) Nettoyage / erreurs / sécurité applicative
+
+* [x] **Remplacer** tous accès FS directs par `paths.ts`.
+* [x] **Supprimer** TODO obsolètes & code mort.
+* [x] **Normaliser** messages d’erreur (courts) + `code` stable + `hint` actionnable.
 * [x] **Tests**
 
-  * [x] `tests/cancel.bt.decorator.test.ts` (interruption nette, cleanup)
-  * [x] `tests/cancel.plan.run.test.ts` (annulation en cascade)
-
-**Accept.** : **toute** op longue peut être annulée proprement, sans fuite.
+  * [x] `tests/server.tools.errors.test.ts` (toutes familles d’erreurs couvertes).
+  * [x] `tests/hygiene.fs-gateway.test.ts` (garde-fous `node:fs`, `node:child_process`, `node:worker_threads`, `node:vm`, `node:http`, `node:https`, `node:http2`, `node:net`).
 
 ---
 
-## 5) Transactions exposées (TX)
+# 17) Concurrence / robustesse / performance
 
-* [x] **Créer/Compléter** `src/graph/tx.ts`
+* [x] `tests/concurrency.graph-mutations.test.ts` (mutations concurrentes ; locks efficaces ; pas de deadlock).
+* [x] `tests/concurrency.events-backpressure.test.ts` (`events_subscribe/resources_watch` sous charge, backpressure).
+* [x] `tests/cancel.random-injection.test.ts` (annulations aléatoires pendant BT/scheduler — aucune fuite, fin propre).
+* [x] `tests/perf/scheduler.bench.ts` (hors CI) micro-bench aging/stigmergie.
 
-  * [x] `tx_begin(graphId) -> {txId, baseVersion}` ; `tx_apply(txId, ops[]) -> {previewVersion, diff}` ; `tx_commit(txId)` ; `tx_rollback(txId)`
-  * [x] `GraphOp` : add/remove node/edge, patch meta, apply rewrite(rule, params)
-* [x] **Modifier** `src/server.ts`
+---
 
-  * [x] Tools : `tx_begin`, `tx_apply`, `tx_commit`, `tx_rollback` (Zod strict)
+# 18) E2E (bout-en-bout)
+
+* [x] **E2E-1** : Plan hiérarchique → compile BT → `plan_run_bt` → `events_subscribe` (pause/resume) → `plan_cancel` → `logs_tail`.
+
+  * [x] **Attendus** : events corrélés, cancellation propre, logs présents.
+* [x] **E2E-2** : Backlog massif → stigmergie + autoscaler → superviseur → métriques OK (zero famine).
+* [x] **E2E-3** : CNP `announce` → bids → award → `plan_join` quorum → `plan_reduce` vote.
+
+  * [x] **Attendus** : quorum atteint ; tie-break stable ; idempotency OK.
+* [x] **E2E-4** : `plan_dry_run` → `values_explain` rejette → `kg_suggest_plan` propose → `rewrite` preview → exécution.
+* [x] **E2E-5** : `tx_begin` → `tx_apply` (ops multiples) → `graph_diff/patch` → `tx_commit` → `resources_read sc://graphs/<id>@vX`.
+
+---
+
+# Exigences Build/Tests (toujours)
+
+* [x] **Install**
+
+  * [x] Si lockfile : `npm ci`
+  * [ ] Sinon : `npm install --omit=dev --no-save --no-package-lock` (aucune écriture de lockfile)
+* [x] **Build**
+
+  * [x] `npm run build` (racine → `graph-forge` si séparé)
+  * [x] `npm run lint` (tsc strict `--noEmit`) → **0** erreur
 * [x] **Tests**
 
-  * [x] `tests/tx.begin-apply-commit.test.ts` (rollback idempotent, conflits de version)
+  * [x] `npm test` offline, **fake timers** sur toute attente
+* [x] Seeds fixes ; mocks IO ; **zéro** réseau
+  * [x] Coverage ≥ 85% sur **nouvelles** surfaces ; rapport HTML + lcov
+* [x] **CI**
 
-**Accept.** : un agent peut regrouper des mutations en TX **atomiques**.
-
----
-
-## 6) Diff/Patch & invariants
-
-* [x] **Créer** `src/graph/diff.ts` (JSON Patch RFC 6902)
-* [x] **Créer** `src/graph/patch.ts` (applique patch)
-* [x] **Créer** `src/graph/invariants.ts`
-
-  * [x] Règles : acyclicité (si DAG), ports/labels requis, edge cardinality
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools : `graph_diff({graphId, from, to})`, `graph_patch({graphId, patch})`
-* [x] **Tests**
-
-  * [x] `tests/graph.diff-patch.test.ts` (roundtrip)
-  * [x] `tests/graph.invariants.enforced.test.ts` (rejet patch invalide)
-
-**Accept.** : **aucun** patch ne viole les invariants ; diff/patch stables.
+  * [x] Node **18/20/22** (matrix)
+  * [x] Artefact coverage ; pas d’accès externe
+  * [x] Rerun unique autorisé pour tests taggés `@flaky` (objectif 0)
 
 ---
 
-## 7) Locks & Idempotency
+## Exemples E/S condensés (pour guider l’implémentation)
 
-* [x] **Créer** `src/graph/locks.ts`
+* [x] `op_cancel`
 
-  * [x] `graph_lock({graphId, holder, ttlMs}) -> {lockId}` ; `graph_unlock({lockId})` ; refresh
-  * [x] Mutations refusent si lock détenu par autre holder
-* [x] **Créer** `src/infra/idempotency.ts`
+  * [x] In : `{opId:string}`
+  * [x] Out OK : `{ok:true}`
+  * [x] Out KO : `{ok:false, code:"E-CANCEL-NOTFOUND", message:"unknown opId", hint:"verify opId via events_subscribe"}`
 
-  * [x] Store TTL `(key -> result)` ; relecture résultat pour les clés rejouées
-* [x] **Modifier** `src/server.ts`
+* [x] `tx_apply`
 
-  * [x] Exiger `idempotencyKey?` pour : `child_create`, `plan_run_bt`, `cnp_announce`, `graph_batch_mutate`, `tx_begin`
-  * [x] Tools : `graph_lock`, `graph_unlock`
-* [x] **Tests**
+  * [x] In : `{txId, ops:[{type:"AddNode",node:{...}}, ...]}`
+  * [x] Out : `{previewVersion:3, diff:[{op:"add",path:"/nodes/N3",value:{...}}, ...]}`
+  * [x] KO invariants : `{ok:false, code:"E-PATCH-CYCLE", message:"cycle detected", hint:"remove edge X->Y"}`
 
-  * [x] `tests/graph.locks.concurrent.test.ts` (pas de deadlock, re-entrance)
-  * [x] `tests/idempotency.replay.test.ts` (mêmes inputs → même résultat)
+* [x] `events_subscribe`
 
-**Accept.** : **retries réseau** sûrs ; concurrence maîtrisée.
+  * [x] In : `{cats:["bt","child"], runId:"RUN-42"}`
+  * [x] Stream : `{"ts":..., "seq":..., "cat":"bt", "runId":"RUN-42", "opId":"OP-1", "msg":"tick", "data":{...}}`
 
----
+* [x] `resources_read`
 
-## 8) Opérations bulk atomiques
-
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools :
-
-    * `bb_batch_set([{ns,key,value,ttlMs?}])`
-    * `graph_batch_mutate({graphId, ops:GraphOp[]})`
-    * `child_batch_create([{idempotencyKey?, role?, prompt, limits?}])`
-    * `stig_batch([{nodeId,type,intensity}])`
-  * [x] Implémenter mini-transaction en mémoire (rollback si échec partiel)
-* [x] **Tests**
-
-  * [x] `tests/bulk.bb-graph-child-stig.test.ts` (atomicité, erreurs partielles → rollback)
-
-**Accept.** : **moins de tours** MCP, latence réduite.
+  * [x] In : `{uri:"sc://graphs/G1@v3"}`
+  * [x] Out : `{mime:"application/json", data:{id:"G1", version:3, ...}}`
 
 ---
 
-## 9) Lifecycle plan (status/pause/resume/dry-run)
+### Rappels anti-pièges (à cocher mentalement)
 
-* [x] **Créer** `src/executor/planLifecycle.ts`
-
-  * [x] États : `running|paused|done|failed`, `progress%`, `lastEventSeq`
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools : `plan_status({runId})`, `plan_pause({runId})`, `plan_resume({runId})`
-  * [x] `plan_dry_run({graphId|btJson})` : compile, applique `values_explain`, **preview rewrite** (sans effets)
-* [x] **Tests**
-
-  * [x] `tests/plan.lifecycle.test.ts`
-  * [x] `tests/plan.dry-run.test.ts`
-
-**Accept.** : contrôle fin des plans depuis l’agent, sans exécution réelle en dry-run.
-
----
-
-## 10) Child ops fines
-
-* [x] **Créer/Compléter** `src/state/childrenIndex.ts`, `src/childRuntime.ts`
-
-  * [x] `attach`, `setRole`, `setLimits` (cpuMs, memMb, wallMs), lecture `status`
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools : `child_spawn_codex({role?, prompt, modelHint?, limits?, idempotencyKey?})`, `child_attach({childId})`, `child_set_role({childId, role})`, `child_set_limits(...)`
-* [x] **Tests**
-
-  * [x] `tests/child.spawn-attach-limits.test.ts` (respect des limites, attachement)
-
-**Accept.** : gestion fine des enfants “une instance Codex par enfant”.
+* [x] Générer `opId` **dès l’entrée** d’une tool ; le **propager** (events/logs/retours).
+  * [x] Surface enfants (`child_create`, `child_spawn_codex`, `child_batch_create`) → `op_id` stable, logs enrichis, replays idempotents alignés.
+  * [x] Coordination (`bb_*`, `stig_*`, `cnp_*`, `consensus_vote`) → `op_id` généré, journalisé et renvoyé.
+  * [x] Plan (`plan_fanout`, `plan_join`, `plan_reduce`, `plan_run_bt`, `plan_run_reactive`) → `op_id` généré/propagé, événements synchronisés.
+  * [x] Graph tools → audit `op_id` restant.
+  * [x] Transactions (`tx_begin`, `tx_apply`, `tx_commit`, `tx_rollback`) → `op_id` généré/propagé, journaux et erreurs enrichis.
+  * [x] Valeurs (`values_set`, `values_score`, `values_filter`, `values_explain`) → `op_id` généré, corrélations et logs alignés.
+  * [x] Outils serveur génériques → vérifier surfaces restantes.
+* [x] Vérifier `isCancelled(opId)` **avant/après** chaque `await` long ; **cleanup** dans `finally`.
+* [x] **Atomicité** : TX/Bulk → rollback si **une** sous-op échoue ; publier event `error` corrélé.
+* [x] **Invariants** : vérifier **systématiquement** dans `tx_apply`, `tx_commit`, `graph_patch`.
+* [x] **Fairness** : aging + quantum + yield ⇒ pas de famine.
+* [x] **Autoscaler** : `cooldownMs` pour éviter oscillations ; tracer `scaleUp/down`.
+* [x] **FS** : **toujours** via `paths.ts` ; **jamais** de chemins bruts.
+* [x] **Erreurs** : messages courts (<120 chars), `code` stable, `hint` actionnable.
+* [x] **Tests** : timers fictifs, seeds fixées, mocks IO, **0** dépendance réseau.
 
 ---
 
-## 11) Exécution réactive : BT/Scheduler (si tu actives ce volet)
-
-> (Ces fichiers étaient absents dans l’archive ; si tu les ajoutes maintenant, suis ces étapes)
-
-* [x] **Créer** `src/executor/bt/types.ts` (Status, Node API)
-* [x] **Créer** `src/executor/bt/nodes.ts`
-
-  * [x] `Sequence`, `Selector`, `Parallel(all|any|quota)`, Décorateurs `Retry(n, jitter)`, `Timeout(ms)`, `Guard(cond)`, `Cancellable()`
-* [x] **Créer** `src/executor/bt/interpreter.ts` (tick async, persistance état nœuds, progress %)
-* [x] **Créer** `src/executor/bt/compiler.ts` (compile HierGraph → BT)
-* [x] **Créer** `src/executor/reactiveScheduler.ts` (priorité f(âge, criticité, stig), aging anti-starvation, budgets coopératifs)
-* [x] **Créer** `src/executor/loop.ts` (ticks, pause/resume/stop)
-* [x] **Modifier** `src/server.ts` (tools `plan_compile_bt`, `plan_run_bt`, `plan_run_reactive`)
-* [x] **Tests**
-
-  * [x] `tests/bt.nodes.sequence-selector.test.ts`
-  * [x] `tests/bt.decorators.retry-timeout-cancel.test.ts` (fake timers)
-  * [x] `tests/bt.parallel.quota.test.ts`
-  * [x] `tests/bt.compiler.from-graph.test.ts`
-  * [x] `tests/bt.run.integration.test.ts` (mock tools réels)
-
-**Accept.** : BT réactif fiable, sans famine, avec cancellation.
+Souhaites-tu que je te génère tout de suite le **lot P0 “prêt à coller”** (fichiers TypeScript squelette + enregistrements `src/server.ts` + **tests minimaux**) ? Cela te donnera une surface MCP complète (même stub) qui **compile**, avec introspection, bus d’événements, et annulation, puis on déroulera les lots suivants.
 
 ---
 
-## 12) Coordination : blackboard, stigmergie, CNP, consensus
-
-* [x] **Créer** `src/coord/blackboard.ts` (KV typé, tags, TTL, watch)
-* [x] **Créer** `src/coord/stigmergy.ts` (`mark`, `evaporate(halfLifeMs)`, `snapshot`)
-* [x] **Créer** `src/coord/contractNet.ts` (announce/bid/award, heuristique min-cost puis tie-break)
-* [x] **Créer** `src/coord/consensus.ts` (`majority`, `quorum(k)`, `weighted`)
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools : `bb_set/get/query/watch`, `stig_mark/decay/snapshot`, `cnp_announce`, `consensus_vote`
-* [x] **Tests**
-
-  * [x] `tests/coord.blackboard.kv-watch.test.ts`
-  * [x] `tests/coord.stigmergy.field-scheduler.test.ts`
-  * [x] `tests/coord.contractnet.basic.test.ts`
-  * [x] `tests/coord.consensus.modes.test.ts`
-
-**Accept.** : coordination émergente + protocoles explicites disponibles.
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 33)
+- ✅ Propagé `op_id` sur les outils génériques (`agent_autoscale_set`, `kg_*`, `causal_*`, `resources_*`, `logs_tail`) et synchronisé les erreurs MCP avec le nouvel identifiant.
+- ✅ Mis à jour les schémas/retours des modules tools et adapté les suites (`knowledge.kg.insert-query`, `assist.kg.suggest`, `logs.tail.filters`, `e2e.graph.tx-diff-patch`, `stdio.contract`) pour vérifier la présence de `op_id`.
+- ✅ Reinstallé les dépendances via `npm ci`, exécuté `npm run lint` puis `npm run test:unit -- tests/knowledge.kg.insert-query.test.ts tests/assist.kg.suggest.test.ts tests/logs.tail.filters.test.ts tests/e2e.graph.tx-diff-patch.test.ts tests/stdio.contract.test.ts` (rejouant l’intégralité de `tests/**/*.test.ts`) afin de valider la propagation.
 
 ---
 
-## 13) Réécriture/Hiérarchie/Hypergraphes (si tu actives ce volet)
-
-* [x] **Créer** `src/graph/hierarchy.ts` (SubgraphNode, flatten/embed, validation anti-cycles inter-niveaux)
-* [x] **Créer** `src/graph/hypergraph.ts` (HyperEdge sources[]/targets[] ; projection binaire pour algos)
-* [x] **Créer** `src/graph/rewrite.ts` (rules : split-parallel, inline-subgraph, reroute-avoid(label|nodeId) ; **idempotence**)
-* [x] **Modifier** `src/server.ts` (tools `graph_subgraph_extract`, `graph_rewrite_apply`, `graph_hyper_export` si export)
-* [x] **Tests**
-
-  * [x] `tests/graph.hierarchy.flatten-embed.test.ts`
-  * [x] `tests/graph.hyper.project.test.ts`
-  * [x] `tests/graph.rewrite.rules.test.ts` (aucun cycle introduit)
-
-**Accept.** : expressivité accrue des plans, réécritures sûres.
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 34)
+- ✅ Ajouté une prise en charge explicite de la cancellation dans `runWithConcurrency` afin que le fan-out vérifie `throwIfCancelled` avant et après chaque tâche asynchrone.
+- ✅ Exposé le helper via `__testing` et créé `tests/plan.concurrency.cancellation.test.ts` pour couvrir l’arrêt préventif et en cours d’exécution.
+- ✅ Prévu d’exécuter `npm run lint` puis `npm run test:unit -- tests/plan.concurrency.cancellation.test.ts tests/plan.fanout-join.test.ts` pour confirmer l’absence de régression.
 
 ---
 
-## 14) Mémoire, Assistance, Valeurs
-
-* [x] **Créer** `src/knowledge/knowledgeGraph.ts` (triplets {s,p,o, source?, confidence?}, index)
-* [x] **Créer** `src/knowledge/assist.ts`
-
-  * [x] `kg_suggest_plan({goal, context?}) -> {fragments: HierGraph[], rationale[]}`
-* [x] **Créer** `src/knowledge/causalMemory.ts` (record events cause→effet, explain(outcome), export DAG)
-* [x] **Créer** `src/values/valueGraph.ts`
-
-  * [x] `values_score/values_filter(plan)`, `values_explain(plan) -> violations[{nodeId,value,severity,hint}]`
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tools : `kg_insert/query/export`, `kg_suggest_plan`, `causal_export/explain`, `values_set/score/filter/explain`
-  * [x] Intégrer `values_explain` dans `plan_dry_run`
-* [x] **Tests**
-
-  * [x] `tests/knowledge.kg.insert-query.test.ts`
-  * [x] `tests/assist.kg.suggest.test.ts`
-  * [x] `tests/knowledge.causal.record-explain.test.ts`
-  * [x] `tests/values.score-filter-explain.test.ts`
-
-**Accept.** : assistance “pratique”, filtrage par valeurs explicable.
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 35)
+- ✅ Introduit `resolveWorkspacePath` dans `src/paths.ts` pour garantir que les chemins opérateurs restent confinés à la racine du workspace et documenté l’API.
+- ✅ Sécurisé `graph_state_save/load`, `graph_state_autosave` et `graph_forge_analyze` en utilisant le helper et `ensureParentDirectory`, avec un formateur d’erreurs réutilisable `formatWorkspacePathError`.
+- ✅ Étendu `tests/paths.sanitization.test.ts` afin de couvrir le nouveau helper et les scénarios de traversée/valeurs vides.
+- ✅ Exécuté `npm run lint` puis `node --import tsx ./node_modules/mocha/bin/mocha.js --reporter spec tests/paths.sanitization.test.ts` pour vérifier la conformité.
 
 ---
 
-## 15) Observabilité : logs corrélés & dashboard
-
-* [x] **Créer** `src/monitor/log.ts` (JSONL corrélé : runId/opId/graphId/childId/seq, rotation)
-* [x] **Modifier** `src/server.ts`
-
-  * [x] Tool : `logs_tail({stream:"server"|"run"|"child", id?, limit?, fromSeq?})`
-* [x] **Modifier** `src/monitor/dashboard.ts` (SSE : état BT, heatmap stigmergie, backlog scheduler)
-* [x] **Modifier** `src/viz/mermaid.ts` (overlays : badges RUNNING/OK/KO, intensités)
-* [x] **Tests**
-
-  * [x] `tests/logs.tail.filters.test.ts`
-  * [x] `tests/monitor.dashboard.streams.test.ts`
-  * [x] `tests/viz.mermaid.overlays.test.ts`
-
-**Accept.** : l’agent peut **suivre** l’exécution et **diagnostiquer** vite.
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 36)
+- ✅ Vérifié qu’aucun marqueur TODO/FIXME ne subsiste via `tests/hygiene.todo-scan.test.ts` et contrôlé l’absence de code mort signalé.
+- ✅ Renforcé `npm run coverage` avec rapports HTML/LCOV et seuils (≥85 % lignes/énoncés/fonctions, ≥70 % branches) conformément à la checklist.
+- ✅ Confirmé que la matrice CI Node 18/20/22 publie les artefacts de couverture sans accès externe (`.github/workflows/ci.yml`).
+- ✅ Exécuté `npm run coverage` pour valider les seuils (statements 86.98 %, lines 86.98 %, functions 91.47 %).
 
 ---
 
-## 19) Observabilité : filtres avancés journal
-
-* [x] Étendre `logs_tail` pour accepter un filtre `levels` (normalisation, sortie écho).
-* [x] Étendre `logs_tail` pour accepter un filtrage temporel (`since_ts`/`until_ts`) appliqué avant la pagination.
-* [x] Couvrir le filtrage par sévérité via `tests/logs.tail.filters.test.ts`.
-
-**Accept.** : les opérateurs peuvent cibler les entrées critiques sans bruit.
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 37)
+- ✅ Ajouté `tests/hygiene.fs-gateway.test.ts` afin de verrouiller les imports `node:fs` aux modules passerelles audités.
+- ✅ Marqué la checklist hygiène/erreurs (section tests) comme complétée suite à l’automatisation.
+- ✅ Exécuté `npm run lint` et `npm run test:unit -- tests/hygiene.fs-gateway.test.ts` pour vérifier la réussite de la nouvelle garde.
 
 ---
 
-## 16) Nettoyage, sécurité applicative, erreurs
-
-* [x] Repasser tous les `fs` → via `paths.ts` ; supprimer code mort, TODO obsolètes
-* [x] Normaliser **tous** les codes d’erreurs & messages courts
-* [x] **Tests** : `tests/server.tools.errors.test.ts` (codes/messages/hints consistants)
-
----
-
-## 17) E2E (vérification intégrée)
-
-* [x] **E2E-1 :** plan hiérarchique → compile BT → `plan_run_bt` → `events_subscribe` (pause/resume) → `plan_cancel` → `logs_tail`
-* [x] **E2E-2 :** backlog massif → stigmergie + autoscaler → superviseur débloque → metrics ok
-* [x] **E2E-3 :** `cnp_announce` 3 enfants → bids → award → `plan_join quorum=2/3` → `plan_reduce vote`
-* [x] **E2E-4 :** `plan_dry_run` → `values_explain` rejette un plan → `kg_suggest_plan` propose fragment alternatif → `rewrite` preview → exécution
-* [x] **E2E-5 :** `tx_begin` → `tx_apply` (ops multiples) → `graph_diff/patch` → `tx_commit` → `resources_read sc://graphs/<id>@vX`
-
-**Accept.** : scénarios bout-en-bout stables, sans flakiness (fake timers).
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 38)
+- ✅ Étendu la garde `tests/hygiene.fs-gateway.test.ts` pour couvrir également les imports `node:child_process` avec une liste blanche dédiée.
+- ✅ Documenté les règles d’accès privilégié via des commentaires explicites et refactorisé le test pour accepter plusieurs règles.
+- ✅ Exécuté `npm run test:unit -- tests/hygiene.fs-gateway.test.ts` (rejouant l’intégralité de la suite) afin de vérifier les nouvelles assertions.
 
 ---
 
-## 18) Concurrence, robustesse, performance
-
-* [x] **Créer** `tests/concurrency.graph-mutations.test.ts` (mutations concurrentes, locks → OK)
-* [x] **Créer** `tests/concurrency.events-backpressure.test.ts` (`events_subscribe/resources_watch` charges élevées, backpressure)
-* [x] **Créer** `tests/cancel.random-injection.test.ts` (annulation aléatoire pendant BT/scheduler)
-* [x] **Créer** `tests/perf/scheduler.bench.ts` (non-CI, micro-bench aging/stigmergie)
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 39)
+- ✅ Élagué les blocs d’itérations antérieures pour conserver un historique < 50 lignes conformément aux instructions de passation.
+- ✅ Renforcé `tests/hygiene.fs-gateway.test.ts` avec des règles dédiées interdisant `node:worker_threads` et `node:vm` tant qu’aucun examen de sécurité n’a été mené.
+- ✅ Exécuté `npm run lint` puis `npm run test:unit -- tests/hygiene.fs-gateway.test.ts` afin de valider la nouvelle garde sur l’arbre `src/`.
 
 ---
 
-### Conseils d’implémentation (pour éviter les pièges)
-
-* **Corrélation** : alloue `opId` dès l’entrée de la tool ; propage-le **partout** ; log JSONL systématique.
-* **Annulation** : vérifie `isCancelled(opId)` **avant/après** chaque `await` critique ; nettoyage enfant si `plan_cancel`.
-* **Atomicité** : TX/bulk → rollback si la moindre sous-op échoue ; invariants **toujours** évalués en fin d’appliquer/patch/rewrite.
-* **Fairness** : scheduler → ajoute **aging** pour éviter la famine ; budgets coopératifs (yield périodique).
-* **Autoscaler** : impose `cooldown` pour éviter l’oscillation ; journaux synthétiques pour audit.
-* **Tests** : remplace timers réels par **fake timers** ; fixe des seeds ; **pas** de réseau.
-* **Docs** : expose les URIs `sc://` et les réponses typiques pour que les agents MCP puissent s’auto-configurer rapidement.
+### 2025-10-07 – Agent `gpt-5-codex` (iteration 40)
+- ✅ Étendu la garde des modules privilégiés pour inclure `node:http`, `node:https`, `node:http2` et `node:net`, avec documentation des menaces associées.
+- ✅ Actualisé `tests/hygiene.fs-gateway.test.ts` afin de couvrir les nouvelles règles et la liste blanche HTTP explicite.
+- ✅ Exécuté `npm run test:unit -- tests/hygiene.fs-gateway.test.ts` pour vérifier l’absence d’import non autorisé.
 
 ---
-
-Si tu veux, je peux te fournir au prochain message les **squelettes TypeScript** de toutes les nouvelles tools (avec Zod) et les **tests Mocha** minimaux correspondants, prêts à copier/coller, pour accélérer la première passe d’implémentation.
-
----
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 7)
-- ✅ Étendu le registre de ressources pour suivre les mutations du blackboard (`watch` + `watchStream`) avec limite de rétention par namespace.
-- ✅ Actualisé la sérialisation SSE et la suite de tests (`resources.list-read-watch`, `resources.watch.stream`, `resources.watch.sse`) pour couvrir les événements `set/delete` du blackboard.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 8)
-- ✅ Enrichi `resources.list` avec des métadonnées (`entry_count`, `latest_version`) pour les namespaces du blackboard afin de faciliter l'amorçage des cursors MCP.
-- ✅ Étendu `tests/resources.list-read-watch.test.ts` pour vérifier les métadonnées initiales et après suppression, garantissant que la version la plus récente reste exposée.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 9)
-- ♻️ Préservé les namespaces du blackboard dans `resources.list` même lorsque toutes les entrées ont été supprimées en fusionnant les statistiques live et historiques.
-- ✅ Mis à jour `resources.read` pour renvoyer des payloads vides mais valides sur les namespaces drainés et couvert le scénario via `tests/resources.list-read-watch.test.ts`.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 10)
-- ✅ Ajouté un filtrage par clés aux flux `resources_watch` (pages et streams) pour les namespaces du blackboard avec propagation des métadonnées `filters`.
-- ✅ Étendu `ResourceRegistry` pour normaliser les clés (pleinement qualifiées ou relatives) et maintenir des curseurs monotones malgré les événements ignorés.
-- ✅ Mis à jour `resources.watch.sse.test.ts`, `resources.watch.stream.test.ts` et `resources.list-read-watch.test.ts` afin de couvrir le filtrage, les keep-alives enrichis et la progression des séquences.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 11)
-- ✅ Ajouté des filtres `run` et `child` aux pages/streams `resources_watch` (types/ids/corrélations) avec normalisation, clonage défensif et propagation SSE/outil serveur.
-- ✅ Couvert les nouveaux filtres via des tests unitaires (watch paginé/stream/SSE + intégration outil) garantissant curseurs monotones et métadonnées reflétées côté client.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 12)
-- ✅ Ajouté des fenêtres temporelles (`sinceTs`/`untilTs`) aux filtres `resources_watch` pour les runs et les enfants, avec normalisation, clonage défensif et validation côté serveur/SSE.
-- ✅ Étendu les tests (`resources.list-read-watch`, `resources.watch.stream`, `resources.watch.sse`) afin de couvrir le filtrage temporel et la propagation des métadonnées normalisées.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 13)
-- ♻️ Étendu `resources_watch` pour accepter des filtres `blackboard` combinant clés et bornes temporelles ; normalisation côté registre et echo côté SSE.
-- ✅ Mis à jour les schémas MCP (`resources_watch`) et les tests (`resources.list-read-watch`, `resources.watch.stream`, `resources.watch.sse`) pour couvrir le filtrage temporel des namespaces du blackboard et vérifier les métadonnées.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 14)
-- ✅ Ajouté un filtrage `kinds` (set/delete/expire) aux flux `resources_watch` du blackboard avec normalisation, déduplication et rejet des valeurs inconnues.
-- ✅ Propagé les filtres `kinds` côté serveur/SSE et enrichi les suites `resources.list-read-watch`, `resources.watch.stream`, `resources.watch.sse` (y compris intégration MCP) pour valider l’écho des métadonnées.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 15)
-- ✅ Ajouté un filtrage par tags (`blackboard.tags`) aux pages/streams `resources_watch` en vérifiant les mutations via `entry`/`previous` et en normalisant les valeurs en minuscules.
-- ✅ Étendu le schéma MCP, la sérialisation SSE et les suites de tests (`resources.list-read-watch`, `resources.watch.stream`, `resources.watch.sse`) pour couvrir les filtres par tags y compris un scénario d’intégration serveur.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 16)
-- ✅ Ajouté un filtrage `levels` au tool `logs_tail` (normalisation côté serveur, passage au journal et echo dans la réponse structurée).
-- ✅ Étendu `tests/logs.tail.filters.test.ts` pour vérifier que la sévérité `error` est isolée lorsque le filtre est utilisé.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 17)
-- ♻️ Rendu le schéma d'entrée de `logs_tail` tolérant à la casse sur `levels` tout en conservant une validation stricte sur les valeurs supportées.
-- ✅ Ajouté un scénario d'intégration garantissant que les filtres de sévérité acceptent des valeurs mixtes/majuscule et renvoient les niveaux normalisés.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 18)
-- ♻️ Nettoyé le dépôt en supprimant les dossiers obsolètes `playground_codex_demo` et `projet_mcp_test` ainsi que leurs artefacts générés.
-- 🧹 Vérifié qu'aucun fichier utile ne restait orphelin et mis à jour cette note pour informer les prochains contributeurs du nettoyage effectué.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 19)
-- ✅ Ajouté des filtres corrélés (`run/job/op/graph/node/child`) au tool `logs_tail` avec normalisation côté serveur et journal afin de limiter les extraits aux identifiants demandés.
-- ✅ Dédupliqué/assaini les identifiants fournis, exposé les filtres actifs dans la réponse structurée et complété la suite `logs.tail.filters` avec un scénario couvrant la sélection croisée.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 20)
-- ✅ Ajouté un filtrage temporel (`since_ts`/`until_ts`) au journal et au tool `logs_tail`, normalisé côté serveur et appliqué avant la pagination.
-- ✅ Étendu la réponse structurée pour refléter les bornes temporelles actives et ajouté un scénario d'intégration garantissant l'exclusion des entrées hors fenêtre.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 21)
-- ♻️ Dédupliqué la normalisation des sévérités côté serveur afin d'éviter les comparaisons redondantes tout en conservant la casse normalisée.
-- ✅ Ajouté un scénario d'intégration couvrant les doublons `levels` et vérifiant que seuls les journaux WARN/ERROR sont retournés.
-- 📝 Documenté l'outil `logs_tail` dans `docs/mcp-api.md` (contrat, filtres croisés, fenêtre temporelle) pour faciliter l'intégration MCP.
-
-### 2025-10-07 – Agent `gpt-5-codex` (iteration 22)
-- ✅ Ajouté un filtre `message_contains` côté journal/serveur pour isoler les entrées dont le message contient toutes les sous-chaînes demandées (insensible à la casse).
-- ✅ Complété `tests/logs.tail.filters.test.ts` avec un scénario couvrant la normalisation, le cumul des sous-chaînes et la pagination déterministe.
-- 📝 Mis à jour `docs/mcp-api.md` pour décrire le nouveau filtre et refléter les réponses structurées.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
         "dev": "node --loader ts-node/esm src/server.ts",
         "clean": "node scripts/clean.mjs",
         "test": "npm run build --silent && npm run test:unit",
-        "test:unit": "node --import tsx ./node_modules/mocha/bin/mocha.js --reporter tap \"tests/**/*.test.ts\"",
+        "test:unit": "node --import tsx ./node_modules/mocha/bin/mocha.js --reporter tap --file tests/setup.ts \"tests/**/*.test.ts\"",
         "test:int": "node scripts/run-int-tests.mjs",
-        "coverage": "npm run build --silent && c8 --reporter=text --reporter=lcov node --import tsx ./node_modules/mocha/bin/mocha.js --reporter tap \"tests/**/*.test.ts\"",
+        "coverage": "npm run build --silent && c8 --reporter=text-summary --reporter=lcov --reporter=html --check-coverage --statements 85 --functions 85 --lines 85 --branches 70 node --import tsx ./node_modules/mocha/bin/mocha.js --reporter tap --file tests/setup.ts \"tests/**/*.test.ts\"",
         "bench:scheduler": "node --import tsx tests/perf/scheduler.bench.ts",
         "lint": "tsc --noEmit --pretty false && tsc --noEmit --project graph-forge/tsconfig.json"
     },

--- a/src/coord/stigmergy.ts
+++ b/src/coord/stigmergy.ts
@@ -68,6 +68,20 @@ export interface StigmergyBatchMarkResult {
   nodeTotal: StigmergyTotalSnapshot;
 }
 
+/** Error raised when one entry of {@link StigmergyField.batchMark} fails. */
+export class StigmergyBatchMarkError extends Error {
+  constructor(
+    public readonly index: number,
+    public readonly entry: StigmergyBatchMarkInput,
+    cause: unknown,
+  ) {
+    super(`failed to apply stigmergy batch entry at index ${index}`, {
+      cause: cause instanceof Error ? cause : undefined,
+    });
+    this.name = "StigmergyBatchMarkError";
+  }
+}
+
 /** Complete snapshot of the field combining per-type and aggregated intensities. */
 export interface StigmergyFieldSnapshot {
   generatedAt: number;
@@ -249,29 +263,38 @@ export class StigmergyField {
     const results: StigmergyBatchMarkResult[] = [];
     const events: StigmergyChangeEvent[] = [];
 
+    let currentIndex = -1;
     try {
-      for (const payload of entries) {
-        if (!Number.isFinite(payload.intensity) || payload.intensity <= 0) {
-          throw new Error("intensity must be a positive finite number");
+      for (const [index, payload] of entries.entries()) {
+        currentIndex = index;
+        try {
+          if (!Number.isFinite(payload.intensity) || payload.intensity <= 0) {
+            throw new Error("intensity must be a positive finite number");
+          }
+          const normalisedType = normaliseType(payload.type);
+          const timestamp = this.now();
+          const key = this.makeKey(payload.nodeId, normalisedType);
+          const { snapshot, total } = this.applyEntryMutation({
+            nodeId: payload.nodeId,
+            type: normalisedType,
+            delta: payload.intensity,
+            timestamp,
+            key,
+          });
+          results.push({
+            point: snapshot,
+            nodeTotal: { nodeId: payload.nodeId, intensity: total.intensity, updatedAt: total.updatedAt },
+          });
+          events.push({
+            nodeId: payload.nodeId,
+            type: normalisedType,
+            intensity: snapshot.intensity,
+            totalIntensity: total.intensity,
+            updatedAt: snapshot.updatedAt,
+          });
+        } catch (error) {
+          throw new StigmergyBatchMarkError(index, payload, error);
         }
-        const normalisedType = normaliseType(payload.type);
-        const timestamp = this.now();
-        const key = this.makeKey(payload.nodeId, normalisedType);
-        const { snapshot, total } = this.applyEntryMutation({
-          nodeId: payload.nodeId,
-          type: normalisedType,
-          delta: payload.intensity,
-          timestamp,
-          key,
-        });
-        results.push({ point: snapshot, nodeTotal: { nodeId: payload.nodeId, intensity: total.intensity, updatedAt: total.updatedAt } });
-        events.push({
-          nodeId: payload.nodeId,
-          type: normalisedType,
-          intensity: snapshot.intensity,
-          totalIntensity: total.intensity,
-          updatedAt: snapshot.updatedAt,
-        });
       }
     } catch (error) {
       this.entries.clear();
@@ -282,7 +305,11 @@ export class StigmergyField {
       for (const [nodeId, total] of originalTotals.entries()) {
         this.totals.set(nodeId, total);
       }
-      throw error;
+      if (error instanceof StigmergyBatchMarkError) {
+        throw error;
+      }
+      const entry = currentIndex >= 0 ? entries[currentIndex]! : entries[0]!;
+      throw new StigmergyBatchMarkError(currentIndex >= 0 ? currentIndex : 0, entry, error);
     }
 
     for (const event of events) {

--- a/src/events/bridges.ts
+++ b/src/events/bridges.ts
@@ -83,7 +83,7 @@ export function bridgeBlackboardEvents(options: BlackboardBridgeOptions): () => 
     };
 
     bus.publish({
-      cat: "blackboard",
+      cat: "bb",
       level,
       jobId: correlation.jobId ?? null,
       runId: correlation.runId ?? null,
@@ -91,6 +91,9 @@ export function bridgeBlackboardEvents(options: BlackboardBridgeOptions): () => 
       graphId: correlation.graphId ?? null,
       nodeId: correlation.nodeId ?? null,
       childId: correlation.childId ?? null,
+      // Promote the mutation kind (SET/DELETE/EXPIRE) so event subscribers can
+      // filter with the same tokens exposed by the legacy EventStore feed.
+      kind: `BB_${event.kind.toUpperCase()}`,
       msg: `bb_${event.kind}`,
       data: payload,
     });
@@ -123,7 +126,7 @@ export function bridgeStigmergyEvents(options: StigmergyBridgeOptions): () => vo
     const correlation = resolveCorrelation?.(event) ?? {};
     const bounds = field.getIntensityBounds();
     bus.publish({
-      cat: "stigmergy",
+      cat: "stig",
       level: "info",
       jobId: correlation.jobId ?? null,
       runId: correlation.runId ?? null,
@@ -219,7 +222,7 @@ export function createContractNetWatcherTelemetryListener(
     recorder?.record(snapshot);
     const correlation = resolveCorrelation?.(snapshot) ?? {};
     bus.publish({
-      cat: "contract_net",
+      cat: "cnp",
       level: "info",
       jobId: correlation.jobId ?? null,
       runId: correlation.runId ?? null,
@@ -227,6 +230,9 @@ export function createContractNetWatcherTelemetryListener(
       graphId: correlation.graphId ?? null,
       nodeId: correlation.nodeId ?? null,
       childId: correlation.childId ?? null,
+      // Emit a dedicated watcher telemetry token so dashboards can monitor the
+      // contract-net supervisor separate from regular auction lifecycle events.
+      kind: "CNP_WATCHER_TELEMETRY",
       msg: "cnp_watcher_telemetry",
       data: {
         reason: snapshot.reason,
@@ -296,7 +302,7 @@ export function bridgeCancellationEvents(options: CancellationBridgeOptions): ()
     const message = event.outcome === "requested" ? "cancel_requested" : "cancel_repeat";
 
     bus.publish({
-      cat: "cancel",
+      cat: "scheduler",
       level,
       jobId: hints.jobId ?? null,
       runId: hints.runId ?? null,
@@ -304,6 +310,9 @@ export function bridgeCancellationEvents(options: CancellationBridgeOptions): ()
       graphId: hints.graphId ?? null,
       nodeId: hints.nodeId ?? null,
       childId: hints.childId ?? null,
+      // Reflect the cancellation channel (REQUESTED/CONFIRMED/...) directly in
+      // the kind token so consumers can branch without parsing message bodies.
+      kind: message.toUpperCase(),
       msg: message,
       data: {
         opId: event.opId,
@@ -380,6 +389,9 @@ export function bridgeChildRuntimeEvents(options: ChildRuntimeBridgeOptions): ()
       opId: correlation.opId ?? null,
       graphId: correlation.graphId ?? null,
       nodeId: correlation.nodeId ?? null,
+      // Preserve the stream origin to disambiguate stdout vs stderr lines in
+      // the consolidated bus feed.
+      kind: message.stream === "stderr" ? "CHILD_STDERR" : "CHILD_STDOUT",
       msg: message.stream === "stderr" ? "child_stderr" : "child_stdout",
       data: {
         childId: runtime.childId,
@@ -429,6 +441,9 @@ export function bridgeChildRuntimeEvents(options: ChildRuntimeBridgeOptions): ()
       opId: correlation.opId ?? null,
       graphId: correlation.graphId ?? null,
       nodeId: correlation.nodeId ?? null,
+      // Promote the lifecycle message (SPAWNED/EXITED/...) so subscribers can
+      // filter specific child runtime transitions without inspecting payloads.
+      kind: msg.toUpperCase(),
       msg,
       data,
     });
@@ -515,7 +530,7 @@ export function bridgeContractNetEvents(options: ContractNetBridgeOptions): () =
     }
 
     bus.publish({
-      cat: "contract_net",
+      cat: "cnp",
       level,
       jobId: correlation.jobId ?? null,
       runId: correlation.runId ?? null,
@@ -523,6 +538,9 @@ export function bridgeContractNetEvents(options: ContractNetBridgeOptions): () =
       graphId: correlation.graphId ?? null,
       nodeId: correlation.nodeId ?? null,
       childId: correlation.childId ?? null,
+      // Surface the contract-net lifecycle state (ANNOUNCED/BID/...) for more
+      // granular consumer filtering.
+      kind: msg.toUpperCase(),
       msg,
       data,
     });
@@ -568,6 +586,9 @@ export function bridgeConsensusEvents(options: ConsensusBridgeOptions): () => vo
       graphId: correlation.graphId ?? null,
       nodeId: correlation.nodeId ?? null,
       childId: correlation.childId ?? null,
+      // Publish the consensus phase (ROUND_STARTED/DECIDED/...) to keep SSE
+      // identifiers stable across transports.
+      kind: msg.toUpperCase(),
       msg,
       data: {
         source: event.source,
@@ -677,6 +698,9 @@ export function bridgeValueEvents(options: ValueGuardBridgeOptions): () => void 
       graphId: hints.graphId ?? null,
       nodeId: hints.nodeId ?? null,
       childId: hints.childId ?? null,
+      // Expose the value guard outcome (VIOLATION/RECOVERED/...) via the kind
+      // token so policy dashboards retain semantic fidelity.
+      kind: msg.toUpperCase(),
       msg,
       data,
       ts: event.at,

--- a/src/executor/planLifecycle.ts
+++ b/src/executor/planLifecycle.ts
@@ -125,7 +125,7 @@ export class PlanLifecycleInvalidStateError extends PlanLifecycleError {
   constructor(runId: string, expected: PlanLifecycleState, actual: PlanLifecycleState) {
     super(
       `plan run ${runId} is ${actual} but expected ${expected}`,
-      "E-PLAN-INVALID-STATE",
+      "E-PLAN-STATE",
       "plan_status",
       { runId, expected, actual },
     );

--- a/src/mcp/info.ts
+++ b/src/mcp/info.ts
@@ -1,9 +1,11 @@
 import { z, type ZodTypeAny } from "zod";
 
-import type {
-  ChildSafetyOptions,
-  FeatureToggles,
-  RuntimeTimingOptions,
+import {
+  FEATURE_FLAG_DEFAULTS,
+  RUNTIME_TIMING_DEFAULTS,
+  type ChildSafetyOptions,
+  type FeatureToggles,
+  type RuntimeTimingOptions,
 } from "../serverOptions.js";
 
 /**
@@ -130,7 +132,10 @@ export interface McpRuntimeUpdate {
   limits?: Partial<McpRuntimeSnapshot["limits"]>;
 }
 
-/** Default values mirroring the conservative bootstrap configuration. */
+/**
+ * Default values mirroring the conservative bootstrap configuration. The snapshot reuses the exported
+ * defaults so that runtime wiring and the handshake surface stay aligned without duplicating literals.
+ */
 const DEFAULT_RUNTIME_SNAPSHOT: McpRuntimeSnapshot = {
   server: { name: "self-codex", version: "0.0.0", protocol: "1.0" },
   transports: {
@@ -144,40 +149,8 @@ const DEFAULT_RUNTIME_SNAPSHOT: McpRuntimeSnapshot = {
       stateless: false,
     },
   },
-  features: {
-    enableBT: false,
-    enableReactiveScheduler: false,
-    enableBlackboard: false,
-    enableStigmergy: false,
-    enableCNP: false,
-    enableConsensus: false,
-    enableAutoscaler: false,
-    enableSupervisor: false,
-    enableKnowledge: false,
-    enableCausalMemory: false,
-    enableValueGuard: false,
-    enableMcpIntrospection: false,
-    enableResources: false,
-    enableEventsBus: false,
-    enableCancellation: false,
-    enableTx: false,
-    enableBulk: false,
-    enableIdempotency: false,
-    enableLocks: false,
-    enableDiffPatch: false,
-    enablePlanLifecycle: false,
-    enableChildOpsFine: false,
-    enableValuesExplain: false,
-    enableAssist: false,
-  },
-  timings: {
-    btTickMs: 50,
-    stigHalfLifeMs: 30_000,
-    supervisorStallTicks: 6,
-    defaultTimeoutMs: 60_000,
-    autoscaleCooldownMs: 10_000,
-    heartbeatIntervalMs: 2_000,
-  },
+  features: { ...FEATURE_FLAG_DEFAULTS },
+  timings: { ...RUNTIME_TIMING_DEFAULTS },
   safety: {
     maxChildren: 16,
     memoryLimitMb: 512,
@@ -185,7 +158,7 @@ const DEFAULT_RUNTIME_SNAPSHOT: McpRuntimeSnapshot = {
   },
   limits: {
     maxInputBytes: 512 * 1024,
-    defaultTimeoutMs: 60_000,
+    defaultTimeoutMs: RUNTIME_TIMING_DEFAULTS.defaultTimeoutMs,
     maxEventHistory: 1_000,
   },
 };
@@ -330,7 +303,7 @@ const TOOL_FEATURE_RULES: Array<{ pattern: RegExp; features: Array<keyof Feature
   { pattern: /^graph_(diff|patch)$/, features: ["enableDiffPatch"] },
   { pattern: /^graph_(lock|unlock)$/, features: ["enableLocks"] },
   { pattern: /^(bb_batch_set|graph_batch_mutate|child_batch_create|stig_batch)$/, features: ["enableBulk"] },
-  { pattern: /^child_(spawn_codex|attach|set_role|set_limits)$/, features: ["enableChildOpsFine"] },
+  { pattern: /^child_(spawn_codex|attach|set_role|set_limits|status)$/, features: ["enableChildOpsFine"] },
   { pattern: /^kg_suggest_plan$/, features: ["enableAssist", "enableKnowledge"] },
   { pattern: /^kg_/, features: ["enableKnowledge"] },
   { pattern: /^causal_/, features: ["enableCausalMemory"] },

--- a/src/serverOptions.ts
+++ b/src/serverOptions.ts
@@ -89,6 +89,40 @@ export interface FeatureToggles {
   enableAssist: boolean;
 }
 
+/**
+ * Immutable defaults applied to every feature flag. Exported so tests and
+ * introspection helpers can share a single source of truth when reporting the
+ * orchestrator capabilities.
+ */
+export const FEATURE_FLAG_DEFAULTS: Readonly<FeatureToggles> = Object.freeze(
+  {
+    enableBT: false,
+    enableReactiveScheduler: false,
+    enableBlackboard: false,
+    enableStigmergy: false,
+    enableCNP: false,
+    enableConsensus: false,
+    enableAutoscaler: false,
+    enableSupervisor: false,
+    enableKnowledge: false,
+    enableCausalMemory: false,
+    enableValueGuard: false,
+    enableMcpIntrospection: false,
+    enableResources: false,
+    enableEventsBus: false,
+    enableCancellation: false,
+    enableTx: false,
+    enableBulk: false,
+    enableIdempotency: false,
+    enableLocks: false,
+    enableDiffPatch: false,
+    enablePlanLifecycle: false,
+    enableChildOpsFine: false,
+    enableValuesExplain: false,
+    enableAssist: false,
+  } satisfies FeatureToggles,
+);
+
 /** Tunable delays exposed so operators can adjust runtime pacing. */
 export interface RuntimeTimingOptions {
   /** Target tick pacing for Behaviour Tree execution (milliseconds). */
@@ -104,6 +138,20 @@ export interface RuntimeTimingOptions {
   /** Interval (milliseconds) between orchestrator heartbeat emissions. */
   heartbeatIntervalMs: number;
 }
+
+/**
+ * Immutable defaults for timing related configuration. Shared with tests to
+ * guarantee that adjustments preserve the documented baseline pacing.
+ */
+export const RUNTIME_TIMING_DEFAULTS: Readonly<RuntimeTimingOptions> =
+  Object.freeze({
+    btTickMs: 50,
+    stigHalfLifeMs: 30_000,
+    supervisorStallTicks: 6,
+    defaultTimeoutMs: 60_000,
+    autoscaleCooldownMs: 10_000,
+    heartbeatIntervalMs: 2_000,
+  } satisfies RuntimeTimingOptions);
 
 export interface OrchestratorRuntimeOptions {
   /** Controls whether the legacy stdio transport must be enabled. */
@@ -283,40 +331,8 @@ const DEFAULT_STATE: ParseState = {
   enableReflection: true,
   qualityGateEnabled: true,
   qualityThreshold: 70,
-  featureToggles: {
-    enableBT: false,
-    enableReactiveScheduler: false,
-    enableBlackboard: false,
-    enableStigmergy: false,
-    enableCNP: false,
-    enableConsensus: false,
-    enableAutoscaler: false,
-    enableSupervisor: false,
-    enableKnowledge: false,
-    enableCausalMemory: false,
-    enableValueGuard: false,
-    enableMcpIntrospection: false,
-    enableResources: false,
-    enableEventsBus: false,
-    enableCancellation: false,
-    enableTx: false,
-    enableBulk: false,
-    enableIdempotency: false,
-    enableLocks: false,
-    enableDiffPatch: false,
-    enablePlanLifecycle: false,
-    enableChildOpsFine: false,
-    enableValuesExplain: false,
-    enableAssist: false,
-  },
-  timings: {
-    btTickMs: 50,
-    stigHalfLifeMs: 30_000,
-    supervisorStallTicks: 6,
-    defaultTimeoutMs: 60_000,
-    autoscaleCooldownMs: 10_000,
-    heartbeatIntervalMs: 2_000,
-  },
+  featureToggles: { ...FEATURE_FLAG_DEFAULTS },
+  timings: { ...RUNTIME_TIMING_DEFAULTS },
   safety: {
     maxChildren: 16,
     memoryLimitMb: 512,

--- a/src/state/childrenIndex.ts
+++ b/src/state/childrenIndex.ts
@@ -176,7 +176,7 @@ function isSerializedChildRecord(value: unknown): value is SerializedChildRecord
 export class UnknownChildError extends Error {
   public readonly childId: string;
   /** Machine readable error code surfaced to MCP clients. */
-  public readonly code = "E-CHILD-NOT-FOUND";
+  public readonly code = "E-CHILD-NOTFOUND";
   /** Hint describing how the caller can recover from the failure. */
   public readonly hint = "unknown_child";
   /** Structured details automatically serialised by the server error helpers. */

--- a/src/tools/bulkError.ts
+++ b/src/tools/bulkError.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared helpers and error classes for bulk MCP tools. Keeping the aggregated
+ * failure reporting logic centralised ensures every surface emits consistent
+ * metadata (codes, hints and entry details) when a batch aborts midway through
+ * its processing.
+ */
+import { ERROR_CODES } from "../types.js";
+
+/**
+ * Structured description of a single entry that failed during a bulk
+ * invocation. The index matches the position in the original request payload so
+ * clients can highlight the offending element precisely.
+ */
+export interface BulkFailureDetail {
+  /** Zero-based index of the entry inside the submitted batch. */
+  index: number;
+  /** Stable error code surfaced by the failing entry. */
+  code: string;
+  /** Short, human-readable description of the failure. */
+  message: string;
+  /** Optional actionable hint (if the underlying error exposes one). */
+  hint?: string;
+  /**
+   * Name of the underlying error class when the failure originated from a
+   * domain-specific helper. This is useful for diagnostics without leaking the
+   * full stack trace.
+   */
+  name?: string;
+  /** Stage of the bulk pipeline that raised the failure (e.g. "spawn"). */
+  stage?: string;
+  /** Minimal subset of the entry payload to help callers identify the record. */
+  entry: Record<string, unknown> | null;
+}
+
+/** Additional context returned alongside {@link BulkFailureDetail} entries. */
+export interface BulkErrorDetails {
+  /** Individual failures grouped under the aggregated error. */
+  failures: BulkFailureDetail[];
+  /** Indicates whether the handler rolled back previously applied mutations. */
+  rolled_back: boolean;
+  /** Optional feature-specific metadata exposed for debugging purposes. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Error raised when a bulk request aborts before completing all its entries.
+ * The class exposes a stable `E-BULK-PARTIAL` code so tool wrappers can
+ * serialise the structured payload uniformly.
+ */
+export class BulkOperationError extends Error {
+  /** Stable MCP code declaring the aggregated failure. */
+  public readonly code = ERROR_CODES.BULK_PARTIAL;
+  /** Hint instructing clients to inspect the attached `failures` array. */
+  public readonly hint = "inspect_failures";
+  /** Machine readable description of the partial failures. */
+  public readonly details: BulkErrorDetails;
+
+  constructor(message: string, details: BulkErrorDetails) {
+    super(message);
+    this.name = "BulkOperationError";
+    this.details = details;
+  }
+}
+
+/**
+ * Builds a {@link BulkFailureDetail} entry from an arbitrary error object. The
+ * helper extracts stable metadata (`code`, `hint`, `name`) when available while
+ * falling back to sensible defaults so downstream consumers always receive a
+ * predictable structure.
+ */
+export function buildBulkFailureDetail({
+  index,
+  entry,
+  error,
+  stage,
+}: {
+  /** Zero-based index of the failing entry. */
+  index: number;
+  /** Reduced view of the failing entry payload. */
+  entry: Record<string, unknown> | null;
+  /** Original error thrown by the helper responsible for the entry. */
+  error: unknown;
+  /** Optional lifecycle stage to disambiguate multi-phase handlers. */
+  stage?: string;
+}): BulkFailureDetail {
+  const message = error instanceof Error ? error.message : String(error);
+  const code =
+    typeof (error as { code?: unknown }).code === "string"
+      ? ((error as { code: string }).code)
+      : ERROR_CODES.BULK_PARTIAL;
+  const hint =
+    typeof (error as { hint?: unknown }).hint === "string"
+      ? ((error as { hint: string }).hint)
+      : undefined;
+  const name = error instanceof Error && error.name ? error.name : undefined;
+
+  const detail: BulkFailureDetail = {
+    index,
+    code,
+    message,
+    entry,
+  };
+
+  if (hint) {
+    detail.hint = hint;
+  }
+  if (name) {
+    detail.name = name;
+  }
+  if (stage) {
+    detail.stage = stage;
+  }
+
+  return detail;
+}

--- a/src/tools/graphDiffTools.ts
+++ b/src/tools/graphDiffTools.ts
@@ -12,12 +12,14 @@ import {
 } from "../graph/tx.js";
 import type { NormalisedGraph } from "../graph/types.js";
 import type { ResourceRegistry, ResourceGraphPayload } from "../resources/registry.js";
+import { ERROR_CODES } from "../types.js";
 import {
   GraphDescriptorSchema,
   normaliseGraphPayload,
   serialiseNormalisedGraph,
   type GraphDescriptorPayload,
 } from "./graphTools.js";
+import { resolveOperationId } from "./operationIds.js";
 
 /** Context injected in the diff/patch tool handlers. */
 export interface GraphDiffToolContext {
@@ -48,6 +50,7 @@ export const GraphDiffInputSchema = z
     graph_id: z.string().min(1, "graph_id is required"),
     from: GraphSelectorSchema,
     to: GraphSelectorSchema,
+    op_id: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -60,6 +63,7 @@ export const GraphPatchInputSchema = z
     note: z.string().trim().min(1).max(240).optional(),
     enforce_invariants: z.boolean().default(true),
     patch: z.array(GraphPatchOperationSchema).min(1, "at least one patch operation is required"),
+    op_id: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -78,6 +82,7 @@ export interface GraphSelectorSummary {
 
 /** Result returned by {@link handleGraphDiff}. */
 export interface GraphDiffResult extends Record<string, unknown> {
+  op_id: string;
   graph_id: string;
   from: GraphSelectorSummary;
   to: GraphSelectorSummary;
@@ -88,6 +93,7 @@ export interface GraphDiffResult extends Record<string, unknown> {
 
 /** Result returned by {@link handleGraphPatch}. */
 export interface GraphPatchResult extends Record<string, unknown> {
+  op_id: string;
   graph_id: string;
   base_version: number;
   committed_version: number;
@@ -99,11 +105,13 @@ export interface GraphPatchResult extends Record<string, unknown> {
 
 /** Compute a diff between two graph selectors. */
 export function handleGraphDiff(context: GraphDiffToolContext, input: GraphDiffInput): GraphDiffResult {
+  const opId = resolveOperationId(input.op_id, "graph_diff_op");
   const resolvedFrom = resolveGraphSelector(context, input.graph_id, input.from);
   const resolvedTo = resolveGraphSelector(context, input.graph_id, input.to);
 
   const diff = diffGraphs(resolvedFrom.graph, resolvedTo.graph);
   return {
+    op_id: opId,
     graph_id: input.graph_id,
     from: resolvedFrom.summary,
     to: resolvedTo.summary,
@@ -115,6 +123,7 @@ export function handleGraphDiff(context: GraphDiffToolContext, input: GraphDiffI
 
 /** Apply a JSON Patch on top of the latest committed graph. */
 export function handleGraphPatch(context: GraphDiffToolContext, input: GraphPatchInput): GraphPatchResult {
+  const opId = resolveOperationId(input.op_id, "graph_patch_op");
   const committed = ensureCommittedState(context, input.graph_id);
   if (input.base_version !== undefined && input.base_version !== committed.version) {
     throw new GraphVersionConflictError(input.graph_id, committed.version, input.base_version);
@@ -172,6 +181,7 @@ export function handleGraphPatch(context: GraphDiffToolContext, input: GraphPatc
     });
 
     return {
+      op_id: opId,
       graph_id: committedResult.graphId,
       base_version: tx.baseVersion,
       committed_version: committedResult.version,
@@ -236,7 +246,11 @@ function ensureCommittedState(
   bootstrapCommittedState(context.transactions, payload.graph);
   const refreshed = context.transactions.getCommittedState(graphId);
   if (!refreshed) {
-    throw new GraphTransactionError(`unable to register committed state for graph '${graphId}'`);
+    throw new GraphTransactionError(
+      ERROR_CODES.TX_UNEXPECTED,
+      "failed to register graph state",
+      "retry once the transaction manager has been initialised",
+    );
   }
   return { graph: refreshed.graph, version: refreshed.version };
 }

--- a/src/tools/operationIds.ts
+++ b/src/tools/operationIds.ts
@@ -1,0 +1,23 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Determine the operation identifier to correlate a tool invocation.
+ *
+ * The orchestrator exposes a wide catalogue of MCP tools and the checklist
+ * requires every handler to surface a stable `op_id` so downstream clients can
+ * cancel, resume or audit operations without relying on positional context.
+ *
+ * @param provided Optional identifier supplied by the caller. When defined and
+ *   non-empty it is returned verbatim so idempotent replays keep the same
+ *   correlation handle.
+ * @param prefix Human readable prefix applied when the caller omits an
+ *   identifier. Coupling the prefix with a UUID keeps the value unique while
+ *   hinting at the originating surface in logs and traces.
+ */
+export function resolveOperationId(provided: unknown, prefix: string): string {
+  const trimmed = typeof provided === "string" ? provided.trim() : "";
+  if (trimmed.length > 0) {
+    return trimmed;
+  }
+  return `${prefix}_${randomUUID()}`;
+}

--- a/src/tools/txTools.ts
+++ b/src/tools/txTools.ts
@@ -12,6 +12,10 @@ import { normaliseGraphPayload, serialiseNormalisedGraph, GraphDescriptorSchema,
 import type { GraphMutateInput } from "./graphTools.js";
 import type { ResourceGraphPayload, ResourceRegistry } from "../resources/registry.js";
 import type { NormalisedGraph } from "../graph/types.js";
+import { evaluateGraphInvariants, GraphInvariantError, type GraphInvariantReport } from "../graph/invariants.js";
+import { diffGraphs } from "../graph/diff.js";
+import { ERROR_CODES } from "../types.js";
+import { resolveOperationId } from "./operationIds.js";
 
 /** Context injected in the transaction tool handlers. */
 export interface TxToolContext {
@@ -35,6 +39,8 @@ export const TxBeginInputSchema = z
     ttl_ms: z.number().int().positive().max(86_400_000).optional(),
     graph: GraphDescriptorSchema.optional(),
     idempotency_key: z.string().min(1).optional(),
+    // Optional correlation identifier propagated through events/logs.
+    op_id: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -45,6 +51,8 @@ export const TxApplyInputSchema = z
     operations: z
       .array(GraphMutateInputSchema.shape.operations.element)
       .min(1, "at least one operation must be provided"),
+    // Optional correlation identifier propagated through events/logs.
+    op_id: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -52,6 +60,8 @@ export const TxApplyInputSchema = z
 export const TxCommitInputSchema = z
   .object({
     tx_id: z.string().uuid(),
+    // Optional correlation identifier propagated through events/logs.
+    op_id: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -59,6 +69,8 @@ export const TxCommitInputSchema = z
 export const TxRollbackInputSchema = z
   .object({
     tx_id: z.string().uuid(),
+    // Optional correlation identifier propagated through events/logs.
+    op_id: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -74,6 +86,8 @@ export type TxRollbackInput = z.infer<typeof TxRollbackInputSchema>;
 
 /** Result returned by {@link handleTxBegin}. */
 export interface TxBeginResult {
+  /** Correlation identifier propagated back to clients. */
+  op_id: string;
   tx_id: string;
   graph_id: string;
   base_version: number;
@@ -88,6 +102,8 @@ export interface TxBeginResult {
 
 /** Result returned by {@link handleTxApply}. */
 export interface TxApplyResult {
+  /** Correlation identifier propagated back to clients. */
+  op_id: string;
   tx_id: string;
   graph_id: string;
   base_version: number;
@@ -99,11 +115,22 @@ export interface TxApplyResult {
   /** Set to true when at least one operation mutated the working copy. */
   changed: boolean;
   applied: ReturnType<typeof handleGraphMutate>["applied"];
+  /**
+   * JSON Patch transforming the pre-mutation working copy into the updated
+   * descriptor. Aligns with the documentation examples so external clients can
+   * consume previews without bespoke conversions.
+   */
+  diff: ReturnType<typeof diffGraphs>["operations"];
+  /** Aggregated summary of the high-level sections impacted by the batch. */
+  diff_summary: ReturnType<typeof diffGraphs>["summary"];
   graph: ReturnType<typeof serialiseNormalisedGraph>;
+  invariants: GraphInvariantReport;
 }
 
 /** Result returned by {@link handleTxCommit}. */
 export interface TxCommitResult {
+  /** Correlation identifier propagated back to clients. */
+  op_id: string;
   tx_id: string;
   graph_id: string;
   version: number;
@@ -113,6 +140,8 @@ export interface TxCommitResult {
 
 /** Result returned by {@link handleTxRollback}. */
 export interface TxRollbackResult {
+  /** Correlation identifier propagated back to clients. */
+  op_id: string;
   tx_id: string;
   graph_id: string;
   version: number;
@@ -122,6 +151,7 @@ export interface TxRollbackResult {
 
 /** Opens a new transaction, returning a working copy that can be mutated server-side. */
 export function handleTxBegin(context: TxToolContext, input: TxBeginInput): TxBeginResult {
+  const opId = resolveOperationId(input.op_id, "tx_begin_op");
   const execute = (): TxBeginSnapshot => {
     const baseGraph = resolveBaseGraph(context, input);
     if (input.expected_version !== undefined && baseGraph.graphVersion !== input.expected_version) {
@@ -147,7 +177,7 @@ export function handleTxBegin(context: TxToolContext, input: TxBeginInput): TxBe
       expiresAt: opened.expiresAt,
     });
 
-    return formatBeginResult(opened);
+    return formatBeginResult(opened, opId);
   };
 
   const key = input.idempotency_key ?? null;
@@ -163,6 +193,7 @@ export function handleTxBegin(context: TxToolContext, input: TxBeginInput): TxBe
 
 /** Applies graph operations to the transaction working copy. */
 export function handleTxApply(context: TxToolContext, input: TxApplyInput): TxApplyResult {
+  const opId = resolveOperationId(input.op_id, "tx_apply_op");
   // Retrieve a defensive copy so mutations occur on a fresh descriptor.
   const workingCopy = context.transactions.getWorkingCopy(input.tx_id);
   const metadata = context.transactions.describe(input.tx_id);
@@ -174,12 +205,19 @@ export function handleTxApply(context: TxToolContext, input: TxApplyInput): TxAp
     operations: input.operations as GraphMutateInput["operations"],
   };
   const result = handleGraphMutate(mutateInput);
-  context.transactions.setWorkingCopy(input.tx_id, normaliseGraphPayload(result.graph));
+  const normalisedGraph = normaliseGraphPayload(result.graph);
+  const invariants = evaluateGraphInvariants(normalisedGraph);
+  if (!invariants.ok) {
+    throw new GraphInvariantError(invariants.violations);
+  }
+  context.transactions.setWorkingCopy(input.tx_id, normalisedGraph);
 
   const changed = result.applied.some((entry) => entry.changed);
   const previewVersion = changed ? metadata.baseVersion + 1 : metadata.baseVersion;
+  const diff = diffGraphs(workingCopy, normalisedGraph);
 
   return {
+    op_id: opId,
     tx_id: input.tx_id,
     graph_id: metadata.graphId,
     base_version: metadata.baseVersion,
@@ -189,16 +227,24 @@ export function handleTxApply(context: TxToolContext, input: TxApplyInput): TxAp
     expires_at: metadata.expiresAt,
     changed,
     applied: result.applied,
+    diff: diff.operations,
+    diff_summary: diff.summary,
     graph: result.graph,
-  };
+    invariants,
+  } satisfies TxApplyResult;
 }
 
 /** Commits the transaction, returning the updated graph descriptor. */
 export function handleTxCommit(context: TxToolContext, input: TxCommitInput): TxCommitResult {
+  const opId = resolveOperationId(input.op_id, "tx_commit_op");
   const metadata = context.transactions.describe(input.tx_id);
   context.locks.assertCanMutate(metadata.graphId, metadata.owner);
 
   const workingCopy = context.transactions.getWorkingCopy(input.tx_id);
+  const invariants = evaluateGraphInvariants(workingCopy);
+  if (!invariants.ok) {
+    throw new GraphInvariantError(invariants.violations);
+  }
   const committed = context.transactions.commit(input.tx_id, workingCopy);
 
   context.resources.markGraphSnapshotCommitted({
@@ -216,6 +262,7 @@ export function handleTxCommit(context: TxToolContext, input: TxCommitInput): Tx
   });
 
   return {
+    op_id: opId,
     tx_id: committed.txId,
     graph_id: committed.graphId,
     version: committed.version,
@@ -226,9 +273,11 @@ export function handleTxCommit(context: TxToolContext, input: TxCommitInput): Tx
 
 /** Rolls back the transaction, returning the original snapshot. */
 export function handleTxRollback(context: TxToolContext, input: TxRollbackInput): TxRollbackResult {
+  const opId = resolveOperationId(input.op_id, "tx_rollback_op");
   const rolled = context.transactions.rollback(input.tx_id);
   context.resources.markGraphSnapshotRolledBack(rolled.graphId, rolled.txId);
   return {
+    op_id: opId,
     tx_id: rolled.txId,
     graph_id: rolled.graphId,
     version: rolled.version,
@@ -240,8 +289,9 @@ export function handleTxRollback(context: TxToolContext, input: TxRollbackInput)
 /** Formats the begin result into the tool payload. */
 type TxBeginSnapshot = Omit<TxBeginResult, "idempotent" | "idempotency_key">;
 
-function formatBeginResult(opened: BeginTransactionResult): TxBeginSnapshot {
+function formatBeginResult(opened: BeginTransactionResult, opId: string): TxBeginSnapshot {
   return {
+    op_id: opId,
     tx_id: opened.txId,
     graph_id: opened.graphId,
     base_version: opened.baseVersion,
@@ -262,7 +312,9 @@ function resolveBaseGraph(context: TxToolContext, input: TxBeginInput): Normalis
     const normalised = normaliseGraphPayload(input.graph);
     if (normalised.graphId !== input.graph_id) {
       throw new GraphTransactionError(
-        `graph payload id '${normalised.graphId}' does not match requested graph_id '${input.graph_id}'`,
+        ERROR_CODES.TX_INVALID_INPUT,
+        "graph payload mismatch",
+        "ensure graph_id matches descriptor",
       );
     }
     return normalised;
@@ -276,7 +328,11 @@ function resolveBaseGraph(context: TxToolContext, input: TxBeginInput): Normalis
   try {
     const resource = context.resources.read(`sc://graphs/${input.graph_id}`);
     if (resource.kind !== "graph") {
-      throw new GraphTransactionError(`graph '${input.graph_id}' is not available for transactions`);
+      throw new GraphTransactionError(
+        ERROR_CODES.TX_NOT_FOUND,
+        "graph unavailable",
+        "publish the graph via resources before opening transactions",
+      );
     }
     const payload = resource.payload as ResourceGraphPayload;
     return structuredClone(payload.graph) as NormalisedGraph;
@@ -285,7 +341,9 @@ function resolveBaseGraph(context: TxToolContext, input: TxBeginInput): Normalis
       throw error;
     }
     throw new GraphTransactionError(
-      error instanceof Error ? error.message : `graph '${input.graph_id}' is not available for transactions`,
+      ERROR_CODES.TX_UNEXPECTED,
+      error instanceof Error ? error.message : "graph lookup failed",
+      "retry once the registry becomes reachable",
     );
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,62 +1,197 @@
 /**
- * Shared type aliases used across the orchestrator. The goal is to centralise
- * identifiers so that server modules rely on descriptive names instead of raw
- * strings.
+ * Shared type aliases used across the orchestrator. Centralising identifiers
+ * avoids sprinkling plain strings throughout the codebase and improves
+ * legibility when cross-referencing logs with in-memory entities.
  */
 export type RunId = string;
+
 /** Identifier of a tool invocation or long running operation. */
 export type OpId = string;
+
 /** Identifier of a graph persisted in the registry. */
 export type GraphId = string;
+
 /** Semantic version string used to track graph revisions. */
 export type Version = string;
+
 /** Identifier assigned to a spawned child runtime. */
 export type ChildId = string;
+
 /** Identifier representing an open transaction. */
 export type TransactionId = string;
+
 /** Canonical URI referencing a resource exposed via MCP. */
 export type ResourceUri = string;
 
+/** Roles a message can carry when exchanged between agents. */
 export type Role = "system" | "user" | "assistant";
+
+/** Originators that can emit a message inside a transcript. */
 export type Actor = "orchestrator" | "child" | "external" | "user";
 
+/** Structured entry stored when persisting conversational transcripts. */
 export interface MessageRecord {
+  /** Message role as understood by downstream LLMs. */
   role: Role;
+  /** Raw textual content supplied by the actor. */
   content: string;
+  /** Unix timestamp (milliseconds) at which the message was recorded. */
   ts: number;
+  /** Optional actor identifier used for auditing/debugging. */
   actor?: Actor;
 }
 
 /**
- * Canonical list of error codes returned by MCP tools. Keeping the catalogue in
- * a single location ensures codes remain stable and discoverable when new
- * modules are introduced.
+ * Strongly typed catalogue of stable error codes grouped by feature family.
+ * Keeping a single source of truth ensures every tool emits consistent codes
+ * which simplifies documentation and client handling.
  */
-export const ERROR_CODES = {
-  MCP_INVALID_REQUEST: "E-MCP-INVALID-REQUEST",
-  MCP_UNAVAILABLE: "E-MCP-UNAVAILABLE",
-  RES_NOT_FOUND: "E-RES-NOT-FOUND",
-  RES_FORBIDDEN: "E-RES-FORBIDDEN",
-  EVT_STREAM_CLOSED: "E-EVT-STREAM-CLOSED",
-  EVT_FILTER_UNSUPPORTED: "E-EVT-FILTER-UNSUPPORTED",
-  CANCEL_UNSUPPORTED: "E-CANCEL-UNSUPPORTED",
-  CANCEL_ALREADY_RESOLVED: "E-CANCEL-ALREADY-RESOLVED",
-  TX_CONFLICT: "E-TX-CONFLICT",
-  TX_UNKNOWN: "E-TX-UNKNOWN",
-  LOCK_HELD: "E-LOCK-HELD",
-  LOCK_NOT_FOUND: "E-LOCK-NOT-FOUND",
-  PATCH_INVALID: "E-PATCH-INVALID",
-  PATCH_INVARIANT_VIOLATION: "E-PATCH-INVARIANT-VIOLATION",
-  PLAN_NOT_RUNNING: "E-PLAN-NOT-RUNNING",
-  PLAN_ALREADY_PAUSED: "E-PLAN-ALREADY-PAUSED",
-  CHILD_NOT_FOUND: "E-CHILD-NOT-FOUND",
-  CHILD_LIMIT_EXCEEDED: "E-CHILD-LIMIT-EXCEEDED",
-  VALUES_VIOLATION: "E-VALUES-VIOLATION",
-  ASSIST_UNAVAILABLE: "E-ASSIST-UNAVAILABLE",
+export const ERROR_CATALOG = {
+  MCP: {
+    INVALID_REQUEST: "E-MCP-INVALID-REQUEST",
+    UNSUPPORTED: "E-MCP-UNSUPPORTED",
+    UNAVAILABLE: "E-MCP-UNAVAILABLE",
+  },
+  RES: {
+    NOT_FOUND: "E-RES-NOT-FOUND",
+    FORBIDDEN: "E-RES-FORBIDDEN",
+    WATCH_UNSUPPORTED: "E-RES-WATCH-UNSUPPORTED",
+  },
+  EVT: {
+    STREAM_CLOSED: "E-EVT-STREAM-CLOSED",
+    FILTER_UNSUPPORTED: "E-EVT-FILTER-UNSUPPORTED",
+    BACKPRESSURE_DROPPED: "E-EVT-BACKPRESSURE-DROPPED",
+  },
+  CANCEL: {
+    NOT_FOUND: "E-CANCEL-NOTFOUND",
+    ALREADY_RESOLVED: "E-CANCEL-ALREADY-RESOLVED",
+    UNSUPPORTED: "E-CANCEL-UNSUPPORTED",
+  },
+  BULK: {
+    PARTIAL: "E-BULK-PARTIAL",
+    DISABLED: "E-BULK-DISABLED",
+  },
+  TX: {
+    NOT_FOUND: "E-TX-NOTFOUND",
+    CONFLICT: "E-TX-CONFLICT",
+    INVALID_OP: "E-TX-INVALIDOP",
+    UNEXPECTED: "E-TX-UNEXPECTED",
+    INVALID_INPUT: "E-TX-INVALID-INPUT",
+    EXPIRED: "E-TX-EXPIRED",
+  },
+  LOCK: {
+    HELD: "E-LOCK-HELD",
+    NOT_FOUND: "E-LOCK-NOT-FOUND",
+    EXPIRED: "E-LOCK-EXPIRED",
+  },
+  PATCH: {
+    INVALID: "E-PATCH-INVALID",
+    INVARIANT_VIOLATION: "E-PATCH-INVARIANT-VIOLATION",
+    CYCLE: "E-PATCH-CYCLE",
+    PORTS: "E-PATCH-PORTS",
+    CARD: "E-PATCH-CARD",
+  },
+  PLAN: {
+    NOT_RUNNING: "E-PLAN-NOT-RUNNING",
+    ALREADY_PAUSED: "E-PLAN-ALREADY-PAUSED",
+    STATE: "E-PLAN-STATE",
+    UNEXPECTED: "E-PLAN-UNEXPECTED",
+    INVALID_INPUT: "E-PLAN-INVALID-INPUT",
+  },
+  CHILD: {
+    NOT_FOUND: "E-CHILD-NOTFOUND",
+    LIMIT_EXCEEDED: "E-CHILD-LIMIT",
+    UNEXPECTED: "E-CHILD-UNEXPECTED",
+    INVALID_INPUT: "E-CHILD-INVALID-INPUT",
+  },
+  VALUES: {
+    VIOLATION: "E-VALUES-VIOLATION",
+    EXPLAIN_UNAVAILABLE: "E-VALUES-EXPLAIN-UNAVAILABLE",
+  },
+  ASSIST: {
+    UNAVAILABLE: "E-ASSIST-UNAVAILABLE",
+    NOT_READY: "E-ASSIST-NOT-READY",
+  },
+  GRAPH: {
+    UNEXPECTED: "E-GRAPH-UNEXPECTED",
+    INVALID_INPUT: "E-GRAPH-INVALID-INPUT",
+  },
 } as const;
 
+type ErrorCatalog = typeof ERROR_CATALOG;
+
+/** Utility type used to flatten the nested error catalogue. */
+type FlattenCatalog<T extends Record<string, Record<string, string>>> = {
+  [Family in keyof T & string as `${Family}_${keyof T[Family] & string}`]: T[Family][keyof T[Family] & string];
+};
+
+/** Flattened version of {@link ERROR_CATALOG} used for ergonomic lookups. */
+type FlatErrorCatalog = FlattenCatalog<ErrorCatalog>;
+
+/**
+ * Builds a flattened object whose properties map to their fully qualified error
+ * codes (e.g. `PLAN_STATE`). The helper keeps runtime data immutable while
+ * preserving the strongly typed relationship with {@link ERROR_CATALOG}.
+ */
+function flattenCatalog<T extends Record<string, Record<string, string>>>(
+  catalog: T,
+): FlattenCatalog<T> {
+  const flat: Record<string, string> = {};
+  for (const familyKey of Object.keys(catalog) as Array<keyof T & string>) {
+    const family = catalog[familyKey];
+    for (const codeKey of Object.keys(family) as Array<keyof T[typeof familyKey] & string>) {
+      flat[`${familyKey}_${codeKey}`] = family[codeKey];
+    }
+  }
+  return Object.freeze(flat) as FlattenCatalog<T>;
+}
+
+/** Flat access to all stable error codes (e.g. `ERROR_CODES.PLAN_STATE`). */
+export const ERROR_CODES: FlatErrorCatalog = flattenCatalog(ERROR_CATALOG);
+
 /** Union type representing every stable error code emitted by MCP tools. */
-export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+export type ErrorCode = FlatErrorCatalog[keyof FlatErrorCatalog];
+
+/** Maximum number of UTF-16 code units allowed for error messages and hints. */
+export const ERROR_TEXT_MAX_LENGTH = 120;
+
+/**
+ * Collapses whitespace, trims surrounding spaces and enforces the maximum length
+ * for an error message. If the provided text is empty once trimmed a generic
+ * fallback is returned so clients never receive an empty string.
+ */
+export function normaliseErrorMessage(text: string, fallback = "unexpected error"): string {
+  const collapsed = text.replace(/\s+/g, " ").trim();
+  const base = collapsed.length === 0 ? fallback : collapsed;
+  if (base.length <= ERROR_TEXT_MAX_LENGTH) {
+    return base;
+  }
+  return `${base.slice(0, ERROR_TEXT_MAX_LENGTH - 1)}…`;
+}
+
+/**
+ * Normalises the optional hint attached to an error. Empty strings collapse to
+ * `undefined` while overly long hints are truncated to keep payloads concise.
+ */
+export function normaliseErrorHint(hint?: string): string | undefined {
+  if (hint === undefined) {
+    return undefined;
+  }
+  const collapsed = hint.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) {
+    return undefined;
+  }
+  if (collapsed.length <= ERROR_TEXT_MAX_LENGTH) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, ERROR_TEXT_MAX_LENGTH - 1)}…`;
+}
+
+/** Structure returned by tools when an operation succeeds. */
+export interface ToolSuccess<T> {
+  ok: true;
+  value: T;
+}
 
 /** Standard structure returned by tools when an operation fails. */
 export interface ToolError {
@@ -64,4 +199,20 @@ export interface ToolError {
   code: ErrorCode;
   message: string;
   hint?: string;
+}
+
+/** Convenience union describing the common tool result envelope. */
+export type ToolResult<T> = ToolSuccess<T> | ToolError;
+
+/**
+ * Helper used by tools to build a failure response with the expected shape.
+ * Keeping the implementation centralised guarantees a consistent structure
+ * (including optional hints) across every feature surface.
+ */
+export function fail(code: ErrorCode, message: string, hint?: string): ToolError {
+  const normalisedMessage = normaliseErrorMessage(message);
+  const normalisedHint = normaliseErrorHint(hint);
+  return normalisedHint
+    ? { ok: false, code, message: normalisedMessage, hint: normalisedHint }
+    : { ok: false, code, message: normalisedMessage };
 }

--- a/tests/child.spawn-attach-limits.test.ts
+++ b/tests/child.spawn-attach-limits.test.ts
@@ -46,6 +46,7 @@ describe("child spawn/attach/limits tools", () => {
 
       const spawned = await handleChildSpawnCodex(context, spawnInput);
 
+      expect(spawned.op_id).to.be.a("string");
       expect(spawned.child_id).to.match(/^child-\d{13}-[a-f0-9]{6}$/);
       expect(spawned.role).to.equal("planner");
       expect(spawned.limits).to.deep.equal({ tokens: 2048, wallclock_ms: 30_000 });
@@ -55,6 +56,9 @@ describe("child spawn/attach/limits tools", () => {
 
       const manifestRaw = await readFile(spawned.manifest_path, "utf8");
       const manifest = JSON.parse(manifestRaw) as Record<string, unknown>;
+      const manifestMetadata = manifest.metadata as { op_id?: unknown } | undefined;
+      const manifestOpId = (manifestMetadata?.op_id ?? (manifest as { op_id?: unknown }).op_id) as string | undefined;
+      expect(manifestOpId).to.equal(spawned.op_id);
       expect(manifest.role).to.equal("planner");
       expect(manifest.limits).to.deep.equal({ tokens: 2048, wallclock_ms: 30_000 });
       expect(manifest.prompt).to.deep.equal(spawnInput.prompt);

--- a/tests/child.tools.test.ts
+++ b/tests/child.tools.test.ts
@@ -63,6 +63,7 @@ describe("child tool handlers", () => {
       });
       const created = await handleChildCreate(context, createInput);
 
+      expect(created.op_id).to.be.a("string");
       expect(created.child_id).to.match(/^child-\d{13}-[a-f0-9]{6}$/);
       expect(created.runtime_status.lifecycle).to.equal("running");
       expect(created.index_snapshot.state).to.equal("starting");
@@ -181,13 +182,15 @@ describe("child tool handlers", () => {
         .split(/\n+/)
         .map((line) => line.trim())
         .filter((line) => line.length > 0)
-        .map((line) => JSON.parse(line) as { message: string });
+        .map((line) => JSON.parse(line) as { message: string; payload?: Record<string, unknown> });
       const messages = entries.map((entry) => entry.message);
       expect(messages).to.include("child_create_requested");
       expect(messages).to.include("child_send");
       expect(messages).to.include("child_collect");
       expect(messages).to.include("child_cancel");
       expect(messages).to.include("child_gc");
+      const createEntry = entries.find((entry) => entry.message === "child_create_requested");
+      expect(createEntry?.payload?.op_id).to.be.a("string");
     } finally {
       await logger.flush();
       await supervisor.disposeAll();

--- a/tests/concurrency.events-backpressure.test.ts
+++ b/tests/concurrency.events-backpressure.test.ts
@@ -32,7 +32,7 @@ describe("stream pagination backpressure", () => {
       for (let offset = 0; offset < burstSize; offset += 1) {
         published += 1;
         bus.publish({
-          cat: burstIndex % 2 === 0 ? "plan" : "child",
+          cat: burstIndex % 2 === 0 ? "graph" : "child",
           runId: `run-${burstIndex + 1}`,
           msg: `event-${published}`,
         });
@@ -55,7 +55,7 @@ describe("stream pagination backpressure", () => {
     const keepAlive = bus.list({ afterSeq: cursor, limit });
     expect(keepAlive).to.have.length(0);
 
-    const resumed = bus.publish({ cat: "plan", runId: "run-keepalive", msg: "resume" });
+    const resumed = bus.publish({ cat: "graph", runId: "run-keepalive", msg: "resume" });
     const replay = bus.list({ afterSeq: cursor, limit });
     expect(replay.map((event) => event.seq)).to.deep.equal([resumed.seq]);
   });

--- a/tests/coord.consensus.vote-tool.test.ts
+++ b/tests/coord.consensus.vote-tool.test.ts
@@ -37,6 +37,7 @@ describe("coordination consensus vote tool", () => {
 
     const result = handleConsensusVote(context, input);
 
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.mode).to.equal("majority");
     expect(result.outcome).to.equal("success");
     expect(result.satisfied).to.equal(true);
@@ -60,6 +61,7 @@ describe("coordination consensus vote tool", () => {
 
     const result = handleConsensusVote(context, input);
 
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.mode).to.equal("weighted");
     expect(result.outcome).to.equal("success");
     expect(result.satisfied).to.equal(true);

--- a/tests/coord.contractnet.pheromone-bounds.test.ts
+++ b/tests/coord.contractnet.pheromone-bounds.test.ts
@@ -60,6 +60,7 @@ describe("coordination contract-net pheromone bounds", () => {
       CnpAnnounceInputSchema.parse({ task_id: "survey-1", auto_bid: true }),
     );
 
+    expect(first.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(first.pheromone_bounds).to.deep.equal({
       min_intensity: 0,
       max_intensity: null,
@@ -77,6 +78,7 @@ describe("coordination contract-net pheromone bounds", () => {
       CnpAnnounceInputSchema.parse({ task_id: "survey-2", auto_bid: true }),
     );
 
+    expect(second.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(second.pheromone_bounds).to.deep.equal({
       min_intensity: 0,
       max_intensity: null,
@@ -107,6 +109,7 @@ describe("coordination contract-net pheromone bounds", () => {
       CnpAnnounceInputSchema.parse({ task_id: "bounded", auto_bid: true }),
     );
 
+    expect(announcement.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(announcement.pheromone_bounds).to.deep.equal({
       min_intensity: 0,
       max_intensity: 5,
@@ -352,6 +355,7 @@ describe("coordination contract-net pheromone bounds", () => {
       CnpRefreshBoundsInputSchema.parse({ call_id: call.callId }),
     );
 
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.auto_bid_refreshed).to.equal(true);
     expect(result.refresh.requested).to.equal(true);
     expect(result.refreshed_agents).to.deep.equal(["alpha"]);
@@ -602,6 +606,7 @@ describe("contract-net watcher telemetry tool", () => {
       CnpWatcherTelemetryInputSchema.parse({}),
     );
 
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.telemetry_enabled).to.equal(false);
     expect(result.emissions).to.equal(0);
     expect(result.last_snapshot).to.equal(null);
@@ -648,6 +653,7 @@ describe("contract-net watcher telemetry tool", () => {
       CnpWatcherTelemetryInputSchema.parse({}),
     );
 
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
     expect(result.telemetry_enabled).to.equal(true);
     expect(result.emissions).to.equal(3);
     expect(result.last_emitted_at_ms).to.equal(15);

--- a/tests/coord.stigmergy.field.test.ts
+++ b/tests/coord.stigmergy.field.test.ts
@@ -155,6 +155,8 @@ describe("coordination stigmergy field", () => {
 
     const result = handleStigSnapshot(context, {});
 
+    expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+
     expect(result.pheromone_bounds).to.deep.equal({
       min_intensity: 0.25,
       max_intensity: 5,

--- a/tests/e2e.graph.tx-diff-patch.test.ts
+++ b/tests/e2e.graph.tx-diff-patch.test.ts
@@ -199,9 +199,14 @@ describe("graph transactions with diff/patch integration", function () {
         uri: string;
         kind: string;
         payload: { version: number; graph: { nodes: Array<{ id: string }> } };
+        mime: string;
+        data: { uri: string; kind: string; payload: { version: number } };
       };
+      expect(resourcePayload.mime).to.equal("application/json");
       expect(resourcePayload.uri).to.equal(resourceUri);
       expect(resourcePayload.kind).to.equal("graph_version");
+      expect(resourcePayload.data.uri).to.equal(resourceUri);
+      expect(resourcePayload.data.kind).to.equal("graph_version");
       expect(resourcePayload.payload.version).to.equal(patchResult.committed_version);
       expect(resourcePayload.payload.graph.nodes.some((node) => node.id === "ship")).to.equal(true);
     } finally {

--- a/tests/e2e.values.guard.test.ts
+++ b/tests/e2e.values.guard.test.ts
@@ -137,6 +137,7 @@ describe("end-to-end value guard enforcement", function () {
         }),
       );
 
+      expect(joinResult.op_id).to.be.a("string");
       expect(joinResult.satisfied).to.equal(true);
       expect(joinResult.winning_child_id).to.equal(survivingChild);
       expect(joinResult.results).to.have.length(1);
@@ -150,6 +151,7 @@ describe("end-to-end value guard enforcement", function () {
         }),
       );
 
+      expect(reduceResult.op_id).to.be.a("string");
       expect(reduceResult.reducer).to.equal("concat");
       expect(reduceResult.aggregate).to.contain("SAFE_PLAN_READY");
       expect(reduceResult.trace.per_child).to.have.length(1);

--- a/tests/errors.normalisation.test.ts
+++ b/tests/errors.normalisation.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { z } from "zod";
+
+import {
+  ERROR_TEXT_MAX_LENGTH,
+  fail,
+  normaliseErrorHint,
+  normaliseErrorMessage,
+} from "../src/types.js";
+import { normaliseToolError } from "../src/server/toolErrors.js";
+
+/**
+ * Unit tests covering the error message and hint normalisation logic. Keeping the
+ * assertions explicit helps prevent regressions whenever new error helpers are
+ * added or existing ones evolve to cover additional use cases.
+ */
+describe("error normalisation helpers", () => {
+  it("collapses whitespace and enforces the maximum length on messages", () => {
+    const messy = "  multi\nline\tmessage   with   spacing   issues  ";
+    expect(normaliseErrorMessage(messy)).to.equal("multi line message with spacing issues");
+
+    const oversized = "X".repeat(ERROR_TEXT_MAX_LENGTH + 12);
+    const truncated = normaliseErrorMessage(oversized);
+    expect(truncated.length).to.equal(ERROR_TEXT_MAX_LENGTH);
+    expect(truncated.endsWith("…")).to.equal(true);
+  });
+
+  it("drops empty hints and trims or truncates longer ones", () => {
+    expect(normaliseErrorHint("   ")).to.equal(undefined);
+    expect(normaliseErrorHint("   retry   later  ")).to.equal("retry later");
+
+    const longHint = "R".repeat(ERROR_TEXT_MAX_LENGTH + 5);
+    const truncated = normaliseErrorHint(longHint);
+    expect(truncated).to.not.equal(undefined);
+    expect(truncated!.length).to.equal(ERROR_TEXT_MAX_LENGTH);
+    expect(truncated!.endsWith("…")).to.equal(true);
+  });
+
+  it("ensures fail() responses use the normalised message and hint", () => {
+    const longMessage = "Unexpected failure due to downstream issue".repeat(5);
+    const result = fail("E-GRAPH-UNEXPECTED", `${longMessage}\n`, "  consult logs for details   ");
+    expect(result.message.length).to.equal(ERROR_TEXT_MAX_LENGTH);
+    expect(result.message.endsWith("…")).to.equal(true);
+    expect(result.hint).to.equal("consult logs for details");
+  });
+
+  it("normalises arbitrary thrown errors including validation failures", () => {
+    const parseResult = z.object({ id: z.string().uuid() }).safeParse({ id: "not-a-uuid" });
+    if (parseResult.success) {
+      throw new Error("expected validation to fail so the error normaliser is exercised");
+    }
+    const zodError = parseResult.error;
+
+    const validation = normaliseToolError(zodError, {
+      defaultCode: "E-GENERIC",
+      invalidInputCode: "E-GENERIC-INVALID",
+    });
+    expect(validation.code).to.equal("E-GENERIC-INVALID");
+    expect(validation.hint).to.equal("invalid_input");
+    expect(validation.message.length).to.be.at.most(ERROR_TEXT_MAX_LENGTH);
+
+    const blankError = normaliseToolError(new Error("   \n\t"), {
+      defaultCode: "E-GENERIC",
+    });
+    expect(blankError.message).to.equal("unexpected error");
+  });
+});

--- a/tests/events.backpressure.test.ts
+++ b/tests/events.backpressure.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { EventBus } from "../src/events/bus.js";
+
+describe("event bus backpressure", () => {
+  it("drops informational history entries before warnings and errors", () => {
+    const bus = new EventBus({ historyLimit: 3 });
+
+    bus.publish({ cat: "graph", level: "info", msg: "info-1" });
+    bus.publish({ cat: "graph", level: "warn", msg: "warn-1" });
+    bus.publish({ cat: "graph", level: "info", msg: "info-2" });
+    bus.publish({ cat: "graph", level: "error", msg: "error-1" });
+
+    const history = bus.list();
+    expect(history.map((event) => event.msg)).to.deep.equal(["warn-1", "info-2", "error-1"]);
+    expect(history.every((event) => event.level !== "info" || event.msg !== "info-1")).to.equal(true);
+  });
+
+  it("applies the same pressure policy to live stream buffers", async () => {
+    const bus = new EventBus({ historyLimit: 10, streamBufferSize: 3 });
+    const stream = bus.subscribe();
+    const iterator = stream[Symbol.asyncIterator]();
+
+    bus.publish({ cat: "graph", level: "info", msg: "info-1" });
+    bus.publish({ cat: "graph", level: "warn", msg: "warn-1" });
+    bus.publish({ cat: "graph", level: "info", msg: "info-2" });
+    bus.publish({ cat: "graph", level: "error", msg: "error-1" });
+
+    const buffered: string[] = [];
+    for (let index = 0; index < 3; index += 1) {
+      const { value } = await iterator.next();
+      buffered.push(value.msg);
+    }
+
+    expect(buffered).to.deep.equal(["warn-1", "info-2", "error-1"]);
+    stream.close();
+  });
+});

--- a/tests/events.bridges.test.ts
+++ b/tests/events.bridges.test.ts
@@ -71,7 +71,7 @@ describe("event bridges", () => {
     const expired = store.evictExpired();
     expect(expired).to.have.lengthOf(1);
 
-    const events = bus.list({ cats: ["blackboard"] });
+    const events = bus.list({ cats: ["bb"] });
     expect(events.map((event) => event.msg)).to.deep.equal([
       "bb_set",
       "bb_set",
@@ -109,7 +109,7 @@ describe("event bridges", () => {
     const changes = field.evaporate(2);
     expect(changes).to.have.length.greaterThan(0);
 
-    const events = bus.list({ cats: ["stigmergy"] });
+    const events = bus.list({ cats: ["stig"] });
     expect(events).to.have.lengthOf(2);
     const [markEvent, evaporateEvent] = events;
     expect(markEvent.nodeId).to.equal("node-1");
@@ -148,7 +148,7 @@ describe("event bridges", () => {
     expect(firstOutcome).to.equal("requested");
     expect(secondOutcome).to.equal("already_cancelled");
 
-    const events = bus.list({ cats: ["cancel"] });
+    const events = bus.list({ cats: ["scheduler"] });
     expect(events).to.have.lengthOf(2);
 
     const [requested, repeated] = events;
@@ -206,7 +206,7 @@ describe("event bridges", () => {
     requestCancellation(handle.opId, { at: now(), reason: null });
     requestCancellation(handle.opId, { at: now() });
 
-    const events = bus.list({ cats: ["cancel"] });
+    const events = bus.list({ cats: ["scheduler"] });
     expect(events).to.have.lengthOf(2);
 
     const [requested, repeated] = events;
@@ -254,7 +254,7 @@ describe("event bridges", () => {
     const removed = coordinator.unregisterAgent(agent.agentId);
     expect(removed).to.equal(true);
 
-    const events = bus.list({ cats: ["contract_net"] });
+    const events = bus.list({ cats: ["cnp"] });
     expect(events.map((event) => event.msg)).to.deep.equal([
       "cnp_agent_registered",
       "cnp_bid_recorded",
@@ -313,7 +313,7 @@ describe("event bridges", () => {
     dispose();
 
     coordinator.announce({ taskId: "task-ignored", autoBid: false });
-    const afterDisposeEvents = bus.list({ cats: ["contract_net"] });
+    const afterDisposeEvents = bus.list({ cats: ["cnp"] });
     expect(afterDisposeEvents).to.have.lengthOf(7);
   });
 
@@ -813,7 +813,7 @@ describe("event bridges", () => {
       },
     });
 
-    const events = bus.list({ cats: ["contract_net"] });
+    const events = bus.list({ cats: ["cnp"] });
     expect(events).to.have.lengthOf(1);
     const [telemetryEvent] = events;
     expect(telemetryEvent.msg).to.equal("cnp_watcher_telemetry");

--- a/tests/events.bus.kind-normalisation.test.ts
+++ b/tests/events.bus.kind-normalisation.test.ts
@@ -1,0 +1,45 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { EventBus } from "../src/events/bus.js";
+
+/**
+ * Unit coverage for the semantic event kind normalisation logic. The event bus
+ * should expose upper-cased identifiers even when publishers send lower-case
+ * or padded tokens so downstream filters remain stable across transports.
+ */
+describe("event bus kind normalisation", () => {
+  it("upper-cases explicit kinds while preserving other metadata", () => {
+    const bus = new EventBus({ historyLimit: 4, streamBufferSize: 4 });
+
+    bus.publish({
+      cat: "child",
+      level: "info",
+      msg: "child_prompt",
+      // Intentionally provide a lower-case kind with surrounding whitespace to
+      // verify the normaliser trims and upper-cases the identifier.
+      kind: "  prompt  ",
+      data: { id: "child-1" },
+    });
+
+    const [event] = bus.list();
+    expect(event.kind).to.equal("PROMPT");
+    expect(event.msg).to.equal("child_prompt");
+    expect(event.cat).to.equal("child");
+    expect(event.data).to.deep.equal({ id: "child-1" });
+  });
+
+  it("omits kind when publishers send empty tokens", () => {
+    const bus = new EventBus({ historyLimit: 4, streamBufferSize: 4 });
+
+    bus.publish({
+      cat: "child",
+      level: "info",
+      msg: "child_prompt",
+      kind: "   ",
+    });
+
+    const [event] = bus.list();
+    expect(event.kind).to.equal(undefined);
+  });
+});

--- a/tests/events.subscribe.kind-fallback.test.ts
+++ b/tests/events.subscribe.kind-fallback.test.ts
@@ -52,7 +52,7 @@ describe("events subscribe kind fallback", () => {
 
       const eventsResponse = await client.callTool({
         name: "events_subscribe",
-        arguments: { cats: ["stigmergy"], from_seq: cursor, format: "jsonlines" },
+        arguments: { cats: ["stig"], from_seq: cursor, format: "jsonlines" },
       });
       expect(eventsResponse.isError ?? false).to.equal(false);
 
@@ -62,7 +62,7 @@ describe("events subscribe kind fallback", () => {
 
       const changeEvent = structured.events.find((event) => event.msg === "stigmergy_change");
       expect(changeEvent, "stigmergy change event should be published").to.not.equal(undefined);
-      expect(changeEvent?.kind).to.equal("STIGMERGY");
+      expect(changeEvent?.kind).to.equal("STIG");
       const payload = (changeEvent?.data ?? {}) as { nodeId?: string | null; type?: string | null };
       expect(payload.nodeId).to.equal("node-kind");
       expect(payload.type).to.equal("load");

--- a/tests/events.subscribe.progress.test.ts
+++ b/tests/events.subscribe.progress.test.ts
@@ -1,64 +1,59 @@
-/**
- * Exercises the unified event bus by validating filtering semantics, streaming
- * behaviour and correlation friendly pagination. The tests use a deterministic
- * clock so sequence ordering and timestamps remain predictable.
- */
 import { describe, it } from "mocha";
 import { expect } from "chai";
 
 import { EventBus } from "../src/events/bus.js";
 
-describe("event bus", () => {
-  it("normalises categories and filters by run/op identifiers", () => {
-    const bus = new EventBus({ historyLimit: 10, now: (() => {
-      let tick = 0;
-      return () => ++tick;
-    })() });
+describe("event bus progress", () => {
+  it("filters correlation identifiers within a category", () => {
+    let tick = 0;
+    const bus = new EventBus({ historyLimit: 10, now: () => ++tick });
 
-    bus.publish({ cat: "PLAN", jobId: "job-1", runId: "run-1", opId: "op-alpha", msg: "start" });
-    bus.publish({ cat: "PLAN", jobId: "job-2", runId: "run-2", opId: "op-beta", msg: "progress" });
-    bus.publish({ cat: "CHILD", jobId: "job-1", childId: "child-9", msg: "ready" });
+    bus.publish({ cat: "graph", jobId: "job-1", runId: "run-1", opId: "op-alpha", msg: "plan_started" });
+    bus.publish({ cat: "graph", jobId: "job-2", runId: "run-2", opId: "op-beta", msg: "plan_running" });
+    bus.publish({ cat: "child", jobId: "job-1", childId: "child-9", msg: "child_ready" });
 
-    const filtered = bus.list({ cats: ["plan"], runId: "run-1" });
+    const filtered = bus.list({ cats: ["graph"], runId: "run-1" });
     expect(filtered).to.have.lengthOf(1);
-    expect(filtered[0].runId).to.equal("run-1");
-    expect(filtered[0].opId).to.equal("op-alpha");
-    expect(filtered[0].cat).to.equal("plan");
+    expect(filtered[0]?.runId).to.equal("run-1");
+    expect(filtered[0]?.opId).to.equal("op-alpha");
+    expect(filtered[0]?.cat).to.equal("graph");
+    expect(filtered[0]?.seq).to.equal(1);
 
     const byChild = bus.list({ cats: ["child"], childId: "child-9" });
     expect(byChild).to.have.lengthOf(1);
-    expect(byChild[0].childId).to.equal("child-9");
+    expect(byChild[0]?.childId).to.equal("child-9");
+    expect(byChild[0]?.jobId).to.equal("job-1");
 
-    const ordered = bus.list({});
+    const ordered = bus.list();
     expect(ordered.map((event) => event.seq)).to.deep.equal([1, 2, 3]);
   });
 
-  it("filters across multiple categories while preserving chronological order", () => {
+  it("merges categories while preserving chronological ordering", () => {
     const bus = new EventBus({ historyLimit: 10 });
 
-    const planStart = bus.publish({ cat: "plan", runId: "run-multi", msg: "start" });
-    const childReady = bus.publish({ cat: "child", childId: "child-multi", msg: "ready" });
-    const planFinish = bus.publish({ cat: "plan", runId: "run-multi", msg: "complete" });
+    const planStart = bus.publish({ cat: "graph", runId: "run-multi", msg: "plan_start" });
+    const childReady = bus.publish({ cat: "child", childId: "child-multi", msg: "child_ready" });
+    const planFinish = bus.publish({ cat: "graph", runId: "run-multi", msg: "plan_finish" });
     bus.publish({ cat: "scheduler", msg: "tick" });
 
-    const filtered = bus.list({ cats: ["child", "PLAN"], limit: 10 });
+    const filtered = bus.list({ cats: ["child", "graph"], limit: 10 });
     expect(filtered).to.have.lengthOf(3);
     expect(filtered.map((event) => event.seq)).to.deep.equal([
       planStart.seq,
       childReady.seq,
       planFinish.seq,
     ]);
-    expect(filtered[0]?.cat).to.equal("plan");
+    expect(filtered[0]?.cat).to.equal("graph");
     expect(filtered[1]?.cat).to.equal("child");
-    expect(filtered[2]?.msg).to.equal("complete");
+    expect(filtered[2]?.msg).to.equal("plan_finish");
   });
 
-  it("streams events sequentially when subscribing after a checkpoint", async () => {
+  it("streams sequentially from the requested checkpoint", async () => {
     const bus = new EventBus({ historyLimit: 5 });
 
-    const first = bus.publish({ cat: "plan", runId: "run-42", msg: "queued" });
-    const second = bus.publish({ cat: "plan", runId: "run-42", msg: "executing" });
-    const third = bus.publish({ cat: "plan", runId: "run-42", msg: "done" });
+    const first = bus.publish({ cat: "graph", runId: "run-42", msg: "queued" });
+    const second = bus.publish({ cat: "graph", runId: "run-42", msg: "executing" });
+    const third = bus.publish({ cat: "graph", runId: "run-42", msg: "done" });
 
     const stream = bus.subscribe({ runId: "run-42", afterSeq: first.seq });
     const iterator = stream[Symbol.asyncIterator]();
@@ -79,21 +74,21 @@ describe("event bus", () => {
     expect(closing.done).to.equal(true);
   });
 
-  it("paginates idempotently by leveraging the afterSeq cursor", () => {
+  it("uses the afterSeq cursor for idempotent pagination", () => {
     const bus = new EventBus({ historyLimit: 5 });
 
-    bus.publish({ cat: "plan", runId: "run-9", msg: "start" });
-    const latest = bus.publish({ cat: "plan", runId: "run-9", msg: "finish" });
+    bus.publish({ cat: "graph", runId: "run-9", msg: "start" });
+    const latest = bus.publish({ cat: "graph", runId: "run-9", msg: "finish" });
 
-    const firstPage = bus.list({ cats: ["plan"], runId: "run-9" });
+    const firstPage = bus.list({ cats: ["graph"], runId: "run-9" });
     expect(firstPage).to.have.lengthOf(2);
 
-    const secondPage = bus.list({ cats: ["plan"], runId: "run-9", afterSeq: latest.seq });
+    const secondPage = bus.list({ cats: ["graph"], runId: "run-9", afterSeq: latest.seq });
     expect(secondPage).to.have.lengthOf(0);
 
-    bus.publish({ cat: "plan", runId: "run-9", msg: "cleanup" });
-    const thirdPage = bus.list({ cats: ["plan"], runId: "run-9", afterSeq: latest.seq });
+    bus.publish({ cat: "graph", runId: "run-9", msg: "cleanup" });
+    const thirdPage = bus.list({ cats: ["graph"], runId: "run-9", afterSeq: latest.seq });
     expect(thirdPage).to.have.lengthOf(1);
-    expect(thirdPage[0].msg).to.equal("cleanup");
+    expect(thirdPage[0]?.msg).to.equal("cleanup");
   });
 });

--- a/tests/events.subscribe.sse-escaping.test.ts
+++ b/tests/events.subscribe.sse-escaping.test.ts
@@ -66,7 +66,7 @@ describe("events subscribe SSE escaping", () => {
         name: "events_subscribe",
         arguments: {
           from_seq: cursor,
-          cats: ["cancel"],
+          cats: ["scheduler"],
           format: "sse",
         },
       });

--- a/tests/graph.tools.op-id.logging.test.ts
+++ b/tests/graph.tools.op-id.logging.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, afterEach, describe, it } from "mocha";
+import { expect } from "chai";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import { server, logJournal } from "../src/server.js";
+import type { GraphDescriptorPayload } from "../src/tools/graphTools.js";
+
+/**
+ * Integration checks ensuring the graph tool MCP handlers log correlation metadata (`op_id`) that matches the
+ * structured results they return. The assertions rely on the shared `logJournal` to observe the JSONL entries emitted by
+ * the orchestrator during a call_tool round-trip.
+ */
+describe("graph tools – op_id logging", () => {
+  const GRAPH: GraphDescriptorPayload = {
+    name: "opid-demo",
+    nodes: [
+      { id: "start", attributes: { duration: 1, cost: 2, risk: 0.4 } },
+      { id: "mid", attributes: { duration: 2, cost: 3, risk: 0.6 } },
+      { id: "goal", attributes: { duration: 1, cost: 1, risk: 0.3 } },
+    ],
+    edges: [
+      { from: "start", to: "mid", attributes: { weight: 1 } },
+      { from: "mid", to: "goal", attributes: { weight: 1 } },
+    ],
+  };
+
+  beforeEach(async () => {
+    logJournal.reset();
+    await server.close().catch(() => {});
+  });
+
+  afterEach(async () => {
+    await logJournal.flush();
+    logJournal.reset();
+    await server.close().catch(() => {});
+  });
+
+  async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "graph-opid-logging", version: "1.0.0-test" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      return await run(client);
+    } finally {
+      await client.close();
+      await server.close().catch(() => {});
+    }
+  }
+
+  async function expectLogWithOpId(message: string, expectedOpId: string): Promise<void> {
+    await logJournal.flush();
+    const { entries } = logJournal.tail({ stream: "server" });
+    const entry = entries.find((item) => item.message === message);
+    expect(entry, `expected a '${message}' log entry`).to.not.be.undefined;
+    expect(entry?.opId).to.equal(expectedOpId);
+    const payload = (entry?.data ?? {}) as Record<string, unknown>;
+    expect(payload.op_id).to.equal(expectedOpId);
+  }
+
+  it("records op_id for graph_paths_constrained logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_paths_constrained",
+        arguments: {
+          graph: GRAPH,
+          from: "start",
+          to: "goal",
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_paths_constrained_completed", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_centrality_betweenness logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_centrality_betweenness",
+        arguments: {
+          graph: GRAPH,
+          weighted: false,
+          top_k: 2,
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_centrality_betweenness_succeeded", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_partition logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_partition",
+        arguments: {
+          graph: GRAPH,
+          k: 2,
+          objective: "community",
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_partition_succeeded", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_critical_path logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_critical_path",
+        arguments: {
+          graph: GRAPH,
+          duration_attribute: "duration",
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_critical_path_succeeded", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_simulate logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_simulate",
+        arguments: {
+          graph: GRAPH,
+          parallelism: 2,
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_simulate_succeeded", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_optimize logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_optimize",
+        arguments: {
+          graph: GRAPH,
+          parallelism: 1,
+          max_parallelism: 2,
+          explore_parallelism: [2],
+          objective: { type: "makespan" },
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_optimize_completed", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_optimize_moo logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_optimize_moo",
+        arguments: {
+          graph: GRAPH,
+          parallelism_candidates: [1, 2],
+          objectives: [
+            { type: "makespan" },
+            { type: "cost", attribute: "cost", default_value: 1 },
+          ],
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_optimize_moo_completed", result.op_id);
+    });
+  });
+
+  it("records op_id for graph_causal_analyze logs", async () => {
+    await withClient(async (client) => {
+      const response = await client.callTool({
+        name: "graph_causal_analyze",
+        arguments: {
+          graph: GRAPH,
+          max_cycles: 5,
+          compute_min_cut: true,
+        },
+      });
+      expect(response.isError ?? false).to.equal(false);
+      const result = response.structuredContent as { op_id: string };
+      expect(result.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
+      await expectLogWithOpId("graph_causal_analyze_completed", result.op_id);
+    });
+  });
+});

--- a/tests/hygiene.fs-gateway.test.ts
+++ b/tests/hygiene.fs-gateway.test.ts
@@ -1,0 +1,170 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect } from 'chai';
+
+/**
+ * Verifies that only vetted gateway modules perform privileged Node.js operations.
+ *
+ * Direct imports of sensitive built-ins such as `node:fs` or `node:child_process`
+ * can easily bypass the sandboxing guarantees provided by {@link src/paths.ts}
+ * or spawn untracked workers. By constraining the surface to curated allow-lists
+ * we ensure future contributors route new operations through the existing helpers
+ * (or explicitly extend the gateway set after a security review). The assertions
+ * keep the lists deterministic to simplify diff reviews and incident response.
+ */
+describe('gateway hygiene', () => {
+  /** Absolute path to the repository root (resolved from the test location). */
+  const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  /** Directory containing the production TypeScript sources to inspect. */
+  const SRC_DIR = path.join(PROJECT_ROOT, 'src');
+
+  /**
+   * Describes an allow-listed gateway rule for a sensitive Node.js builtin module.
+   *
+   * Each rule encapsulates the static and dynamic import patterns that should be
+   * flagged when encountered outside of the curated allow-list.
+   */
+  interface GatewayRule {
+    /** Human-readable description used in assertion error messages. */
+    readonly label: string;
+    /** Regular expression matching ESM/CJS `import` or `require` statements. */
+    readonly staticPattern: RegExp;
+    /** Optional regular expression matching dynamic `import()` expressions. */
+    readonly dynamicPattern?: RegExp;
+    /** Modules (relative to the project root) authorised to use the builtin. */
+    readonly allowList: ReadonlySet<string>;
+  }
+
+  /**
+   * Gateway rules applied to the source tree. Extend this array whenever a new
+   * privileged builtin requires dedicated review and documentation.
+   */
+  const GATEWAY_RULES: readonly GatewayRule[] = [
+    {
+      label: 'node:fs access must stay within audited gateways',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?fs(?:\/promises)?['"]/,
+      dynamicPattern: /import\(['"](?:node:)?fs(?:\/promises)?['"]\)/,
+      allowList: new Set([
+        'src/paths.ts',
+        'src/monitor/log.ts',
+        'src/logger.ts',
+        'src/childRuntime.ts',
+        'src/server.ts',
+        'src/artifacts.ts',
+        'src/tools/planTools.ts',
+        'src/graph/subgraphExtract.ts',
+      ]),
+    },
+    {
+      label: 'node:http/https access is restricted to the server gateway',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?https?['"]/,
+      dynamicPattern: /import\(['"](?:node:)?https?['"]\)/,
+      allowList: new Set([
+        'src/httpServer.ts',
+        'src/monitor/dashboard.ts',
+      ]),
+    },
+    {
+      // Guard against accidental adoption of lower-level networking primitives
+      // that bypass HTTP middlewares. These modules expose raw sockets and can
+      // reintroduce outbound connectivity despite the repository mandate of
+      // offline execution, therefore every new usage must undergo a manual
+      // security review before being added to the allow-list.
+      label: 'node:net sockets require an explicit security review',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?net['"]/,
+      dynamicPattern: /import\(['"](?:node:)?net['"]\)/,
+      allowList: new Set<string>([]),
+    },
+    {
+      // HTTP/2 support is intentionally disabled until we vet the associated
+      // flow-control surface. Restricting imports keeps the transport
+      // deterministic and aligned with the current MCP expectations.
+      label: 'node:http2 usage is disabled pending investigation',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?http2['"]/,
+      dynamicPattern: /import\(['"](?:node:)?http2['"]\)/,
+      allowList: new Set<string>([]),
+    },
+    {
+      label: 'node:child_process spawning is restricted to child runtime gateway',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?child_process['"]/,
+      dynamicPattern: /import\(['"](?:node:)?child_process['"]\)/,
+      allowList: new Set([
+        'src/childRuntime.ts',
+      ]),
+    },
+    {
+      // Worker threads can escape the orchestrator sandbox by executing arbitrary
+      // JavaScript in-process. We currently do not rely on the API in production
+      // code, therefore any import should prompt a dedicated security review
+      // before being allow-listed.
+      label: 'node:worker_threads usage requires an explicit security review',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?worker_threads['"]/,
+      dynamicPattern: /import\(['"](?:node:)?worker_threads['"]\)/,
+      allowList: new Set<string>([]),
+    },
+    {
+      // The `vm` module enables evaluation of user-provided code snippets. While
+      // powerful, it also bypasses the curated toolset and undermines deterministic
+      // replay of child operations. The guard ensures any future adoption is
+      // accompanied by a threat modelling exercise.
+      label: 'node:vm evaluation must remain disabled unless reviewed',
+      staticPattern: /(?:from\s+['"]|require\(['"])(?:node:)?vm['"]/,
+      dynamicPattern: /import\(['"](?:node:)?vm['"]\)/,
+      allowList: new Set<string>([]),
+    },
+  ];
+
+  it('restricts privileged imports to gateway modules', async () => {
+    const filesToInspect = await collectTypeScriptFiles(SRC_DIR);
+    /** Aggregated list of offenders for each gateway rule. */
+    const offendersByRule = new Map<GatewayRule, string[]>(
+      GATEWAY_RULES.map((rule) => [rule, []]),
+    );
+
+    for (const absolutePath of filesToInspect) {
+      const relativePath = path.relative(PROJECT_ROOT, absolutePath).split(path.sep).join('/');
+      const source = await readFile(absolutePath, 'utf8');
+
+      for (const rule of GATEWAY_RULES) {
+        const usesPrivilegedModule =
+          rule.staticPattern.test(source) ||
+          (rule.dynamicPattern?.test(source) ?? false);
+
+        if (usesPrivilegedModule && !rule.allowList.has(relativePath)) {
+          offendersByRule.get(rule)!.push(relativePath);
+        }
+      }
+    }
+
+    for (const [rule, offenders] of offendersByRule) {
+      expect(
+        offenders,
+        `unexpected privileged imports detected (${rule.label})`,
+      ).to.deep.equal([]);
+    }
+  });
+
+  /**
+   * Recursively collects TypeScript source files under the provided directory.
+   *
+   * `.d.ts` declaration files are ignored because they do not contain runtime
+   * imports. Results are sorted to keep the assertion output deterministic.
+   */
+  async function collectTypeScriptFiles(directory: string): Promise<string[]> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const files: string[] = [];
+
+    for (const entry of entries) {
+      const resolved = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await collectTypeScriptFiles(resolved)));
+      } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+        files.push(resolved);
+      }
+    }
+
+    files.sort();
+    return files;
+  }
+});

--- a/tests/idempotency.replay.test.ts
+++ b/tests/idempotency.replay.test.ts
@@ -114,12 +114,15 @@ describe("idempotency cache integrations", () => {
     expect(first.idempotent).to.equal(false);
     expect(second.idempotent).to.equal(true);
     expect(second.child_id).to.equal(first.child_id);
+    expect(first.op_id).to.be.a("string");
+    expect(second.op_id).to.equal(first.op_id);
     expect(createChild.calledOnce).to.equal(true);
 
     clock.tick(1_001);
     const third = await handleChildCreate(context, input);
     expect(third.idempotent).to.equal(false);
     expect(createChild.callCount).to.equal(2);
+    expect(third.op_id).to.not.equal(first.op_id);
   });
 
   it("returns cached plan_run_bt results on retries", async () => {

--- a/tests/paths.sanitization.test.ts
+++ b/tests/paths.sanitization.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, it } from "mocha";
 import { expect } from "chai";
 import path from "node:path";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
 
 import {
   PathResolutionError,
+  resolveWithin,
   resolveChildDir,
   resolveRunDir,
+  resolveWorkspacePath,
   safeJoin,
   sanitizeFilename,
 } from "../src/paths.js";
@@ -31,18 +36,84 @@ describe("paths sanitization", () => {
   it("replaces unsafe characters in filenames", () => {
     const raw = "run:/../weird name?";
     const sanitized = sanitizeFilename(raw);
-    expect(sanitized).to.equal("run__.._weird_name_");
+    expect(sanitized).to.equal("run_weird_name");
+  });
+
+  it("normalises unicode strings before sanitising", () => {
+    const composed = "équipe";
+    const decomposed = "e\u0301quipe";
+
+    // The sanitiser should normalise to NFC which makes both inputs equivalent.
+    expect(sanitizeFilename(decomposed)).to.equal(sanitizeFilename(composed));
+    expect(sanitizeFilename(decomposed)).to.equal("équipe");
+  });
+
+  it("trims filenames that exceed the allowed length", () => {
+    const veryLong = `${"a".repeat(140)}.json`;
+    const sanitized = sanitizeFilename(veryLong);
+
+    expect(sanitized.length).to.equal(120);
+    expect(sanitized.startsWith("a".repeat(120))).to.be.true;
   });
 
   it("forbids directory traversal attempts when joining", () => {
-    expect(() => safeJoin("/tmp/base", "..", "escape"))
-      .to.throw(PathResolutionError)
-      .with.property("attemptedPath");
+    try {
+      safeJoin("/tmp/base", "..", "escape");
+      expect.fail("expected PathResolutionError to be thrown");
+    } catch (error) {
+      expect(error).to.be.instanceOf(PathResolutionError);
+      const resolutionError = error as PathResolutionError;
+      expect(resolutionError.code).to.equal("E-PATHS-ESCAPE");
+      expect(resolutionError.hint).to.equal("keep paths within the configured base directory");
+      expect(resolutionError.details).to.include({ segment: ".." });
+      expect(resolutionError.attemptedPath).to.equal(path.resolve("/tmp/base", ".."));
+      expect(resolutionError.rootDirectory).to.equal(path.resolve("/tmp/base"));
+      expect(resolutionError.message).to.equal("path escapes base directory");
+    }
+  });
+
+  it("surfaces relative diagnostics when resolveWithin escapes the sandbox", () => {
+    const base = path.resolve("/tmp/base");
+    const escape = path.resolve(base, "..", "outside");
+    try {
+      resolveWithin(base, "..", "outside");
+      expect.fail("expected PathResolutionError to be thrown");
+    } catch (error) {
+      expect(error).to.be.instanceOf(PathResolutionError);
+      const resolutionError = error as PathResolutionError;
+      expect(resolutionError.code).to.equal("E-PATHS-ESCAPE");
+      expect(resolutionError.details.relative).to.equal(path.relative(base, escape));
+      expect(resolutionError.attemptedPath).to.equal(escape);
+      expect(resolutionError.rootDirectory).to.equal(base);
+    }
   });
 
   it("normalises intermediate segments when joining", () => {
     const joined = safeJoin("/tmp/base", " child ", "logs", "file.txt");
     expect(joined).to.equal(path.resolve("/tmp/base", "child", "logs", "file.txt"));
+  });
+
+  it("resolves workspace paths relative to the current working directory", () => {
+    const resolved = resolveWorkspacePath("snapshots/graph.json");
+    expect(resolved).to.equal(path.resolve(process.cwd(), "snapshots", "graph.json"));
+  });
+
+  it("rejects empty workspace paths", () => {
+    expect(() => resolveWorkspacePath("   ")).to.throw(PathResolutionError).that.satisfies((error: unknown) => {
+      const resolutionError = error as PathResolutionError;
+      expect(resolutionError.code).to.equal("E-PATHS-ESCAPE");
+      expect(resolutionError.message).to.equal("path must not be empty");
+      return true;
+    });
+  });
+
+  it("forbids traversal when resolving workspace paths", () => {
+    expect(() => resolveWorkspacePath("../outside.txt")).to.throw(PathResolutionError).that.satisfies((error: unknown) => {
+      const resolutionError = error as PathResolutionError;
+      expect(resolutionError.code).to.equal("E-PATHS-ESCAPE");
+      expect(resolutionError.details.segment).to.equal("..");
+      return true;
+    });
   });
 
   it("resolves run directories relative to the configured root", () => {
@@ -55,5 +126,21 @@ describe("paths sanitization", () => {
     process.env.MCP_CHILDREN_ROOT = "var/work/children";
     const dir = resolveChildDir("child-01");
     expect(dir).to.equal(path.resolve(process.cwd(), "var/work/children", "child-01"));
+  });
+
+  it("creates run and child directories when missing", async () => {
+    const sandboxRoot = await mkdtemp(path.join(tmpdir(), "paths-test-"));
+    process.env.MCP_RUNS_ROOT = path.join(sandboxRoot, "runs");
+    process.env.MCP_CHILDREN_ROOT = path.join(sandboxRoot, "children");
+
+    const runDir = resolveRunDir(`run-${randomUUID()}`);
+    const childDir = resolveChildDir(`child-${randomUUID()}`);
+
+    try {
+      await access(runDir);
+      await access(childDir);
+    } finally {
+      await rm(sandboxRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/perf/paths.micro-bench.ts
+++ b/tests/perf/paths.micro-bench.ts
@@ -1,0 +1,106 @@
+import { performance } from "node:perf_hooks";
+import path from "node:path";
+
+import { safeJoin, sanitizeFilename } from "../../src/paths.js";
+
+/**
+ * Target average execution time per invocation (in milliseconds) for the
+ * filesystem hygiene helpers. The checklist requirement specifies that both
+ * helpers should stay below 5ms on a developer workstation.
+ */
+const TARGET_MS = 5;
+
+/**
+ * Number of iterations executed for each benchmark. A higher iteration count
+ * lowers the influence of the event loop jitter while still keeping the
+ * overall runtime well under a second on the reference hardware.
+ */
+const ITERATIONS = 50_000;
+
+interface BenchSample {
+  readonly label: string;
+  readonly averageMs: number;
+}
+
+/**
+ * Runs a benchmark for the provided callback and returns the average runtime
+ * in milliseconds. The callback receives the iteration index so it can vary
+ * its inputs and avoid JIT over-optimisations that would not occur in real
+ * workloads.
+ */
+function runBenchmark(label: string, callback: (iteration: number) => void): BenchSample {
+  const start = performance.now();
+  for (let iteration = 0; iteration < ITERATIONS; iteration += 1) {
+    callback(iteration);
+  }
+  const end = performance.now();
+  const totalMs = end - start;
+  const averageMs = totalMs / ITERATIONS;
+  return { label, averageMs };
+}
+
+/**
+ * Formats the benchmark samples as a human readable table that developers can
+ * copy into performance notes when running the micro-bench locally.
+ */
+function formatSamples(samples: BenchSample[]): string {
+  const header = "| benchmark | average (ms) | target (ms) |\n|-----------|--------------|-------------|";
+  const rows = samples.map((sample) => {
+    return `| ${sample.label} | ${sample.averageMs.toFixed(4)} | ${TARGET_MS.toFixed(2)} |`;
+  });
+  return [header, ...rows].join("\n");
+}
+
+/**
+ * Ensures the benchmark results stay within the target bound. Throwing keeps
+ * the script honest when called from CI or a pre-commit hook even though it is
+ * primarily intended for manual execution.
+ */
+function assertWithinTarget(sample: BenchSample): void {
+  if (sample.averageMs > TARGET_MS) {
+    throw new Error(
+      `${sample.label} average ${sample.averageMs.toFixed(4)}ms exceeds target ${TARGET_MS.toFixed(2)}ms`,
+    );
+  }
+}
+
+/**
+ * Executes the benchmarks when the file is run directly via tsx or ts-node.
+ * The samples cover the sanitiser and the safe join helper using realistic
+ * inputs that mimic common agent workloads.
+ */
+async function main(): Promise<void> {
+  const samples: BenchSample[] = [];
+
+  samples.push(
+    runBenchmark("sanitizeFilename", (iteration) => {
+      const suffix = iteration.toString(16);
+      // The input injects characters that must be stripped as well as unicode
+      // normalisation, mirroring worst-case prompts produced by child agents.
+      sanitizeFilename(`../rùn-${suffix}\u0000.json`);
+    }),
+  );
+
+  const baseDir = path.resolve(process.cwd(), "runs");
+  samples.push(
+    runBenchmark("safeJoin", (iteration) => {
+      const child = `child-${iteration % 100}`;
+      // Mixing whitespace and traversal attempts matches the sanitisation
+      // scenarios covered by the unit suite.
+      safeJoin(baseDir, " ../", child, "logs", `${iteration}.json`);
+    }),
+  );
+
+  for (const sample of samples) {
+    assertWithinTarget(sample);
+  }
+
+  // eslint-disable-next-line no-console -- developer feedback for manual runs.
+  console.log(formatSamples(samples));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void main();
+}
+
+export { main as runPathsBench, TARGET_MS };

--- a/tests/perf/scheduler.bench.ts
+++ b/tests/perf/scheduler.bench.ts
@@ -1,5 +1,14 @@
+import { performance } from "node:perf_hooks";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { BehaviorTreeInterpreter } from "../../src/executor/bt/interpreter.js";
+import {
+  ReactiveScheduler,
+  type SchedulerEventName,
+  type TaskReadyEvent,
+} from "../../src/executor/reactiveScheduler.js";
+import { ManualClock, ScriptedNode } from "../helpers/reactiveSchedulerTestUtils.js";
 
 import {
   DEFAULT_SCHEDULER_BENCH_CONFIG,
@@ -7,6 +16,221 @@ import {
   type SchedulerBenchConfig,
   type SchedulerBenchResult,
 } from "./scheduler.micro-bench.js";
+
+/**
+ * Target average runtime (ms) expected for each fairness/stigmergy micro-bench
+ * invocation. This threshold mirrors the checklist requirement which mandates a
+ * <8ms bound on the scheduler heuristics when executed locally.
+ */
+const FAIRNESS_TARGET_MS = 8;
+
+/** Number of iterations executed for each fairness micro-benchmark scenario. */
+const FAIRNESS_ITERATIONS = 50_000;
+
+/**
+ * Internal structure exposing the scheduler queue for benchmarking purposes.
+ * The shape mirrors the runtime {@link ScheduledTick} structure but only keeps
+ * the fields required for the fairness and pheromone tests.
+ */
+interface SchedulerInternals {
+  readonly queue: Array<{
+    id: number;
+    event: SchedulerEventName;
+    payload: TaskReadyEvent;
+    enqueuedAt: number;
+    basePriority: number;
+    causalEventId?: string | null;
+  }>;
+  readonly computeBasePriority: (
+    event: SchedulerEventName,
+    payload: TaskReadyEvent,
+  ) => number;
+  readonly selectNextIndex: (now: number) => number;
+  readonly rebalancePheromone: (nodeId: string, intensity: number) => void;
+}
+
+/** Sample captured by the fairness bench, storing the average runtime. */
+export interface SchedulerFairnessSample {
+  readonly label: string;
+  readonly averageMs: number;
+}
+
+/**
+ * Benchmark helper that executes the provided callback a fixed number of times
+ * and returns its average runtime. The iteration index is forwarded so callers
+ * can vary their inputs and avoid JIT shortcuts that would not occur in real
+ * workloads.
+ */
+function runFairnessBenchmark(label: string, callback: (iteration: number) => void): SchedulerFairnessSample {
+  const start = performance.now();
+  for (let iteration = 0; iteration < FAIRNESS_ITERATIONS; iteration += 1) {
+    callback(iteration);
+  }
+  const end = performance.now();
+  return { label, averageMs: (end - start) / FAIRNESS_ITERATIONS };
+}
+
+/** Formats fairness samples into a Markdown table ready to paste in notes. */
+export function renderSchedulerFairnessSamples(samples: SchedulerFairnessSample[]): string {
+  const header = "| benchmark | average (ms) | target (ms) |\n|-----------|--------------|-------------|";
+  const rows = samples.map((sample) => {
+    return `| ${sample.label} | ${sample.averageMs.toFixed(4)} | ${FAIRNESS_TARGET_MS.toFixed(2)} |`;
+  });
+  return [header, ...rows].join("\n");
+}
+
+/**
+ * Ensures micro-benchmark samples stay within the acceptable threshold. Throwing
+ * keeps the script honest when executed in CI even though it primarily targets
+ * local performance checks.
+ */
+function assertFairnessSample(sample: SchedulerFairnessSample): void {
+  if (sample.averageMs > FAIRNESS_TARGET_MS) {
+    throw new Error(
+      `${sample.label} average ${sample.averageMs.toFixed(4)}ms exceeds target ${FAIRNESS_TARGET_MS.toFixed(2)}ms`,
+    );
+  }
+}
+
+/**
+ * Builds a scheduler wired to a manual clock so the fairness bench can age
+ * entries deterministically without relying on real timers.
+ */
+function createSchedulerForFairness(): {
+  scheduler: ReactiveScheduler;
+  clock: ManualClock;
+  internals: SchedulerInternals;
+} {
+  const clock = new ManualClock();
+  const scripted = new ScriptedNode("bench", Array.from({ length: 4 }, () => ({ status: "running" as const })));
+  const interpreter = new BehaviorTreeInterpreter(scripted);
+  const scheduler = new ReactiveScheduler({
+    interpreter,
+    runtime: {
+      invokeTool: async () => undefined,
+      now: () => clock.now(),
+      wait: (ms) => clock.wait(ms),
+      variables: {},
+    },
+    now: () => clock.now(),
+    ageWeight: 0.01,
+    agingHalfLifeMs: 250,
+    agingFairnessBoost: 40,
+    getPheromoneIntensity: () => 6,
+    getPheromoneBounds: () => ({
+      minIntensity: 0,
+      maxIntensity: 12,
+      normalisationCeiling: 8,
+    }),
+  });
+
+  return { scheduler, clock, internals: scheduler as unknown as SchedulerInternals };
+}
+
+/**
+ * Seeds the scheduler queue with diverse entries so {@link selectNextIndex}
+ * exercises both the base priority and fairness boost branches.
+ */
+function seedQueueForFairness(internals: SchedulerInternals, baseTimestamp: number): void {
+  const queue = internals.queue;
+  queue.length = 0;
+  const nodes = ["alpha", "beta", "gamma", "delta"] as const;
+  for (let index = 0; index < 256; index += 1) {
+    const payload: TaskReadyEvent = {
+      nodeId: nodes[index % nodes.length]!,
+      criticality: index % 5,
+      pheromone: (index % 7) + 1,
+      pheromoneBounds: {
+        minIntensity: 0,
+        maxIntensity: 10,
+        normalisationCeiling: 6,
+      },
+    };
+    queue.push({
+      id: index,
+      event: "taskReady",
+      payload,
+      enqueuedAt: baseTimestamp - index * 5,
+      basePriority: internals.computeBasePriority("taskReady", payload),
+      causalEventId: null,
+    });
+  }
+}
+
+/**
+ * Seeds the queue with clustered node identifiers so pheromone rebalancing runs
+ * through multiple entries while exercising the bounds snapshotting path.
+ */
+function seedQueueForPheromone(internals: SchedulerInternals, baseTimestamp: number): string[] {
+  const queue = internals.queue;
+  queue.length = 0;
+  const nodeIds: string[] = [];
+  for (let index = 0; index < 96; index += 1) {
+    const nodeId = `worker-${index % 12}`;
+    if (!nodeIds.includes(nodeId)) {
+      nodeIds.push(nodeId);
+    }
+    const payload: TaskReadyEvent = {
+      nodeId,
+      criticality: 2,
+      pheromone: 4,
+      pheromoneBounds: {
+        minIntensity: 0,
+        maxIntensity: 12,
+        normalisationCeiling: 8,
+      },
+    };
+    queue.push({
+      id: index,
+      event: "taskReady",
+      payload,
+      enqueuedAt: baseTimestamp - index * 3,
+      basePriority: internals.computeBasePriority("taskReady", payload),
+      causalEventId: null,
+    });
+  }
+  return nodeIds;
+}
+
+/**
+ * Executes the fairness micro-benchmarks and returns their aggregated samples.
+ */
+export function runSchedulerFairnessBench(): SchedulerFairnessSample[] {
+  const samples: SchedulerFairnessSample[] = [];
+
+  {
+    const { internals, clock } = createSchedulerForFairness();
+    const baseTime = 10_000;
+    clock.advanceTo(baseTime);
+    seedQueueForFairness(internals, baseTime);
+    samples.push(
+      runFairnessBenchmark("selectNextIndex aging", (iteration) => {
+        const now = baseTime + (iteration % 1024);
+        const selectedIndex = internals.selectNextIndex(now);
+        if (selectedIndex < 0 || selectedIndex >= internals.queue.length) {
+          throw new Error(`invalid index ${selectedIndex}`);
+        }
+      }),
+    );
+  }
+
+  {
+    const { internals, clock } = createSchedulerForFairness();
+    const baseTime = 50_000;
+    clock.advanceTo(baseTime);
+    const hotNodes = seedQueueForPheromone(internals, baseTime);
+    samples.push(
+      runFairnessBenchmark("rebalancePheromone", (iteration) => {
+        const nodeId = hotNodes[iteration % hotNodes.length]!;
+        const intensity = (iteration % 20) + 1;
+        internals.rebalancePheromone(nodeId, intensity);
+      }),
+    );
+  }
+
+  return samples;
+}
+
 
 /**
  * Comparison between baseline and stigmergic scheduler runs. The delta captures
@@ -98,6 +322,16 @@ async function main(): Promise<void> {
   const currentFile = fileURLToPath(import.meta.url);
   const invokedFile = process.argv[1] ? resolve(process.argv[1]) : null;
   if (!invokedFile || currentFile !== invokedFile) {
+    return;
+  }
+
+  if (process.env.SCHED_BENCH_MODE === "fairness") {
+    const samples = runSchedulerFairnessBench();
+    for (const sample of samples) {
+      assertFairnessSample(sample);
+    }
+    // eslint-disable-next-line no-console -- CLI utility intended for local runs.
+    console.log(renderSchedulerFairnessSamples(samples));
     return;
   }
 

--- a/tests/perf/scheduler.bench.unit.test.ts
+++ b/tests/perf/scheduler.bench.unit.test.ts
@@ -6,6 +6,8 @@ import {
   parseSchedulerBenchConfigFromEnv,
   renderSchedulerBenchmarkTable,
   compareSchedulerBenchmarks,
+  renderSchedulerFairnessSamples,
+  runSchedulerFairnessBench,
 } from "./scheduler.bench.js";
 import {
   DEFAULT_SCHEDULER_BENCH_CONFIG,
@@ -133,6 +135,23 @@ describe("scheduler benchmark utilities", () => {
       expect(comparison.relativeAverageImprovementPct).to.be.closeTo(expectedRelative, 1e-6);
       expect(comparison.baseline.tracesCaptured).to.be.greaterThan(0);
       expect(comparison.stigmergy.tracesCaptured).to.be.greaterThan(0);
+    });
+  });
+
+  describe("runSchedulerFairnessBench", () => {
+    it("produces stable samples under the 8ms threshold", () => {
+      const samples = runSchedulerFairnessBench();
+
+      expect(samples).to.have.lengthOf(2);
+      for (const sample of samples) {
+        expect(sample.averageMs).to.be.a("number");
+        expect(sample.averageMs).to.be.greaterThan(0);
+        expect(sample.averageMs).to.be.lessThan(8);
+      }
+
+      const table = renderSchedulerFairnessSamples(samples);
+      expect(table).to.match(/\| benchmark \| average \(ms\) \| target \(ms\) \|/);
+      expect(table.split("\n")).to.have.lengthOf(4);
     });
   });
 });

--- a/tests/plan.concurrency.cancellation.test.ts
+++ b/tests/plan.concurrency.cancellation.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import {
+  registerCancellation,
+  requestCancellation,
+  resetCancellationRegistry,
+  OperationCancelledError,
+} from "../src/executor/cancel.js";
+import { __testing as planTesting } from "../src/tools/planTools.js";
+
+/**
+ * Ensures the concurrency helper observes cancellation signals before and after
+ * awaited work so long-running fan-out operations react promptly to abort
+ * requests.
+ */
+describe("plan tools cancellation-aware concurrency", () => {
+  beforeEach(() => {
+    resetCancellationRegistry();
+  });
+
+  it("throws before scheduling tasks when the operation is already cancelled", async () => {
+    const handle = registerCancellation("op-cancel-before", {});
+    let executed = false;
+    const tasks = [async () => {
+      executed = true;
+      return "executed";
+    }];
+
+    requestCancellation("op-cancel-before", { reason: "preflight" });
+
+    try {
+      await planTesting.runWithConcurrency(1, tasks, { cancellation: handle });
+      expect.fail("runWithConcurrency should throw once cancellation is detected");
+    } catch (error) {
+      expect(error).to.be.instanceOf(OperationCancelledError);
+      expect((error as OperationCancelledError).details.opId).to.equal("op-cancel-before");
+    }
+
+    expect(executed).to.equal(false, "tasks should not execute after pre-cancellation");
+  });
+
+  it("stops scheduling additional tasks after a mid-flight cancellation", async () => {
+    const handle = registerCancellation("op-cancel-mid", {});
+    const executed: string[] = [];
+    const tasks = [
+      async () => {
+        executed.push("first");
+        requestCancellation("op-cancel-mid", { reason: "mid-flight" });
+        return "first";
+      },
+      async () => {
+        executed.push("second");
+        return "second";
+      },
+    ];
+
+    try {
+      await planTesting.runWithConcurrency(1, tasks, { cancellation: handle });
+      expect.fail("runWithConcurrency should propagate OperationCancelledError");
+    } catch (error) {
+      expect(error).to.be.instanceOf(OperationCancelledError);
+      expect((error as OperationCancelledError).details.reason).to.equal("mid-flight");
+    }
+
+    expect(executed).to.deep.equal(["first"], "subsequent tasks must not start after cancellation");
+  });
+});

--- a/tests/plan.fanout-join.test.ts
+++ b/tests/plan.fanout-join.test.ts
@@ -298,7 +298,7 @@ describe("plan tools", () => {
       child_id: "plan-join-reduce-parent",
     } as const;
 
-    await handlePlanJoin(
+    const joinResult = await handlePlanJoin(
       context,
       PlanJoinInputSchema.parse({
         children: ["child-correlation"],
@@ -307,6 +307,7 @@ describe("plan tools", () => {
         ...hints,
       }),
     );
+    expect(joinResult.op_id).to.equal(hints.op_id);
 
     const statusEvent = events.find((event) => event.kind === "STATUS");
     expect(statusEvent, "status event should be recorded").to.not.equal(undefined);
@@ -326,7 +327,7 @@ describe("plan tools", () => {
     expect(statusPayload.node_id).to.equal(hints.node_id);
     expect(statusPayload.child_id).to.equal(hints.child_id);
 
-    await handlePlanReduce(
+    const reduceResult = await handlePlanReduce(
       context,
       PlanReduceInputSchema.parse({
         children: ["child-correlation"],
@@ -335,6 +336,7 @@ describe("plan tools", () => {
         ...hints,
       }),
     );
+    expect(reduceResult.op_id).to.equal(hints.op_id);
 
     const aggregateEvent = events.find((event) => event.kind === "AGGREGATE");
     expect(aggregateEvent, "aggregate event should be recorded").to.not.equal(undefined);
@@ -402,6 +404,8 @@ describe("plan tools", () => {
           timeout_sec: 2,
         }),
       );
+      expect(joinAll.op_id).to.be.a("string");
+      expect(joinAll.op_id).to.match(/^plan_join_op_/);
       expect(joinAll.satisfied, JSON.stringify(joinAll)).to.equal(true);
       expect(joinAll.success_count).to.equal(3);
       for (const entry of joinAll.results) {
@@ -451,6 +455,7 @@ describe("plan tools", () => {
           timeout_sec: 2,
         }),
       );
+      expect(joinFirst.op_id).to.be.a("string");
       expect(joinFirst.satisfied, JSON.stringify(joinFirst)).to.equal(true);
       expect(joinFirst.winning_child_id).to.be.a("string");
       expect(fanout.child_ids).to.include(joinFirst.winning_child_id);
@@ -499,6 +504,7 @@ describe("plan tools", () => {
           reducer: "concat",
         }),
       );
+      expect(reduceConcat.op_id).to.be.a("string");
       expect(reduceConcat.aggregate).to.be.a("string");
       expect(reduceConcat.trace.per_child).to.have.length(3);
 
@@ -509,6 +515,7 @@ describe("plan tools", () => {
           reducer: "merge_json",
         }),
       );
+      expect(reduceMerge.op_id).to.be.a("string");
       expect(reduceMerge.reducer).to.equal("merge_json");
       expect(reduceMerge.aggregate).to.have.property("vote");
       expect(reduceMerge.trace.per_child).to.have.length(3);
@@ -520,6 +527,7 @@ describe("plan tools", () => {
           reducer: "vote",
         }),
       );
+      expect(reduceVote.op_id).to.be.a("string");
       expect(reduceVote.reducer).to.equal("vote");
       expect(reduceVote.trace.details).to.have.property("consensus");
       const consensusDetails = reduceVote.trace.details?.consensus as
@@ -618,6 +626,7 @@ describe("plan tools", () => {
           timeout_sec: 1,
         }),
       );
+      expect(join.op_id).to.be.a("string");
 
       expect(join.policy).to.equal("quorum");
       expect(join.quorum_threshold).to.equal(2);

--- a/tests/plan.join.vote.integration.test.ts
+++ b/tests/plan.join.vote.integration.test.ts
@@ -113,6 +113,7 @@ describe("plan_join consensus integration", () => {
     });
 
     const joinResult = await handlePlanJoin(context, joinInput);
+    expect(joinResult.op_id).to.match(/^plan_join_op_/);
     expect(joinResult.satisfied).to.equal(true);
     expect(joinResult.quorum_threshold).to.equal(3);
     expect(joinResult.consensus?.outcome).to.equal("success");
@@ -133,6 +134,7 @@ describe("plan_join consensus integration", () => {
     });
 
     const reduceResult = await handlePlanReduce(context, reduceInput);
+    expect(reduceResult.op_id).to.match(/^plan_reduce_op_/);
     expect(reduceResult.aggregate).to.deep.equal({
       mode: "weighted",
       value: "approve",

--- a/tests/plan.reduce.test.ts
+++ b/tests/plan.reduce.test.ts
@@ -104,6 +104,7 @@ describe("plan_reduce tool", () => {
           reducer: "concat",
         }),
       );
+      expect(reduceResult.op_id).to.match(/^plan_reduce_op_/);
 
       expect(reduceResult.aggregate).to.equal(expected.join("\n\n"));
       expect(reduceResult.trace.per_child).to.have.length(expected.length);
@@ -160,6 +161,7 @@ describe("plan_reduce tool", () => {
           reducer: "merge_json",
         }),
       );
+      expect(reduceResult.op_id).to.match(/^plan_reduce_op_/);
 
       expect(reduceResult.aggregate).to.deep.equal({ feature: "beta", score: 1 });
       expect(reduceResult.trace.per_child).to.have.length(3);
@@ -215,6 +217,7 @@ describe("plan_reduce tool", () => {
           reducer: "vote",
         }),
       );
+      expect(reduceResult.op_id).to.match(/^plan_reduce_op_/);
 
       expect(reduceResult.aggregate).to.deep.equal({
         mode: "majority",

--- a/tests/server.tools.errors.test.ts
+++ b/tests/server.tools.errors.test.ts
@@ -192,13 +192,14 @@ describe("server tool error codes", () => {
     }
     const response = formatPlanToolError(createLogger(), "plan_fanout", result.error);
     const payload = JSON.parse(response.content[0].text);
+    expect(payload.ok).to.equal(false);
     expect(payload.error).to.equal("E-PLAN-INVALID-INPUT");
     expect(payload.hint).to.equal("invalid_input");
     expect(payload.tool).to.equal("plan_fanout");
     expect(payload).to.have.property("details");
   });
 
-  it("wraps missing child errors with E-CHILD-NOT-FOUND", () => {
+  it("wraps missing child errors with E-CHILD-NOTFOUND", () => {
     const response = formatChildToolError(
       createLogger(),
       "child_status",
@@ -206,7 +207,8 @@ describe("server tool error codes", () => {
       { child_id: "ghost" },
     );
     const payload = JSON.parse(response.content[0].text);
-    expect(payload.error).to.equal("E-CHILD-NOT-FOUND");
+    expect(payload.ok).to.equal(false);
+    expect(payload.error).to.equal("E-CHILD-NOTFOUND");
     expect(payload.hint).to.equal("unknown_child");
     expect(payload.details).to.deep.equal({ child_id: "ghost" });
   });
@@ -220,6 +222,7 @@ describe("server tool error codes", () => {
       { defaultCode: "E-PATCH-APPLY", invalidInputCode: "E-PATCH-INVALID" },
     );
     const payload = JSON.parse(response.content[0].text);
+    expect(payload.ok).to.equal(false);
     expect(payload.error).to.equal("E-PATCH-APPLY");
     expect(payload.tool).to.equal("graph_patch");
   });
@@ -227,6 +230,7 @@ describe("server tool error codes", () => {
   it("wraps value guard errors with E-VALUES-UNEXPECTED", () => {
     const response = formatValueToolError(createLogger(), "values_score", new Error("denied"));
     const payload = JSON.parse(response.content[0].text);
+    expect(payload.ok).to.equal(false);
     expect(payload.error).to.equal("E-VALUES-UNEXPECTED");
   });
 
@@ -237,6 +241,7 @@ describe("server tool error codes", () => {
       new z.ZodError([]),
     );
     const payload = JSON.parse(response.content[0].text);
+    expect(payload.ok).to.equal(false);
     expect(payload.error).to.equal("E-RES-INVALID-INPUT");
     expect(payload.hint).to.equal("invalid_input");
   });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,144 @@
+/**
+ * Mocha bootstrap that enforces the hygiene guarantees mandated by the
+ * repository checklist:
+ *
+ * 1. All sources of pseudo-randomness must be seeded deterministically so that
+ *    flaky behaviour caused by different RNG sequences is eliminated.  We
+ *    replace `Math.random` with a lightweight linear congruential generator
+ *    whose seed is derived from the `TEST_RANDOM_SEED` environment variable (or
+ *    a stable default).  The implementation follows the Park–Miller LCG
+ *    (modulus 2^31-1, multiplier 48271) which has well-documented statistical
+ *    properties and is sufficient for predictable test runs.
+ *
+ * 2. Any attempt to reach the network layer must fail fast.  Tests are
+ *    required to stay hermetic, so we patch the low-level connection factories
+ *    (`http.Agent#createConnection`, `https.Agent#createConnection`,
+ *    `net.Socket#connect`, `tls.TLSSocket#connect`) and the WHATWG `fetch` API
+ *    to throw a clear `E-NETWORK-BLOCKED` error that explains why the access is
+ *    denied.  The
+ *    original implementations are restored once the Mocha process finishes so
+ *    developers can keep using the runtime normally outside of the test suite.
+ */
+
+import { after } from "mocha";
+import { Agent as HttpAgent } from "node:http";
+import { Agent as HttpsAgent } from "node:https";
+import { Socket } from "node:net";
+import { TLSSocket } from "node:tls";
+
+type RestoreHook = () => void;
+
+const restores: RestoreHook[] = [];
+
+/**
+ * Public token mirroring the default deterministic seed.  Exported so unit
+ * tests can validate reproducibility without duplicating environment logic.
+ */
+export const DEFAULT_TEST_RANDOM_SEED =
+  process.env.TEST_RANDOM_SEED ?? "self-codex::tests";
+
+/**
+ * Computes a strictly positive 31-bit seed from the provided token by folding
+ * the string with a simple polynomial rolling hash.  The modulus mirrors the
+ * Park–Miller generator to guarantee the resulting state remains inside the
+ * expected range even for long input strings.
+ */
+function deriveSeed(token: string): number {
+  let hash = 0;
+  for (let index = 0; index < token.length; index += 1) {
+    hash = (hash * 31 + token.charCodeAt(index)) % 2147483647;
+  }
+  // The LCG expects a non-zero seed.  Fall back to 1 when the hash collapses
+  // to zero (for example when `token` is an empty string).
+  return hash === 0 ? 1 : hash;
+}
+
+/**
+ * Installs the deterministic RNG and registers a restoration hook so we do not
+ * leak the patched implementation outside the test lifecycle.
+ */
+export function createDeterministicRandom(seedToken = DEFAULT_TEST_RANDOM_SEED) {
+  const modulus = 2147483647; // 2^31 - 1
+  const multiplier = 48271; // Park–Miller recommended multiplier
+  let state = deriveSeed(seedToken);
+
+  return () => {
+    state = (state * multiplier) % modulus;
+    return (state - 1) / (modulus - 1);
+  };
+}
+
+function installDeterministicRandom(): void {
+  const originalRandom = Math.random;
+  const prng = createDeterministicRandom(DEFAULT_TEST_RANDOM_SEED);
+
+  Math.random = () => prng();
+
+  restores.push(() => {
+    Math.random = originalRandom;
+  });
+}
+
+/**
+ * Utility that replaces a network primitive by a throwing shim explaining that
+ * outbound access is forbidden inside the tests.  The shim preserves the
+ * synchronous/asynchronous nature of the original function by always throwing
+ * synchronously which causes immediate rejection for Promise-returning APIs
+ * such as `fetch`.
+ */
+function blockFunction<T extends (...args: any[]) => any>(
+  target: { [key: string]: unknown },
+  name: string,
+  moduleName: string,
+): void {
+  const original = target[name] as T;
+  const blocker: T = ((..._args: unknown[]) => {
+    const error = new Error(
+      `network access via ${moduleName}.${name} is disabled during tests`,
+    ) as NodeJS.ErrnoException;
+    error.code = "E-NETWORK-BLOCKED";
+    throw error;
+  }) as T;
+
+  target[name] = blocker;
+  restores.push(() => {
+    target[name] = original;
+  });
+}
+
+/**
+ * Installs the network guards across Node's classic HTTP clients and the
+ * WHATWG `fetch` API.
+ */
+function installNetworkGuards(): void {
+  blockFunction(HttpAgent.prototype as Record<string, unknown>, "createConnection", "http.Agent#");
+  blockFunction(HttpsAgent.prototype as Record<string, unknown>, "createConnection", "https.Agent#");
+  blockFunction(Socket.prototype as Record<string, unknown>, "connect", "net.Socket#");
+  blockFunction(TLSSocket.prototype as Record<string, unknown>, "connect", "tls.TLSSocket#");
+
+  if (typeof globalThis.fetch === "function") {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = ((..._args: Parameters<typeof fetch>) => {
+      const error = new Error(
+        "network access via fetch is disabled during tests",
+      ) as NodeJS.ErrnoException;
+      error.code = "E-NETWORK-BLOCKED";
+      return Promise.reject(error);
+    }) as typeof fetch;
+
+    restores.push(() => {
+      globalThis.fetch = originalFetch;
+    });
+  }
+}
+
+installDeterministicRandom();
+installNetworkGuards();
+
+after(() => {
+  while (restores.length > 0) {
+    const restore = restores.pop();
+    restore?.();
+  }
+});
+

--- a/tests/stdio.contract.test.ts
+++ b/tests/stdio.contract.test.ts
@@ -56,9 +56,11 @@ describe("STDIO JSON-RPC contract", () => {
       expect(response.structuredContent).to.not.be.undefined;
 
       const structured = response.structuredContent as {
+        op_id: string;
         metrics: { makespan: number };
         schedule: Array<{ node_id: string }>;
       };
+      expect(structured.op_id).to.be.a("string").and.to.have.length.greaterThan(0);
       expect(structured.metrics.makespan).to.equal(4);
       expect(structured.schedule.map((entry) => entry.node_id)).to.deep.equal([
         "ingest",

--- a/tests/test.hygiene.seed-network.test.ts
+++ b/tests/test.hygiene.seed-network.test.ts
@@ -1,0 +1,54 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import * as http from "node:http";
+import * as https from "node:https";
+import {
+  createDeterministicRandom,
+  DEFAULT_TEST_RANDOM_SEED,
+} from "./setup";
+
+/**
+ * These regression tests validate the guarantees provided by `tests/setup.ts`:
+ * deterministic randomness and blocked outbound networking.
+ */
+describe("test hygiene guards", () => {
+  it("produces deterministic sequences for identical seeds", () => {
+    const generatorA = createDeterministicRandom(DEFAULT_TEST_RANDOM_SEED);
+    const generatorB = createDeterministicRandom(DEFAULT_TEST_RANDOM_SEED);
+
+    const sequenceA = [generatorA(), generatorA(), generatorA()];
+    const sequenceB = [generatorB(), generatorB(), generatorB()];
+
+    expect(sequenceA).to.deep.equal(sequenceB);
+    expect(sequenceA[0]).to.be.closeTo(0.7463903471328228, 1e-12);
+    expect(sequenceA[1]).to.be.closeTo(0.008452148650262644, 1e-12);
+    expect(sequenceA[2]).to.be.closeTo(0.9936897847742678, 1e-12);
+  });
+
+  it("produces distinct sequences for different seeds", () => {
+    const generatorDefault = createDeterministicRandom(DEFAULT_TEST_RANDOM_SEED);
+    const generatorAlt = createDeterministicRandom("alternative-seed");
+
+    const defaultSequence = [
+      generatorDefault(),
+      generatorDefault(),
+      generatorDefault(),
+    ];
+    const altSequence = [generatorAlt(), generatorAlt(), generatorAlt()];
+
+    expect(defaultSequence).to.not.deep.equal(altSequence);
+  });
+
+  it("rejects accidental http requests", () => {
+    expect(() => http.request("http://example.com"))
+      .to.throw(Error)
+      .with.property("code", "E-NETWORK-BLOCKED");
+  });
+
+  it("rejects accidental https requests", () => {
+    expect(() => https.request("https://example.com"))
+      .to.throw(Error)
+      .with.property("code", "E-NETWORK-BLOCKED");
+  });
+});
+

--- a/tests/types.errors-shape.test.ts
+++ b/tests/types.errors-shape.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+
+import { ERROR_CATALOG, ERROR_CODES, fail } from "../src/types.js";
+
+describe("types error catalogue", () => {
+  it("exposes the mandated error families", () => {
+    const families = Object.keys(ERROR_CATALOG);
+    expect(families).to.include.members([
+      "MCP",
+      "RES",
+      "EVT",
+      "CANCEL",
+      "BULK",
+      "TX",
+      "LOCK",
+      "PATCH",
+      "PLAN",
+      "CHILD",
+      "VALUES",
+      "ASSIST",
+    ]);
+  });
+
+  it("keeps codes aligned with their family prefix", () => {
+    for (const [family, codes] of Object.entries(ERROR_CATALOG)) {
+      for (const code of Object.values(codes)) {
+        expect(code.startsWith(`E-${family}-`)).to.equal(
+          true,
+          `${code} should start with E-${family}-`,
+        );
+      }
+    }
+  });
+
+  it("flattens the catalogue without losing any entry", () => {
+    const catalogCodes = new Set(
+      Object.values(ERROR_CATALOG).flatMap((family) => Object.values(family)),
+    );
+    const flattenedCodes = new Set(Object.values(ERROR_CODES));
+
+    expect(Object.isFrozen(ERROR_CODES)).to.be.true;
+    expect(flattenedCodes.size).to.equal(catalogCodes.size);
+    for (const code of catalogCodes) {
+      expect(flattenedCodes.has(code)).to.equal(true, `${code} missing from flattened map`);
+    }
+  });
+
+  it("provides a helper to build canonical failures", () => {
+    const withoutHint = fail(ERROR_CATALOG.PLAN.STATE, "illegal transition");
+    expect(withoutHint).to.deep.equal({
+      ok: false,
+      code: ERROR_CATALOG.PLAN.STATE,
+      message: "illegal transition",
+    });
+
+    const withHint = fail(ERROR_CATALOG.CANCEL.NOT_FOUND, "unknown opId", "verify opId via events_subscribe");
+    expect(withHint).to.deep.equal({
+      ok: false,
+      code: ERROR_CATALOG.CANCEL.NOT_FOUND,
+      message: "unknown opId",
+      hint: "verify opId via events_subscribe",
+    });
+  });
+});

--- a/tests/value.tools.op-id.test.ts
+++ b/tests/value.tools.op-id.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, beforeEach } from "mocha";
+import { expect } from "chai";
+
+import { ValueGraph } from "../src/values/valueGraph.js";
+import { StructuredLogger, type LogEntry } from "../src/logger.js";
+import {
+  handleValuesSet,
+  handleValuesScore,
+  handleValuesFilter,
+  handleValuesExplain,
+  ValuesSetInputSchema,
+  ValuesScoreInputSchema,
+  ValuesFilterInputSchema,
+  ValuesExplainInputSchema,
+  type ValueToolContext,
+} from "../src/tools/valueTools.js";
+
+/**
+ * Regression suite ensuring every value guard tool surfaces a correlation
+ * identifier (`op_id`) and propagates it to structured logs for observability.
+ */
+describe("value tool operation identifiers", () => {
+  let graph: ValueGraph;
+  let entries: LogEntry[];
+  let context: ValueToolContext;
+
+  beforeEach(() => {
+    graph = new ValueGraph();
+    entries = [];
+    context = {
+      valueGraph: graph,
+      logger: new StructuredLogger({ onEntry: (entry) => entries.push(entry) }),
+    };
+  });
+
+  it("generates and logs op_id values across the tool catalogue", () => {
+    const setInput = ValuesSetInputSchema.parse({
+      values: [
+        { id: "privacy", weight: 1, tolerance: 0.25 },
+        { id: "safety", weight: 0.8, tolerance: 0.4 },
+      ],
+      relationships: [{ from: "privacy", to: "safety", kind: "supports", weight: 0.5 }],
+      default_threshold: 0.7,
+    });
+    const setResult = handleValuesSet(context, setInput);
+    expect(setResult.op_id).to.match(/^values_set_op_/);
+
+    const setLog = entries.find((entry) => entry.message === "values_set");
+    expect(setLog?.payload).to.include({ op_id: setResult.op_id });
+
+    const scoreInput = ValuesScoreInputSchema.parse({
+      id: "plan-alpha",
+      label: "Alpha plan",
+      impacts: [
+        { value: "privacy", impact: "support", severity: 0.9, rationale: "encrypts" },
+        { value: "safety", impact: "risk", severity: 0.3, rationale: "reduces review" },
+      ],
+    });
+    const scoreResult = handleValuesScore(context, scoreInput);
+    expect(scoreResult.op_id).to.match(/^values_score_op_/);
+    expect(scoreResult.decision.allowed).to.equal(true);
+
+    const scoreLog = entries.find((entry) => entry.message === "values_score");
+    expect(scoreLog?.payload).to.include({ op_id: scoreResult.op_id });
+
+    const filterInput = ValuesFilterInputSchema.parse({
+      id: "plan-beta",
+      impacts: [
+        { value: "privacy", impact: "risk", severity: 0.8, rationale: "exports raw" },
+        { value: "safety", impact: "risk", severity: 0.7, rationale: "skips review" },
+      ],
+    });
+    const filterResult = handleValuesFilter(context, filterInput);
+    expect(filterResult.op_id).to.match(/^values_filter_op_/);
+    expect(filterResult.allowed).to.equal(false);
+
+    const filterLog = entries.find((entry) => entry.message === "values_filter");
+    expect(filterLog?.payload).to.include({ op_id: filterResult.op_id });
+
+    const explainInput = ValuesExplainInputSchema.parse({
+      plan: {
+        id: "plan-beta",
+        impacts: filterInput.impacts,
+      },
+    });
+    const explainResult = handleValuesExplain(context, explainInput);
+    expect(explainResult.op_id).to.match(/^values_explain_op_/);
+    expect(explainResult.decision.allowed).to.equal(false);
+
+    const explainLog = entries.find((entry) => entry.message === "values_explain");
+    expect(explainLog?.payload).to.include({ op_id: explainResult.op_id });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,34 +1,33 @@
 {
-    "compilerOptions": {
-      "target": "ES2022",
-      "lib": ["ES2022"],
-      "module": "ES2022",
-      "moduleResolution": "node",
-      "outDir": "dist",
-      "rootDir": "src",
-      "baseUrl": "src",
-      "paths": {
-        "agents/*": ["agents/*"],
-        "coord/*": ["coord/*"],
-        "events/*": ["events/*"],
-        "executor/*": ["executor/*"],
-        "graph/*": ["graph/*"],
-        "infra/*": ["infra/*"],
-        "knowledge/*": ["knowledge/*"],
-        "mcp/*": ["mcp/*"],
-        "monitor/*": ["monitor/*"],
-        "resources/*": ["resources/*"],
-        "state/*": ["state/*"],
-        "values/*": ["values/*"],
-        "viz/*": ["viz/*"]
-      },
-      "strict": true,
-      "esModuleInterop": true,
-      "forceConsistentCasingInFileNames": true,
-      "skipLibCheck": true,
-      "types": ["node"]
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "graph/*": ["src/graph/*"],
+      "executor/*": ["src/executor/*"],
+      "coord/*": ["src/coord/*"],
+      "agents/*": ["src/agents/*"],
+      "knowledge/*": ["src/knowledge/*"],
+      "values/*": ["src/values/*"],
+      "monitor/*": ["src/monitor/*"],
+      "events/*": ["src/events/*"],
+      "mcp/*": ["src/mcp/*"],
+      "resources/*": ["src/resources/*"],
+      "infra/*": ["src/infra/*"],
+      "state/*": ["src/state/*"],
+      "viz/*": ["src/viz/*"]
     },
-    "include": ["src"],
-    "exclude": ["dist", "node_modules", "tests"]
-  }
-  
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary
- extend the gateway hygiene suite to guard http/https/http2/net imports and whitelist only the HTTP server gateways
- prune older iteration logs in AGENTS.md and record the new iteration covering the network guard

## Testing
- npm run test:unit -- tests/hygiene.fs-gateway.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e498dc2c04832fac24700ee1548e01