### PR TITLE
Add Stage 3 transaction audit harness

### DIFF
--- a/validation_runs/20251007T184620Z/README.md
+++ b/validation_runs/20251007T184620Z/README.md
@@ -1,0 +1,26 @@
+# Validation run 20251007T184620Z
+
+This directory captures the artefacts for the MCP validation and improvement campaign.
+
+## Structure
+
+- `inputs/` — JSON payloads sent to the server for each tool invocation.
+- `outputs/` — Raw JSON responses captured verbatim from the server.
+- `events/` — Event stream dumps stored as JSON Lines.
+- `logs/` — Timestamped execution logs for the harness and server.
+- `resources/` — Snapshots of resources read during validation.
+- `report/` — Human-readable and machine-readable summaries.
+- `lib/` — Reusable utilities specific to this validation run.
+- `tests/` — Focused automated checks covering the validation utilities.
+
+## Planned workflow
+
+1. Bootstrap the run context and trace identifier generator.
+2. Connect to the MCP server and enumerate available tools.
+3. Execute each checklist stage while recording structured artefacts.
+   - Stage 1 focuses on introspection (`lib/introspection.ts`).
+   - Stage 2 introduces deterministic smoke tests for graph-centric tools (`lib/baseTools.ts`).
+   - Stage 3 validates transactions, graph diff/patch flows, cooperative locks and idempotency (`lib/transactions.ts`).
+4. Generate the final report deliverables under `report/`.
+
+Each stage of the workflow maps directly to the checklist maintained in `AGENTS.md`.

--- a/validation_runs/20251007T184620Z/lib/artifactRecorder.ts
+++ b/validation_runs/20251007T184620Z/lib/artifactRecorder.ts
@@ -1,0 +1,210 @@
+import { appendFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { RunContext } from './runContext.js';
+
+/**
+ * Enumerates the log levels used by the validation harness. The levels mirror
+ * conventional application logging semantics so that the resulting artefacts
+ * remain easy to scan manually or to ingest in external tooling.
+ */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+/**
+ * Represents the absolute paths of the artefacts generated while recording a
+ * single MCP tool invocation. Keeping the paths explicit makes it easier for
+ * callers to cross-link the evidence in the final report.
+ */
+export interface ToolCallArtefacts {
+  /** Absolute path of the JSON payload written under `inputs/`. */
+  readonly inputPath: string;
+  /** Absolute path of the JSON response written under `outputs/`. */
+  readonly outputPath: string;
+}
+
+/**
+ * Options accepted by {@link ArtifactRecorder.recordToolInput}. The trace
+ * identifier is optional: when omitted, the recorder relies on the
+ * {@link RunContext.createTraceId} generator to produce a deterministic value.
+ */
+export interface RecordToolInputOptions {
+  /** Name of the MCP tool being exercised. */
+  readonly toolName: string;
+  /** Payload that will be forwarded to the MCP tool. */
+  readonly payload: unknown;
+  /** Optional trace identifier to reuse across retries. */
+  readonly traceId?: string;
+}
+
+/**
+ * Options accepted by {@link ArtifactRecorder.recordToolOutput}. The method
+ * expects a trace identifier that matches the earlier call to
+ * {@link ArtifactRecorder.recordToolInput} to guarantee a stable mapping.
+ */
+export interface RecordToolOutputOptions {
+  /** Name of the MCP tool that produced the response. */
+  readonly toolName: string;
+  /** Payload returned by the MCP tool. */
+  readonly payload: unknown;
+  /** Trace identifier shared with the corresponding input payload. */
+  readonly traceId: string;
+}
+
+/**
+ * Options accepted by {@link ArtifactRecorder.appendEvent}. Each event is
+ * appended as an individual JSON line in a file associated to the trace.
+ */
+export interface AppendEventOptions {
+  /** Trace identifier of the call the event belongs to. */
+  readonly traceId: string;
+  /** Event payload captured from the MCP server. */
+  readonly event: unknown;
+}
+
+/**
+ * Options accepted by {@link ArtifactRecorder.appendLogEntry}. The optional
+ * trace identifier lets the log entry be correlated with a specific call when
+ * relevant. Free-form contextual data can be attached through the `details`
+ * property.
+ */
+export interface AppendLogOptions {
+  /** Severity level associated with the log line. */
+  readonly level: LogLevel;
+  /** Human readable message that summarises the log entry. */
+  readonly message: string;
+  /** Optional trace identifier to correlate the log with a tool call. */
+  readonly traceId?: string;
+  /** Optional structured payload providing additional context. */
+  readonly details?: Record<string, unknown> | undefined;
+}
+
+/**
+ * Provides deterministic helpers for writing MCP validation artefacts to disk.
+ * The recorder produces predictable file names so that the report can reference
+ * them without ambiguity. It also takes care of serialising the data with a
+ * human-friendly indentation to facilitate manual inspections.
+ */
+export class ArtifactRecorder {
+  private readonly context: RunContext;
+  private readonly now: () => Date;
+  private invocationCounter = 0;
+  private readonly prefixByTrace = new Map<string, string>();
+
+  constructor(context: RunContext, options: { readonly clock?: () => Date } = {}) {
+    this.context = context;
+    this.now = options.clock ?? (() => new Date());
+  }
+
+  /**
+   * Records the payload that will be sent to an MCP tool. The method returns
+   * both the trace identifier used for the call and the path of the generated
+   * JSON artefact under `inputs/`.
+   */
+  async recordToolInput(options: RecordToolInputOptions): Promise<{ traceId: string; inputPath: string }> {
+    const traceId = options.traceId ?? this.context.createTraceId();
+    const filePrefix = this.computeFilePrefix(options.toolName, traceId);
+    this.prefixByTrace.set(traceId, filePrefix);
+    const inputPath = path.join(this.context.directories.inputs, `${filePrefix}-input.json`);
+
+    await this.writeJsonFile(inputPath, {
+      traceId,
+      toolName: options.toolName,
+      recordedAt: this.now().toISOString(),
+      payload: options.payload,
+    });
+
+    return { traceId, inputPath };
+  }
+
+  /**
+   * Records the payload returned by an MCP tool. The JSON file stored under
+   * `outputs/` mirrors the structure used for inputs so that diffs remain easy
+   * to visualise.
+   */
+  async recordToolOutput(options: RecordToolOutputOptions): Promise<ToolCallArtefacts> {
+    const filePrefix = this.prefixByTrace.get(options.traceId) ?? this.computeFilePrefix(options.toolName, options.traceId);
+    this.prefixByTrace.set(options.traceId, filePrefix);
+    const outputPath = path.join(this.context.directories.outputs, `${filePrefix}-output.json`);
+
+    await this.writeJsonFile(outputPath, {
+      traceId: options.traceId,
+      toolName: options.toolName,
+      recordedAt: this.now().toISOString(),
+      payload: options.payload,
+    });
+
+    return {
+      inputPath: path.join(this.context.directories.inputs, `${filePrefix}-input.json`),
+      outputPath,
+    };
+  }
+
+  /**
+   * Appends an event payload to the JSON Lines file associated with the trace
+   * identifier. The resulting artefact can be streamed in real time, making it
+   * suitable for tailing while long running operations are in progress.
+   */
+  async appendEvent(options: AppendEventOptions): Promise<string> {
+    const eventPath = path.join(this.context.directories.events, `${options.traceId}.jsonl`);
+
+    await this.appendJsonLine(eventPath, {
+      traceId: options.traceId,
+      observedAt: this.now().toISOString(),
+      event: options.event,
+    });
+
+    return eventPath;
+  }
+
+  /**
+   * Appends a structured log entry to the run-wide log file. The method uses a
+   * JSON Lines representation to keep the artefact both machine and human
+   * friendly.
+   */
+  async appendLogEntry(options: AppendLogOptions): Promise<string> {
+    const logPath = path.join(this.context.directories.logs, 'run.log');
+
+    await this.appendJsonLine(logPath, {
+      timestamp: this.now().toISOString(),
+      level: options.level,
+      message: options.message,
+      traceId: options.traceId,
+      details: options.details,
+    });
+
+    return logPath;
+  }
+
+  /** Generates a deterministic file prefix combining timestamp, counter and tool name. */
+  private computeFilePrefix(toolName: string, traceId: string): string {
+    this.invocationCounter += 1;
+    const timestamp = this.now().toISOString().replace(/[:.]/g, '-');
+    const sanitizedTool = this.sanitizeSegment(toolName);
+    const suffix = traceId.replace(/[^a-zA-Z0-9_-]/g, '-');
+
+    return `${timestamp}-${this.invocationCounter.toString().padStart(4, '0')}-${sanitizedTool}-${suffix}`;
+  }
+
+  /** Serialises the provided value as pretty-printed JSON into the target file. */
+  private async writeJsonFile(filePath: string, value: unknown): Promise<void> {
+    const json = `${JSON.stringify(value, null, 2)}\n`;
+    await writeFile(filePath, json, 'utf8');
+  }
+
+  /** Appends a JSON line representation of the value to the target file. */
+  private async appendJsonLine(filePath: string, value: unknown): Promise<void> {
+    const jsonLine = `${JSON.stringify(value)}\n`;
+    await appendFile(filePath, jsonLine, 'utf8');
+  }
+
+  /** Sanitises a file path segment by replacing disallowed characters. */
+  private sanitizeSegment(segment: string): string {
+    return segment
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .replace(/-+/g, '-');
+  }
+}
+

--- a/validation_runs/20251007T184620Z/lib/baseTools.ts
+++ b/validation_runs/20251007T184620Z/lib/baseTools.ts
@@ -1,0 +1,296 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { RunContext } from './runContext.js';
+import { ArtifactRecorder } from './artifactRecorder.js';
+import { McpSession, McpToolCallError, type ToolCallRecord } from './mcpSession.js';
+
+import type { GraphDescriptorPayload, GraphGenerateResult } from '../../../src/tools/graphTools.js';
+
+/**
+ * Summary describing the extracted payloads from an MCP tool response. Storing
+ * the structured and textual interpretations keeps the audit artefacts easy to
+ * correlate while avoiding repeated JSON parsing when generating the final
+ * report.
+ */
+export interface ToolResponseSummary {
+  /** Whether the MCP response flagged the call as an error. */
+  readonly isError: boolean;
+  /** Structured content decoded from the MCP response when available. */
+  readonly structured?: unknown;
+  /** JSON payload decoded from the textual content, if valid JSON was found. */
+  readonly parsedText?: unknown;
+  /** Normalised error code extracted from the textual payload, when present. */
+  readonly errorCode?: string | null;
+  /** Optional hint exposed by the MCP tool to guide remediation. */
+  readonly hint?: string | null;
+}
+
+/**
+ * Snapshot describing a single MCP tool invocation exercised during the base
+ * tools validation stage. The metadata is persisted to disk so the final report
+ * can reference trace identifiers, artefact paths and error codes directly.
+ */
+export interface BaseToolCallSummary {
+  /** Name of the MCP tool that was invoked. */
+  readonly toolName: string;
+  /** Optional semantic scenario identifier (e.g. normal vs. invalid input). */
+  readonly scenario?: string;
+  /** Trace identifier correlating logs, events and artefacts. */
+  readonly traceId: string;
+  /** Wall-clock duration (in milliseconds) spent waiting for the response. */
+  readonly durationMs: number;
+  /** Paths of the captured input/output artefacts. */
+  readonly artefacts: ToolCallRecord['artefacts'];
+  /**
+   * Structured summary of the MCP response, including error codes when
+   * available.
+   */
+  readonly response: ToolResponseSummary;
+}
+
+/** Aggregated report written once the stage finishes executing. */
+export interface BaseToolsStageReport {
+  /** Identifier of the validation run. */
+  readonly runId: string;
+  /** ISO timestamp marking the completion of the stage. */
+  readonly completedAt: string;
+  /** List of tool invocations captured during the stage. */
+  readonly calls: BaseToolCallSummary[];
+  /** High level metrics extracted from the captured calls. */
+  readonly metrics: {
+    /** Total number of tool calls issued. */
+    readonly totalCalls: number;
+    /** Number of calls whose response flagged an error. */
+    readonly errorCount: number;
+  };
+  /** Optional identifier of the generated baseline graph reused by later steps. */
+  readonly generatedGraphId?: string;
+}
+
+/** Options accepted by {@link runBaseToolsStage}. */
+export interface BaseToolsStageOptions {
+  /** Validation run context shared across stages. */
+  readonly context: RunContext;
+  /** Recorder used to persist inputs/outputs, events and logs. */
+  readonly recorder: ArtifactRecorder;
+  /** Optional factory injected during testing to control the MCP session. */
+  readonly createSession?: () => McpSession;
+}
+
+/** Result returned by {@link runBaseToolsStage}. */
+export interface BaseToolsStageResult {
+  /** Absolute path of the JSON report generated for this stage. */
+  readonly reportPath: string;
+  /** Optional absolute path where the generated baseline graph was persisted. */
+  readonly generatedGraphPath?: string;
+  /** Collected summaries for each tool invocation. */
+  readonly calls: BaseToolCallSummary[];
+}
+
+/**
+ * Extracts the textual payload from an MCP response and attempts to parse it as
+ * JSON. The helper gracefully falls back to the raw string when parsing fails
+ * so that the audit report can still surface the original message.
+ */
+function parseTextContent(response: ToolCallRecord['response']): { parsed?: unknown; errorCode?: string | null; hint?: string | null } {
+  const contentEntries = Array.isArray(response.content) ? response.content : [];
+  const firstText = contentEntries.find(
+    (entry): entry is { type?: string; text?: string } => typeof entry?.text === 'string' && (entry.type === undefined || entry.type === 'text'),
+  );
+  if (!firstText?.text) {
+    return { parsed: undefined, errorCode: null, hint: null };
+  }
+
+  try {
+    const parsed = JSON.parse(firstText.text);
+    const errorCode = typeof (parsed as { error?: unknown }).error === 'string' ? (parsed as { error: string }).error : null;
+    const hint = typeof (parsed as { hint?: unknown }).hint === 'string' ? (parsed as { hint: string }).hint : null;
+    return { parsed, errorCode, hint };
+  } catch {
+    return { parsed: firstText.text, errorCode: null, hint: null };
+  }
+}
+
+/** Builds a structured summary of the MCP response for the audit report. */
+function summariseResponse(response: ToolCallRecord['response']): ToolResponseSummary {
+  const { parsed, errorCode, hint } = parseTextContent(response);
+  return {
+    isError: response.isError ?? false,
+    structured: response.structuredContent ?? undefined,
+    parsedText: parsed,
+    errorCode: errorCode ?? null,
+    hint: hint ?? null,
+  };
+}
+
+/**
+ * Calls an MCP tool while capturing the {@link BaseToolCallSummary}. Transport
+ * failures are converted into synthetic summaries so the report still contains
+ * the trace identifiers and artefact paths required for debugging.
+ */
+async function callAndRecord(
+  session: McpSession,
+  toolName: string,
+  payload: unknown,
+  options: { scenario?: string },
+  sink: BaseToolCallSummary[],
+): Promise<ToolCallRecord | null> {
+  try {
+    const call = await session.callTool(toolName, payload);
+    sink.push({
+      toolName,
+      scenario: options.scenario,
+      traceId: call.traceId,
+      durationMs: call.durationMs,
+      artefacts: call.artefacts,
+      response: summariseResponse(call.response),
+    });
+    return call;
+  } catch (error) {
+    if (error instanceof McpToolCallError) {
+      sink.push({
+        toolName,
+        scenario: options.scenario,
+        traceId: error.traceId,
+        durationMs: error.durationMs,
+        artefacts: error.artefacts,
+        response: {
+          isError: true,
+          structured: undefined,
+          parsedText:
+            error.cause instanceof Error
+              ? { message: error.cause.message, stack: error.cause.stack }
+              : { message: String(error.cause) },
+          errorCode: 'transport_failure',
+          hint: null,
+        },
+      });
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Executes the second checklist stage dedicated to baseline MCP tool coverage.
+ * The harness focuses on deterministic graph tooling that does not require
+ * complex orchestration state so that future stages can build upon the captured
+ * artefacts.
+ */
+export async function runBaseToolsStage(options: BaseToolsStageOptions): Promise<BaseToolsStageResult> {
+  const session = options.createSession
+    ? options.createSession()
+    : new McpSession({
+        context: options.context,
+        recorder: options.recorder,
+        clientName: 'validation-base-tools',
+        clientVersion: '1.0.0',
+      });
+
+  await session.open();
+
+  const calls: BaseToolCallSummary[] = [];
+  let generatedGraph: GraphDescriptorPayload | undefined;
+
+  try {
+    const generateCall = await callAndRecord(
+      session,
+      'graph_generate',
+      {
+        name: 'validation_baseline',
+        default_weight: 2,
+        tasks: {
+          tasks: [
+            { id: 'fetch', label: 'Fetch dependencies' },
+            { id: 'build', label: 'Build', depends_on: ['fetch'], weight: 3 },
+            { id: 'test', label: 'Test', depends_on: ['build'] },
+          ],
+        },
+      },
+      { scenario: 'valid' },
+      calls,
+    );
+
+    if (generateCall?.response.structuredContent) {
+      const structured = generateCall.response.structuredContent as GraphGenerateResult;
+      generatedGraph = structured.graph;
+    } else if (generateCall?.response.content) {
+      const parsed = parseTextContent(generateCall.response).parsed as Partial<GraphGenerateResult> | undefined;
+      if (parsed && typeof parsed === 'object' && parsed && 'graph' in parsed) {
+        generatedGraph = (parsed as { graph?: GraphDescriptorPayload }).graph;
+      }
+    }
+
+    if (!generatedGraph) {
+      throw new Error('graph_generate did not return a graph descriptor');
+    }
+
+    await callAndRecord(
+      session,
+      'graph_validate',
+      { graph: generatedGraph, include_invariants: true },
+      { scenario: 'valid' },
+      calls,
+    );
+
+    await callAndRecord(
+      session,
+      'graph_summarize',
+      { graph: generatedGraph, include_centrality: true },
+      { scenario: 'valid' },
+      calls,
+    );
+
+    const firstNode = generatedGraph.nodes[0]?.id ?? 'fetch';
+    const lastNode = generatedGraph.nodes[generatedGraph.nodes.length - 1]?.id ?? 'test';
+
+    await callAndRecord(
+      session,
+      'graph_paths_k_shortest',
+      { graph: generatedGraph, from: firstNode, to: lastNode, k: 2 },
+      { scenario: 'valid' },
+      calls,
+    );
+
+    await callAndRecord(
+      session,
+      'graph_paths_k_shortest',
+      { graph: generatedGraph, from: '', to: 'missing', k: 0 },
+      { scenario: 'invalid' },
+      calls,
+    );
+
+    await callAndRecord(
+      session,
+      'logs_tail',
+      {},
+      { scenario: 'valid' },
+      calls,
+    );
+  } finally {
+    await session.close();
+  }
+
+  const report: BaseToolsStageReport = {
+    runId: options.context.runId,
+    completedAt: new Date().toISOString(),
+    calls,
+    metrics: {
+      totalCalls: calls.length,
+      errorCount: calls.filter((entry) => entry.response.isError).length,
+    },
+    generatedGraphId: generatedGraph?.graph_id,
+  };
+
+  const reportPath = path.join(options.context.directories.report, 'step02-base-tools.json');
+  await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  let generatedGraphPath: string | undefined;
+  if (generatedGraph) {
+    generatedGraphPath = path.join(options.context.directories.resources, 'stage02-base-graph.json');
+    await writeFile(generatedGraphPath, `${JSON.stringify(generatedGraph, null, 2)}\n`, 'utf8');
+  }
+
+  return { reportPath, generatedGraphPath, calls };
+}

--- a/validation_runs/20251007T184620Z/lib/introspection.ts
+++ b/validation_runs/20251007T184620Z/lib/introspection.ts
@@ -1,0 +1,238 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { RunContext } from './runContext.js';
+import { ArtifactRecorder } from './artifactRecorder.js';
+import { McpSession } from './mcpSession.js';
+
+import type { McpInfo, McpCapabilities } from '../../../src/mcp/info.js';
+import type { ResourceListEntry } from '../../../src/resources/registry.js';
+import { getEventBusInstance } from '../../../src/server.js';
+import type { EventEnvelope } from '../../../src/events/bus.js';
+
+/**
+ * Structured representation of the `events_subscribe` tool output used by the
+ * harness. The server mirrors the JSON-Lines payload both as plain text and as
+ * structured content; the latter is easier to consume programmatically.
+ */
+export interface EventsSubscribeResult {
+  readonly format: 'jsonlines' | 'sse';
+  readonly events: Array<{
+    readonly seq: number;
+    readonly ts: number;
+    readonly cat: string;
+    readonly kind: string;
+    readonly level: string;
+    readonly job_id: string | null;
+    readonly run_id: string | null;
+    readonly op_id: string | null;
+    readonly graph_id: string | null;
+    readonly node_id: string | null;
+    readonly child_id: string | null;
+    readonly msg: string;
+    readonly data: unknown;
+  }>;
+  readonly stream: string;
+  readonly next_seq: number | null;
+  readonly count: number;
+}
+
+/** Summary of the artefacts collected while running the introspection stage. */
+export interface IntrospectionSummary {
+  readonly info: McpInfo;
+  readonly capabilities: McpCapabilities;
+  readonly resourceCatalog: {
+    readonly all: ResourceListEntry[];
+    readonly byPrefix: Array<{ readonly prefix: string; readonly items: ResourceListEntry[]; readonly traceId: string }>;
+  };
+  readonly eventProbe: {
+    readonly published: EventEnvelope;
+    readonly baseline: EventsSubscribeResult;
+    readonly followUp: EventsSubscribeResult;
+  };
+  readonly reportPath: string;
+  readonly resourceIndexPath: string;
+}
+
+/** Options accepted by {@link runIntrospectionStage}. */
+export interface IntrospectionStageOptions {
+  /** Validation run context shared by the harness. */
+  readonly context: RunContext;
+  /** Recorder used to persist artefacts and logs. */
+  readonly recorder: ArtifactRecorder;
+  /** Optional factory injected for unit testing to control session creation. */
+  readonly createSession?: () => McpSession;
+}
+
+/**
+ * Small helper that extracts the JSON payload embedded in the textual MCP
+ * response. Introspection tools serialise their result as a human-readable JSON
+ * document, making simple parsing sufficient for our audit needs.
+ */
+function parseJsonContent(response: Awaited<ReturnType<McpSession['callTool']>>['response']): unknown {
+  const firstTextEntry = Array.isArray(response.content)
+    ? response.content.find((entry): entry is { type?: string; text?: string } => entry?.type === 'text')
+    : undefined;
+  const raw = firstTextEntry?.text ?? '{}';
+  return JSON.parse(raw);
+}
+
+/**
+ * Derives a deterministic prefix from a resource URI so that we can issue
+ * targeted scans. The prefix mirrors the MCP contract: scheme + authority with
+ * a trailing slash (e.g. `sc://graphs/`).
+ */
+function deriveResourcePrefix(uri: string): string {
+  const parsed = new URL(uri);
+  return `${parsed.protocol}//${parsed.host}/`;
+}
+
+/**
+ * Executes the first checklist stage by invoking the introspection tools,
+ * listing resources and collecting a live event sample. The function stores a
+ * machine-readable report alongside a resource index to facilitate downstream
+ * inspection.
+ */
+export async function runIntrospectionStage(options: IntrospectionStageOptions): Promise<IntrospectionSummary> {
+  const session = options.createSession
+    ? options.createSession()
+    : new McpSession({
+        context: options.context,
+        recorder: options.recorder,
+        clientName: 'validation-introspection',
+        clientVersion: '1.0.0',
+        featureOverrides: {
+          enableMcpIntrospection: true,
+          enableResources: true,
+          enableEventsBus: true,
+        },
+      });
+
+  await session.open();
+
+  try {
+    const infoCall = await session.callTool('mcp_info', {});
+    const infoPayload = parseJsonContent(infoCall.response) as { info: McpInfo };
+    const info = infoPayload.info;
+
+    const capabilitiesCall = await session.callTool('mcp_capabilities', {});
+    const capabilitiesPayload = parseJsonContent(capabilitiesCall.response) as { capabilities: McpCapabilities };
+    const capabilities = capabilitiesPayload.capabilities;
+
+    const resourcesAllCall = await session.callTool('resources_list', { limit: 200 });
+    const resourcesAll = (
+      (resourcesAllCall.response.structuredContent as { items?: ResourceListEntry[] } | undefined)?.items ?? []
+    ).slice();
+
+    const prefixes = new Map<string, ResourceListEntry[]>();
+    for (const entry of resourcesAll) {
+      const prefix = deriveResourcePrefix(entry.uri);
+      const bucket = prefixes.get(prefix) ?? [];
+      bucket.push(entry);
+      prefixes.set(prefix, bucket);
+    }
+
+    const resourceCalls: Array<{ prefix: string; items: ResourceListEntry[]; traceId: string }> = [];
+    for (const [prefix] of prefixes) {
+      const listing = await session.callTool('resources_list', { prefix, limit: 200 });
+      const items = (listing.response.structuredContent as { items?: ResourceListEntry[] } | undefined)?.items ?? [];
+      resourceCalls.push({ prefix, items, traceId: listing.traceId });
+    }
+
+    const baselineEventsCall = await session.callTool('events_subscribe', { limit: 5 });
+    const baselineEvents = (baselineEventsCall.response.structuredContent ?? baselineEventsCall.response) as EventsSubscribeResult;
+    for (const event of baselineEvents.events) {
+      await options.recorder.appendEvent({
+        traceId: baselineEventsCall.traceId,
+        event,
+      });
+    }
+
+    const eventBus = getEventBusInstance();
+    const published = eventBus.publish({
+      cat: 'graph',
+      level: 'info',
+      runId: `validation-${options.context.runId}`,
+      msg: 'introspection_probe',
+      kind: 'probe',
+      data: { stage: 'introspection', timestamp: new Date().toISOString() },
+    });
+
+    const followUpEventsCall = await session.callTool('events_subscribe', {
+      from_seq: baselineEvents.next_seq ?? published.seq - 1,
+      limit: 20,
+    });
+    const followUpEvents = (followUpEventsCall.response.structuredContent ?? followUpEventsCall.response) as EventsSubscribeResult;
+
+    for (const event of followUpEvents.events) {
+      await options.recorder.appendEvent({
+        traceId: followUpEventsCall.traceId,
+        event,
+      });
+    }
+
+    const report = {
+      info,
+      capabilities,
+      resources: {
+        prefixes: resourceCalls.map((entry) => ({ prefix: entry.prefix, count: entry.items.length })),
+      },
+      events: {
+        published_seq: published.seq,
+        baseline_count: baselineEvents.count,
+        follow_up_count: followUpEvents.count,
+      },
+    };
+
+    const reportPath = path.join(options.context.directories.report, 'step01-introspection.json');
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+    const resourceIndexPath = path.join(options.context.directories.resources, 'resource-prefixes.json');
+    await writeFile(
+      resourceIndexPath,
+      `${JSON.stringify(
+        {
+          all: resourcesAll,
+          byPrefix: resourceCalls,
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    await options.recorder.appendLogEntry({
+      level: 'info',
+      message: 'introspection_stage_completed',
+      details: {
+        info_tool_trace: infoCall.traceId,
+        capabilities_tool_trace: capabilitiesCall.traceId,
+        resources_trace: resourcesAllCall.traceId,
+        prefixes_traces: resourceCalls.map((entry) => ({ prefix: entry.prefix, trace: entry.traceId })),
+        baseline_events_trace: baselineEventsCall.traceId,
+        follow_up_events_trace: followUpEventsCall.traceId,
+        report_path: reportPath,
+        resource_index_path: resourceIndexPath,
+      },
+    });
+
+    return {
+      info,
+      capabilities,
+      resourceCatalog: {
+        all: resourcesAll,
+        byPrefix: resourceCalls,
+      },
+      eventProbe: {
+        published,
+        baseline: baselineEvents,
+        followUp: followUpEvents,
+      },
+      reportPath,
+      resourceIndexPath,
+    };
+  } finally {
+    await session.close();
+  }
+}
+

--- a/validation_runs/20251007T184620Z/lib/mcpSession.ts
+++ b/validation_runs/20251007T184620Z/lib/mcpSession.ts
@@ -1,0 +1,232 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+
+import {
+  server,
+  configureRuntimeFeatures,
+  getRuntimeFeatures,
+} from '../../../src/server.js';
+import type { FeatureToggles } from '../../../src/serverOptions.js';
+import type { RunContext } from './runContext.js';
+import { ArtifactRecorder, type ToolCallArtefacts } from './artifactRecorder.js';
+
+/**
+ * Describes the options accepted when establishing an MCP validation session.
+ * The harness operates in-process and therefore only requires a run context,
+ * an artefact recorder and, optionally, feature overrides to activate gated
+ * tools during the discovery stages.
+ */
+export interface McpSessionOptions {
+  /** Validation run context providing directories and trace generator. */
+  readonly context: RunContext;
+  /** Recorder used to persist structured artefacts produced by the harness. */
+  readonly recorder: ArtifactRecorder;
+  /** Optional semantic name surfaced during the MCP handshake. */
+  readonly clientName?: string;
+  /** Optional semantic version surfaced during the MCP handshake. */
+  readonly clientVersion?: string;
+  /** Optional feature overrides toggled for the lifetime of the session. */
+  readonly featureOverrides?: Partial<FeatureToggles>;
+}
+
+/**
+ * Snapshot describing a single tool invocation. The structure exposes the raw
+ * MCP response together with metadata that simplifies downstream reporting and
+ * troubleshooting of failed calls.
+ */
+export interface ToolCallRecord {
+  /** Trace identifier correlating artefacts, logs and events. */
+  readonly traceId: string;
+  /** Fully qualified tool name exercised by the harness. */
+  readonly toolName: string;
+  /** JSON artefact paths generated for the call input/output payloads. */
+  readonly artefacts: ToolCallArtefacts;
+  /** Raw MCP response returned by the server. */
+  readonly response: Awaited<ReturnType<Client['callTool']>>;
+  /** Wall-clock duration (milliseconds) spent waiting for the response. */
+  readonly durationMs: number;
+}
+
+/**
+ * Error raised when the MCP client fails to obtain a response. The exception
+ * surfaces the captured artefact paths so operators can inspect the payloads
+ * even when the server rejects the request at the transport level.
+ */
+export class McpToolCallError extends Error {
+  /** Trace identifier correlated with the failing request. */
+  public readonly traceId: string;
+  /** Name of the tool that triggered the failure. */
+  public readonly toolName: string;
+  /** Duration elapsed before the failure was observed. */
+  public readonly durationMs: number;
+  /** Artefacts persisted for the failed call (input + output snapshot). */
+  public readonly artefacts: ToolCallArtefacts;
+  /** Original error raised by the MCP SDK or server implementation. */
+  public readonly cause: unknown;
+
+  constructor(message: string, details: {
+    readonly traceId: string;
+    readonly toolName: string;
+    readonly durationMs: number;
+    readonly artefacts: ToolCallArtefacts;
+    readonly cause: unknown;
+  }) {
+    super(message);
+    this.name = 'McpToolCallError';
+    this.traceId = details.traceId;
+    this.toolName = details.toolName;
+    this.durationMs = details.durationMs;
+    this.artefacts = details.artefacts;
+    this.cause = details.cause;
+  }
+}
+
+/**
+ * Lightweight harness that spins up an in-memory MCP client connected to the
+ * orchestrator. The session automatically toggles the required runtime features
+ * and restores the initial configuration once all calls complete.
+ */
+export class McpSession {
+  private readonly context: RunContext;
+  private readonly recorder: ArtifactRecorder;
+  private readonly clientInfo: { name: string; version: string };
+  private readonly featureOverrides: Partial<FeatureToggles>;
+
+  private client: Client | null = null;
+  private baselineFeatures: FeatureToggles | null = null;
+
+  constructor(options: McpSessionOptions) {
+    this.context = options.context;
+    this.recorder = options.recorder;
+    this.clientInfo = {
+      name: options.clientName ?? 'validation-harness',
+      version: options.clientVersion ?? '0.0.0-audit',
+    };
+    this.featureOverrides = options.featureOverrides ?? {};
+  }
+
+  /** Returns the underlying MCP client. Throws when the session is not open. */
+  private getClient(): Client {
+    if (!this.client) {
+      throw new Error('MCP session is not connected');
+    }
+    return this.client;
+  }
+
+  /**
+   * Opens the MCP session by connecting the orchestrator to an in-memory
+   * transport. Feature overrides are applied lazily so tests can customise the
+   * environment without mutating global state before the connection occurs.
+   */
+  async open(): Promise<void> {
+    if (this.client) {
+      return;
+    }
+
+    this.baselineFeatures = getRuntimeFeatures();
+    const nextFeatures = { ...this.baselineFeatures, ...this.featureOverrides };
+    configureRuntimeFeatures(nextFeatures);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.close().catch(() => {});
+    await server.connect(serverTransport);
+
+    this.client = new Client({
+      name: this.clientInfo.name,
+      version: this.clientInfo.version,
+    });
+    await this.client.connect(clientTransport);
+  }
+
+  /**
+   * Closes the MCP session and restores the runtime feature toggles captured at
+   * startup. The helper is idempotent so repeated invocations remain safe.
+   */
+  async close(): Promise<void> {
+    if (this.client) {
+      await this.client.close().catch(() => {});
+      this.client = null;
+    }
+    await server.close().catch(() => {});
+    if (this.baselineFeatures) {
+      configureRuntimeFeatures(this.baselineFeatures);
+      this.baselineFeatures = null;
+    }
+  }
+
+  /**
+   * Executes a single MCP tool call while recording deterministic artefacts and
+   * structured logs. The helper always writes an output snapshot, even when the
+   * SDK throws, so operators can inspect the captured error payloads.
+   */
+  async callTool(toolName: string, payload: unknown): Promise<ToolCallRecord> {
+    const client = this.getClient();
+    const startedAt = process.hrtime.bigint();
+    const { traceId, inputPath } = await this.recorder.recordToolInput({
+      toolName,
+      payload,
+    });
+
+    try {
+      const response = await client.callTool({ name: toolName, arguments: payload });
+      const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      const artefacts = await this.recorder.recordToolOutput({
+        toolName,
+        traceId,
+        payload: response,
+      });
+      await this.recorder.appendLogEntry({
+        level: response.isError ? 'warn' : 'info',
+        message: 'tool_call_completed',
+        traceId,
+        details: {
+          tool: toolName,
+          duration_ms: durationMs,
+          input_path: inputPath,
+          output_path: artefacts.outputPath,
+          is_error: response.isError ?? false,
+        },
+      });
+
+      return {
+        traceId,
+        toolName,
+        artefacts,
+        response,
+        durationMs,
+      };
+    } catch (error: unknown) {
+      const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      const failurePayload = {
+        error: error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : { message: String(error) },
+      };
+      const artefacts = await this.recorder.recordToolOutput({
+        toolName,
+        traceId,
+        payload: failurePayload,
+      });
+      await this.recorder.appendLogEntry({
+        level: 'error',
+        message: 'tool_call_failed',
+        traceId,
+        details: {
+          tool: toolName,
+          duration_ms: durationMs,
+          input_path: inputPath,
+          output_path: artefacts.outputPath,
+          error: failurePayload.error,
+        },
+      });
+      throw new McpToolCallError(`MCP tool call failed: ${toolName}`, {
+        traceId,
+        toolName,
+        durationMs,
+        artefacts,
+        cause: error,
+      });
+    }
+  }
+}
+

--- a/validation_runs/20251007T184620Z/lib/runContext.ts
+++ b/validation_runs/20251007T184620Z/lib/runContext.ts
@@ -1,0 +1,117 @@
+import { mkdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+
+/**
+ * Describes the absolute paths of the artefact directories managed for a
+ * validation run. Each sub-folder hosts a dedicated category of evidence that
+ * must be collected while exercising the MCP server.
+ */
+export interface RunDirectories {
+  /** Directory that stores the JSON payloads sent to the MCP tools. */
+  readonly inputs: string;
+  /** Directory that stores the raw JSON responses returned by the server. */
+  readonly outputs: string;
+  /** Directory that contains event stream captures serialised as JSON Lines. */
+  readonly events: string;
+  /** Directory that aggregates timestamped execution logs. */
+  readonly logs: string;
+  /** Directory that mirrors the resources fetched via the MCP resource APIs. */
+  readonly resources: string;
+  /** Directory dedicated to the human and machine readable reports. */
+  readonly report: string;
+}
+
+/**
+ * Represents the contextual information shared across validation steps,
+ * including the run identifier, the resolved filesystem layout and a
+ * deterministic trace identifier generator.
+ */
+export interface RunContext {
+  /** Identifier chosen for the validation run (mirrors the timestamp folder). */
+  readonly runId: string;
+  /** Absolute path of the run root directory. */
+  readonly rootDir: string;
+  /** Lazily created directories storing the audit artefacts. */
+  readonly directories: RunDirectories;
+  /** Function that yields unique trace identifiers for MCP invocations. */
+  readonly createTraceId: () => string;
+}
+
+/**
+ * Ensures that the canonical directory structure exists for the validation
+ * artefacts. Missing folders are created lazily, whereas pre-existing ones are
+ * left untouched to preserve potential manual notes.
+ */
+export async function ensureRunDirectories(runRoot: string): Promise<RunDirectories> {
+  const directories: RunDirectories = {
+    inputs: path.join(runRoot, 'inputs'),
+    outputs: path.join(runRoot, 'outputs'),
+    events: path.join(runRoot, 'events'),
+    logs: path.join(runRoot, 'logs'),
+    resources: path.join(runRoot, 'resources'),
+    report: path.join(runRoot, 'report'),
+  };
+
+  await Promise.all(
+    Object.values(directories).map(async (dir) => {
+      try {
+        const stats = await stat(dir);
+        if (!stats.isDirectory()) {
+          throw new Error(`Path ${dir} exists but is not a directory`);
+        }
+      } catch (error: unknown) {
+        await mkdir(dir, { recursive: true });
+      }
+    }),
+  );
+
+  return directories;
+}
+
+/**
+ * Builds a deterministic trace identifier generator. The factory derives a
+ * reproducible 32-hex digest from the provided seed and a monotonic counter,
+ * ensuring that retries can share the same trace identifier when the seed is
+ * preserved. The prefix helps quickly differentiate trace identifiers from
+ * other IDs when scanning logs.
+ */
+export function createTraceIdFactory(seed: string = randomUUID()): () => string {
+  const sanitizedSeed = seed.replace(/[^a-zA-Z0-9_-]/g, '');
+  let counter = 0;
+
+  return () => {
+    counter += 1;
+    const hash = createHash('sha256');
+    hash.update(sanitizedSeed);
+    hash.update(':');
+    hash.update(counter.toString(10));
+
+    return `trace-${hash.digest('hex').slice(0, 32)}`;
+  };
+}
+
+/**
+ * Creates a high-level context object that the validation harness can pass to
+ * each stage of the checklist. The helper combines directory initialisation and
+ * trace identifier generation while keeping the API intentionally small to ease
+ * testing.
+ */
+export async function createRunContext(params: {
+  /** Run identifier that should match the timestamp-based folder name. */
+  readonly runId: string;
+  /** Absolute path to the workspace root (repository root). */
+  readonly workspaceRoot: string;
+  /** Optional seed used to make trace identifier generation reproducible. */
+  readonly traceSeed?: string;
+}): Promise<RunContext> {
+  const rootDir = path.join(params.workspaceRoot, 'validation_runs', params.runId);
+  const directories = await ensureRunDirectories(rootDir);
+
+  return {
+    runId: params.runId,
+    rootDir,
+    directories,
+    createTraceId: createTraceIdFactory(params.traceSeed),
+  };
+}

--- a/validation_runs/20251007T184620Z/lib/transactions.ts
+++ b/validation_runs/20251007T184620Z/lib/transactions.ts
@@ -1,0 +1,577 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { RunContext } from './runContext.js';
+import { ArtifactRecorder } from './artifactRecorder.js';
+import { McpSession, McpToolCallError, type ToolCallRecord } from './mcpSession.js';
+import type { BaseToolCallSummary, ToolResponseSummary } from './baseTools.js';
+
+import type { TxBeginResult, TxApplyResult, TxCommitResult } from '../../../src/tools/txTools.js';
+import type { GraphPatchResult, GraphDiffResult } from '../../../src/tools/graphDiffTools.js';
+import type { GraphDescriptorPayload } from '../../../src/tools/graphTools.js';
+import type { GraphLockResult, GraphUnlockResult } from '../../../src/tools/graphLockTools.js';
+
+/**
+ * Descriptor of the aggregated signals captured while executing the transaction
+ * validation stage. The structure is persisted to disk as JSON so downstream
+ * reporting (Stages 7–8) can correlate metrics without re-processing raw
+ * artefacts.
+ */
+export interface TransactionsStageReport {
+  /** Identifier of the validation run. */
+  readonly runId: string;
+  /** ISO timestamp describing when the stage finished executing. */
+  readonly completedAt: string;
+  /** Graph identifier targeted by the transaction scenarios. */
+  readonly graphId: string;
+  /** Summaries for every tool invocation recorded during the stage. */
+  readonly calls: BaseToolCallSummary[];
+  /** High-level metrics extracted from the tool calls. */
+  readonly metrics: {
+    /** Total number of MCP calls issued while running the stage. */
+    readonly totalCalls: number;
+    /** Number of calls that yielded an MCP error response. */
+    readonly errorCount: number;
+    /** Version returned by the initial transaction commit. */
+    readonly committedVersion: number;
+    /** Version returned by the successful graph_patch invocation. */
+    readonly patchedVersion: number | null;
+  };
+  /** Summary of the graph diff executed after the first commit. */
+  readonly diff: {
+    readonly traceId: string;
+    readonly changed: boolean;
+    readonly operations: number;
+  } | null;
+  /** Snapshot of the patch workflow (success + expected failure). */
+  readonly patch: {
+    readonly successTraceId: string;
+    readonly failureTraceId: string | null;
+    readonly failureCode: string | null;
+  };
+  /** Summary of the cooperative locking scenario. */
+  readonly locks: {
+    readonly acquiredTraceId: string;
+    readonly lockId: string;
+    readonly conflictTraceId: string | null;
+    readonly conflictCode: string | null;
+    readonly releasedTraceId: string | null;
+  };
+  /** Summary of the idempotency replay check. */
+  readonly idempotency: {
+    readonly key: string;
+    readonly initialTraceId: string;
+    readonly replayTraceId: string;
+    readonly identicalPayload: boolean;
+    readonly initialFlag: boolean;
+    readonly replayFlag: boolean;
+    readonly txId: string;
+  };
+  /** Absolute path where the final committed graph descriptor was stored. */
+  readonly finalGraphPath: string | null;
+}
+
+/** Options accepted by {@link runTransactionsStage}. */
+export interface TransactionsStageOptions {
+  /** Shared validation run context. */
+  readonly context: RunContext;
+  /** Recorder in charge of persisting artefacts (inputs/outputs/events/logs). */
+  readonly recorder: ArtifactRecorder;
+  /** Optional factory injected by tests to override the MCP session. */
+  readonly createSession?: () => McpSession;
+}
+
+/** Result returned by {@link runTransactionsStage}. */
+export interface TransactionsStageResult {
+  /** Path of the JSON report generated for the stage. */
+  readonly reportPath: string;
+  /** Absolute path of the latest committed graph descriptor. */
+  readonly finalGraphPath: string | null;
+  /** Collected summaries for each MCP call performed by the stage. */
+  readonly calls: BaseToolCallSummary[];
+  /** Identifier of the graph exercised by the scenarios. */
+  readonly graphId: string;
+  /** Version returned by the successful patch invocation (if any). */
+  readonly patchedVersion: number | null;
+}
+
+/**
+ * Extracts the first textual entry from an MCP response and attempts to parse
+ * it as JSON. The helper mirrors the Stage 2 behaviour so error payloads remain
+ * comparable across reports.
+ */
+function parseTextContent(response: ToolCallRecord['response']): {
+  parsed?: unknown;
+  errorCode?: string | null;
+  hint?: string | null;
+} {
+  const contentEntries = Array.isArray(response.content) ? response.content : [];
+  const firstText = contentEntries.find(
+    (entry): entry is { type?: string; text?: string } =>
+      typeof entry?.text === 'string' && (entry.type === undefined || entry.type === 'text'),
+  );
+  if (!firstText?.text) {
+    return { parsed: undefined, errorCode: null, hint: null };
+  }
+
+  try {
+    const parsed = JSON.parse(firstText.text);
+    const errorCode = typeof (parsed as { error?: unknown }).error === 'string' ? (parsed as { error: string }).error : null;
+    const hint = typeof (parsed as { hint?: unknown }).hint === 'string' ? (parsed as { hint: string }).hint : null;
+    return { parsed, errorCode, hint };
+  } catch {
+    return { parsed: firstText.text, errorCode: null, hint: null };
+  }
+}
+
+/** Builds a structured summary of the MCP response for the audit report. */
+function summariseResponse(response: ToolCallRecord['response']): ToolResponseSummary {
+  const { parsed, errorCode, hint } = parseTextContent(response);
+  return {
+    isError: response.isError ?? false,
+    structured: response.structuredContent ?? undefined,
+    parsedText: parsed,
+    errorCode: errorCode ?? null,
+    hint: hint ?? null,
+  };
+}
+
+/** Extract a stable error code from the summary, falling back to structured payloads. */
+function resolveErrorCode(summary: ToolResponseSummary): string | null {
+  if (summary.errorCode) {
+    return summary.errorCode;
+  }
+  const structured = summary.structured;
+  if (structured && typeof structured === 'object' && structured !== null) {
+    const candidate = (structured as { error?: unknown }).error;
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+  }
+  const parsed = summary.parsedText;
+  if (parsed && typeof parsed === 'object' && parsed !== null) {
+    const candidate = (parsed as { error?: unknown }).error;
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Calls an MCP tool while capturing the {@link BaseToolCallSummary}. Transport
+ * errors are converted into synthetic entries to keep traceability intact.
+ */
+async function callAndRecord(
+  session: McpSession,
+  toolName: string,
+  payload: unknown,
+  options: { scenario?: string },
+  sink: BaseToolCallSummary[],
+): Promise<ToolCallRecord | null> {
+  try {
+    const call = await session.callTool(toolName, payload);
+    sink.push({
+      toolName,
+      scenario: options.scenario,
+      traceId: call.traceId,
+      durationMs: call.durationMs,
+      artefacts: call.artefacts,
+      response: summariseResponse(call.response),
+    });
+    return call;
+  } catch (error) {
+    if (error instanceof McpToolCallError) {
+      sink.push({
+        toolName,
+        scenario: options.scenario,
+        traceId: error.traceId,
+        durationMs: error.durationMs,
+        artefacts: error.artefacts,
+        response: {
+          isError: true,
+          structured: undefined,
+          parsedText:
+            error.cause instanceof Error
+              ? { message: error.cause.message, stack: error.cause.stack }
+              : { message: String(error.cause) },
+          errorCode: 'transport_failure',
+          hint: null,
+        },
+      });
+      return null;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Executes the third checklist stage that focuses on transaction flows,
+ * cooperative locks, diff/patch invariants and idempotency guarantees. The
+ * function orchestrates the required MCP tool calls, persists their artefacts
+ * and aggregates a compact report consumed by later phases of the audit.
+ */
+export async function runTransactionsStage(options: TransactionsStageOptions): Promise<TransactionsStageResult> {
+  const graphId = 'G_TEST';
+  const baseGraph: GraphDescriptorPayload = {
+    name: 'Stage 3 validation graph',
+    graph_id: graphId,
+    graph_version: 1,
+    metadata: {
+      stage: 'transactions',
+      enforce_dag: true,
+      release_channel: 'alpha',
+    },
+    nodes: [
+      { id: 'ingest', label: 'Ingest', attributes: { max_out_degree: 3 } },
+      { id: 'analyse', label: 'Analyse' },
+    ],
+    edges: [{ from: 'ingest', to: 'analyse', label: 'next', attributes: { lane: 'primary' } }],
+  };
+
+  const session = options.createSession
+    ? options.createSession()
+    : new McpSession({
+        context: options.context,
+        recorder: options.recorder,
+        clientName: 'validation-transactions',
+        clientVersion: '1.0.0',
+        featureOverrides: {
+          enableTx: true,
+          enableDiffPatch: true,
+          enableLocks: true,
+          enableResources: true,
+          enableIdempotency: true,
+        },
+      });
+
+  await session.open();
+
+  const calls: BaseToolCallSummary[] = [];
+
+  try {
+    const beginCall = await callAndRecord(
+      session,
+      'tx_begin',
+      {
+        graph_id: graphId,
+        owner: 'stage3-harness',
+        note: 'seed baseline descriptor',
+        ttl_ms: 5_000,
+        graph: baseGraph,
+      },
+      { scenario: 'tx_begin_initial' },
+      calls,
+    );
+    if (!beginCall) {
+      throw new Error('tx_begin did not return a response');
+    }
+    const beginResult = (beginCall.response.structuredContent ?? beginCall.response) as TxBeginResult;
+
+    const applyCall = await callAndRecord(
+      session,
+      'tx_apply',
+      {
+        tx_id: beginResult.tx_id,
+        operations: [
+          { op: 'add_node', node: { id: 'ship', label: 'Ship', attributes: { lane: 'delivery' } } },
+          { op: 'add_edge', edge: { from: 'analyse', to: 'ship', label: 'handoff' } },
+          { op: 'set_node_attribute', id: 'analyse', key: 'phase', value: 'inspection' },
+        ],
+      },
+      { scenario: 'tx_apply_enrichment' },
+      calls,
+    );
+    if (!applyCall) {
+      throw new Error('tx_apply failed before receiving a response');
+    }
+    const applyResult = (applyCall.response.structuredContent ?? applyCall.response) as TxApplyResult;
+
+    const commitCall = await callAndRecord(
+      session,
+      'tx_commit',
+      { tx_id: beginResult.tx_id },
+      { scenario: 'tx_commit_initial' },
+      calls,
+    );
+    if (!commitCall) {
+      throw new Error('tx_commit failed before receiving a response');
+    }
+    const commitResult = (commitCall.response.structuredContent ?? commitCall.response) as TxCommitResult;
+
+    const diffCall = await callAndRecord(
+      session,
+      'graph_diff',
+      {
+        graph_id: graphId,
+        from: { graph: baseGraph },
+        to: { latest: true },
+      },
+      { scenario: 'graph_diff_post_commit' },
+      calls,
+    );
+    const diffResult = diffCall
+      ? ((diffCall.response.structuredContent ?? diffCall.response) as GraphDiffResult)
+      : null;
+
+    const commitGraph = commitResult.graph as GraphDescriptorPayload;
+    const enrichedNodes = commitGraph.nodes.map((node) =>
+      node.id === 'ship'
+        ? {
+            ...node,
+            attributes: { ...(node.attributes ?? {}), status: 'ready', lane: node.attributes?.lane ?? 'delivery' },
+          }
+        : { ...node },
+    );
+    if (!enrichedNodes.some((node) => node.id === 'deliver')) {
+      enrichedNodes.push({ id: 'deliver', label: 'Deliver', attributes: { lane: 'customer' } });
+    }
+    const enrichedEdges = commitGraph.edges.map((edge) => ({ ...edge }));
+    if (!enrichedEdges.some((edge) => edge.from === 'ship' && edge.to === 'deliver')) {
+      enrichedEdges.push({ from: 'ship', to: 'deliver', label: 'finalise' });
+    }
+    const enrichedGraph: GraphDescriptorPayload = {
+      ...commitGraph,
+      graph_id: graphId,
+      metadata: { ...(commitGraph.metadata ?? {}), release_channel: 'beta', release_candidate: true },
+      nodes: enrichedNodes,
+      edges: enrichedEdges,
+    };
+
+    const patchPlanCall = await callAndRecord(
+      session,
+      'graph_diff',
+      {
+        graph_id: graphId,
+        from: { latest: true },
+        to: { graph: enrichedGraph },
+      },
+      { scenario: 'graph_diff_patch_plan' },
+      calls,
+    );
+    const patchPlan = patchPlanCall
+      ? ((patchPlanCall.response.structuredContent ?? patchPlanCall.response) as GraphDiffResult)
+      : null;
+    const patchOperations = patchPlan?.operations ?? [];
+    if (patchOperations.length === 0) {
+      throw new Error('graph_diff did not produce patch operations');
+    }
+
+    const patchCall = await callAndRecord(
+      session,
+      'graph_patch',
+      {
+        graph_id: graphId,
+        base_version: commitResult.version,
+        owner: 'stage3-harness',
+        note: 'extend workflow',
+        patch: patchOperations,
+      },
+      { scenario: 'graph_patch_success' },
+      calls,
+    );
+    const patchResult = patchCall
+      ? ((patchCall.response.structuredContent ?? patchCall.response) as GraphPatchResult)
+      : null;
+    if (!patchResult) {
+      throw new Error('graph_patch did not return a structured response');
+    }
+
+    const patchedGraph = patchResult.graph as GraphDescriptorPayload;
+
+    const cycleGraph: GraphDescriptorPayload = {
+      ...patchedGraph,
+      graph_id: graphId,
+      edges: patchedGraph.edges.concat({ from: 'deliver', to: 'ingest', label: 'cycle' }),
+    };
+
+    const invalidPlanCall = await callAndRecord(
+      session,
+      'graph_diff',
+      {
+        graph_id: graphId,
+        from: { latest: true },
+        to: { graph: cycleGraph },
+      },
+      { scenario: 'graph_diff_cycle_plan' },
+      calls,
+    );
+    const invalidPlan = invalidPlanCall
+      ? ((invalidPlanCall.response.structuredContent ?? invalidPlanCall.response) as GraphDiffResult)
+      : null;
+    const invalidOperations = invalidPlan?.operations ?? [{ op: 'add', path: '/edges/-', value: { from: 'deliver', to: 'ingest', label: 'cycle' } }];
+
+    const invalidPatchCall = await callAndRecord(
+      session,
+      'graph_patch',
+      {
+        graph_id: graphId,
+        base_version: patchResult.committed_version ?? commitResult.version,
+        owner: 'stage3-harness',
+        note: 'induce cycle for invariant check',
+        patch: invalidOperations,
+      },
+      { scenario: 'graph_patch_invariant_violation' },
+      calls,
+    );
+
+    const lockCall = await callAndRecord(
+      session,
+      'graph_lock',
+      {
+        graph_id: graphId,
+        holder: 'stage3-harness',
+        ttl_ms: 5_000,
+      },
+      { scenario: 'graph_lock_acquire' },
+      calls,
+    );
+    const lockResult = lockCall
+      ? ((lockCall.response.structuredContent ?? lockCall.response) as GraphLockResult)
+      : null;
+
+    const conflictLockCall = await callAndRecord(
+      session,
+      'graph_lock',
+      {
+        graph_id: graphId,
+        holder: 'stage3-intruder',
+      },
+      { scenario: 'graph_lock_conflict' },
+      calls,
+    );
+
+    const unlockCall = lockResult
+      ? await callAndRecord(
+          session,
+          'graph_unlock',
+          { lock_id: lockResult.lock_id },
+          { scenario: 'graph_unlock_release' },
+          calls,
+        )
+      : null;
+    const unlockResult = unlockCall
+      ? ((unlockCall.response.structuredContent ?? unlockCall.response) as GraphUnlockResult)
+      : null;
+
+    const idempotencyKey = 'stage3-idempotent-begin';
+    const idempotentBeginCall = await callAndRecord(
+      session,
+      'tx_begin',
+      {
+        graph_id: graphId,
+        owner: 'stage3-idempotency',
+        note: 'idempotency check',
+        idempotency_key: idempotencyKey,
+      },
+      { scenario: 'tx_begin_idempotency_initial' },
+      calls,
+    );
+    if (!idempotentBeginCall) {
+      throw new Error('tx_begin idempotency probe failed on initial call');
+    }
+    const idempotentBeginResult = (idempotentBeginCall.response.structuredContent ?? idempotentBeginCall.response) as TxBeginResult;
+
+    const idempotentReplayCall = await callAndRecord(
+      session,
+      'tx_begin',
+      {
+        graph_id: graphId,
+        owner: 'stage3-idempotency',
+        note: 'idempotency check',
+        idempotency_key: idempotencyKey,
+      },
+      { scenario: 'tx_begin_idempotency_replay' },
+      calls,
+    );
+    if (!idempotentReplayCall) {
+      throw new Error('tx_begin idempotency replay did not yield a response');
+    }
+    const idempotentReplayResult = (idempotentReplayCall.response.structuredContent ?? idempotentReplayCall.response) as TxBeginResult;
+
+    await callAndRecord(
+      session,
+      'tx_rollback',
+      { tx_id: idempotentBeginResult.tx_id },
+      { scenario: 'tx_rollback_idempotency_cleanup' },
+      calls,
+    );
+
+    if (idempotentBeginResult.tx_id !== idempotentReplayResult.tx_id) {
+      throw new Error('idempotent tx_begin returned a different transaction identifier');
+    }
+    const { idempotent: initialFlag, ...initialComparable } = idempotentBeginResult;
+    const { idempotent: replayFlag, ...replayComparable } = idempotentReplayResult;
+    const identicalPayload = JSON.stringify(initialComparable) === JSON.stringify(replayComparable);
+
+    const invalidPatchSummary = calls.find(
+      (entry) => entry.toolName === 'graph_patch' && entry.scenario === 'graph_patch_invariant_violation',
+    );
+    const failureCode = invalidPatchSummary ? resolveErrorCode(invalidPatchSummary.response) : null;
+
+    const report: TransactionsStageReport = {
+      runId: options.context.runId,
+      completedAt: new Date().toISOString(),
+      graphId,
+      calls,
+      metrics: {
+        totalCalls: calls.length,
+        errorCount: calls.filter((entry) => entry.response.isError).length,
+        committedVersion: commitResult.version,
+        patchedVersion: patchResult?.committed_version ?? null,
+      },
+      diff: diffResult
+        ? {
+            traceId: diffCall!.traceId,
+            changed: diffResult.changed,
+            operations: diffResult.operations.length,
+          }
+        : null,
+      patch: {
+        successTraceId: patchCall?.traceId ?? 'unknown',
+        failureTraceId: invalidPatchCall?.traceId ?? null,
+        failureCode,
+      },
+      locks: {
+        acquiredTraceId: lockCall?.traceId ?? 'unknown',
+        lockId: lockResult?.lock_id ?? 'unknown',
+        conflictTraceId: conflictLockCall?.traceId ?? null,
+        conflictCode: conflictLockCall?.response.errorCode ?? null,
+        releasedTraceId: unlockResult ? unlockCall?.traceId ?? null : null,
+      },
+      idempotency: {
+        key: idempotencyKey,
+        initialTraceId: idempotentBeginCall.traceId,
+        replayTraceId: idempotentReplayCall.traceId,
+        identicalPayload,
+        initialFlag: initialFlag ?? false,
+        replayFlag: replayFlag ?? false,
+        txId: idempotentReplayResult.tx_id,
+      },
+      finalGraphPath: null,
+    };
+
+    const reportPath = path.join(options.context.directories.report, 'step03-transactions.json');
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+    let finalGraphPath: string | null = null;
+    if (patchResult.graph) {
+      finalGraphPath = path.join(options.context.directories.resources, 'stage03-transaction-graph.json');
+      await writeFile(finalGraphPath, `${JSON.stringify(patchResult.graph, null, 2)}\n`, 'utf8');
+      report.finalGraphPath = finalGraphPath;
+    }
+
+    // Rewrite the report with the resolved final graph path when available.
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+    return {
+      reportPath,
+      finalGraphPath,
+      calls,
+      graphId,
+      patchedVersion: patchResult?.committed_version ?? null,
+    };
+  } finally {
+    await session.close();
+  }
+}

--- a/validation_runs/20251007T184620Z/tests/artifactRecorder.test.ts
+++ b/validation_runs/20251007T184620Z/tests/artifactRecorder.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { expect } from 'chai';
+
+import { ArtifactRecorder } from '../lib/artifactRecorder.js';
+import { createRunContext, createTraceIdFactory } from '../lib/runContext.js';
+
+/**
+ * Helper returning a deterministic Date instance suitable for predictable
+ * artefact names in the tests.
+ */
+function fixedDate(): Date {
+  return new Date('2025-01-02T03:04:05.678Z');
+}
+
+describe('ArtifactRecorder', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await mkdtemp(path.join(tmpdir(), 'artifact-recorder-'));
+    await mkdir(path.join(workspaceRoot, 'validation_runs'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('records tool inputs using deterministic trace identifiers', async () => {
+    const runId = 'RUN';
+    const context = await createRunContext({ runId, workspaceRoot, traceSeed: 'seed' });
+    const recorder = new ArtifactRecorder(context, { clock: fixedDate });
+
+    const result = await recorder.recordToolInput({ toolName: 'mcp_info', payload: { foo: 'bar' } });
+    const expectedTrace = createTraceIdFactory('seed')();
+
+    expect(result.traceId).to.equal(expectedTrace);
+
+    const stats = await stat(result.inputPath);
+    expect(stats.isFile()).to.equal(true);
+
+    const contents = JSON.parse(await readFile(result.inputPath, 'utf8'));
+    expect(contents).to.deep.equal({
+      traceId: result.traceId,
+      toolName: 'mcp_info',
+      recordedAt: '2025-01-02T03:04:05.678Z',
+      payload: { foo: 'bar' },
+    });
+  });
+
+  it('records tool outputs paired with the corresponding input file name', async () => {
+    const runId = 'RUN';
+    const context = await createRunContext({ runId, workspaceRoot, traceSeed: 'seed' });
+    const recorder = new ArtifactRecorder(context, { clock: fixedDate });
+
+    const { traceId, inputPath } = await recorder.recordToolInput({ toolName: 'mcp_info', payload: { foo: 'bar' } });
+    const artefacts = await recorder.recordToolOutput({ traceId, toolName: 'mcp_info', payload: { ok: true } });
+
+    expect(artefacts.inputPath).to.equal(inputPath);
+
+    const outputContents = JSON.parse(await readFile(artefacts.outputPath, 'utf8'));
+    expect(outputContents).to.deep.equal({
+      traceId,
+      toolName: 'mcp_info',
+      recordedAt: '2025-01-02T03:04:05.678Z',
+      payload: { ok: true },
+    });
+  });
+
+  it('appends events and log entries as JSON lines', async () => {
+    const runId = 'RUN';
+    const context = await createRunContext({ runId, workspaceRoot, traceSeed: 'seed' });
+    const recorder = new ArtifactRecorder(context, { clock: fixedDate });
+
+    const { traceId } = await recorder.recordToolInput({ toolName: 'mcp_capabilities', payload: {} });
+    const eventPath = await recorder.appendEvent({ traceId, event: { type: 'progress', value: 42 } });
+    await recorder.appendEvent({ traceId, event: { type: 'progress', value: 84 } });
+
+    const eventLines = (await readFile(eventPath, 'utf8')).trim().split('\n');
+    expect(eventLines).to.have.length(2);
+    expect(eventLines[0]).to.equal(
+      JSON.stringify({ traceId, observedAt: '2025-01-02T03:04:05.678Z', event: { type: 'progress', value: 42 } }),
+    );
+
+    const logPath = await recorder.appendLogEntry({
+      level: 'info',
+      message: 'Tool invocation completed',
+      traceId,
+      details: { durationMs: 1200 },
+    });
+
+    const logLines = (await readFile(logPath, 'utf8')).trim().split('\n');
+    expect(logLines[0]).to.equal(
+      JSON.stringify({
+        timestamp: '2025-01-02T03:04:05.678Z',
+        level: 'info',
+        message: 'Tool invocation completed',
+        traceId,
+        details: { durationMs: 1200 },
+      }),
+    );
+  });
+});
+

--- a/validation_runs/20251007T184620Z/tests/baseTools.test.ts
+++ b/validation_runs/20251007T184620Z/tests/baseTools.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import { mkdtemp, rm, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { ensureRunDirectories, createTraceIdFactory, type RunContext } from '../lib/runContext.js';
+import { ArtifactRecorder } from '../lib/artifactRecorder.js';
+import { runBaseToolsStage } from '../lib/baseTools.js';
+
+import { getRuntimeFeatures, configureRuntimeFeatures, server } from '../../../src/server.js';
+import type { FeatureToggles } from '../../../src/serverOptions.js';
+
+/**
+ * Deterministic clock helper ensuring generated artefact names remain stable
+ * during tests. Each invocation increases the timestamp by one second so JSON
+ * snapshots keep unique names without relying on real wall-clock time.
+ */
+function buildDeterministicClock(startIso = '2025-02-02T00:00:00.000Z'): () => Date {
+  const start = new Date(startIso).getTime();
+  let tick = 0;
+  return () => new Date(start + tick++ * 1000);
+}
+
+describe('Stage 2 – Base MCP tool smoke tests', () => {
+  let context: RunContext;
+  let recorder: ArtifactRecorder;
+  let tempRoot: string;
+  let baselineFeatures: FeatureToggles;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), 'mcp-base-tools-'));
+    const directories = await ensureRunDirectories(tempRoot);
+    context = {
+      runId: 'test-base-tools',
+      rootDir: tempRoot,
+      directories,
+      createTraceId: createTraceIdFactory('base-tools-test'),
+    };
+    recorder = new ArtifactRecorder(context, { clock: buildDeterministicClock() });
+    baselineFeatures = getRuntimeFeatures();
+  });
+
+  afterEach(async () => {
+    await configureRuntimeFeatures(baselineFeatures);
+    await server.close().catch(() => {});
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('runs the base tools stage and persists deterministic artefacts', async () => {
+    const result = await runBaseToolsStage({ context, recorder });
+
+    expect(result.calls.length).to.be.at.least(5);
+    const toolNames = result.calls.map((entry) => entry.toolName);
+    expect(toolNames).to.include.members([
+      'graph_generate',
+      'graph_validate',
+      'graph_summarize',
+      'graph_paths_k_shortest',
+      'logs_tail',
+    ]);
+
+    const invalidCall = result.calls.find(
+      (entry) => entry.toolName === 'graph_paths_k_shortest' && entry.scenario === 'invalid',
+    );
+    expect(invalidCall).to.not.equal(undefined);
+    expect(invalidCall?.response.isError).to.equal(true);
+    expect(invalidCall?.response.errorCode).to.equal('transport_failure');
+    expect(
+      typeof (invalidCall?.response.parsedText as { message?: string } | undefined)?.message,
+    ).to.equal('string');
+    expect(
+      (invalidCall?.response.parsedText as { message?: string } | undefined)?.message ?? '',
+    ).to.contain('Invalid arguments for tool graph_paths_k_shortest');
+
+    const report = JSON.parse(await readFile(result.reportPath, 'utf8')) as {
+      metrics: { totalCalls: number; errorCount: number };
+      calls: Array<{ toolName: string; scenario?: string }>;
+    };
+    expect(report.metrics.totalCalls).to.equal(result.calls.length);
+    expect(report.calls.some((entry) => entry.scenario === 'invalid')).to.equal(true);
+
+    if (result.generatedGraphPath) {
+      const stats = await stat(result.generatedGraphPath);
+      expect(stats.isFile()).to.equal(true);
+    } else {
+      expect.fail('expected generatedGraphPath to be defined');
+    }
+
+    const logsTailCall = result.calls.find((entry) => entry.toolName === 'logs_tail');
+    expect(logsTailCall?.response.isError).to.equal(false);
+    expect(logsTailCall?.response.structured).to.be.an('object');
+  }).timeout(20_000);
+});

--- a/validation_runs/20251007T184620Z/tests/introspection.test.ts
+++ b/validation_runs/20251007T184620Z/tests/introspection.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import { mkdtemp, rm, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { ensureRunDirectories, createTraceIdFactory } from '../lib/runContext.js';
+import { ArtifactRecorder } from '../lib/artifactRecorder.js';
+import { McpSession } from '../lib/mcpSession.js';
+import { runIntrospectionStage } from '../lib/introspection.js';
+import type { RunContext } from '../lib/runContext.js';
+
+import { getRuntimeFeatures, configureRuntimeFeatures, server } from '../../../src/server.js';
+import type { FeatureToggles } from '../../../src/serverOptions.js';
+
+/**
+ * Utility creating a deterministic clock used by the recorder to ensure tests
+ * can assert exact artefact names. Each invocation advances the timestamp by a
+ * single second which keeps JSON snapshots unique without introducing drift.
+ */
+function buildDeterministicClock(startIso = '2025-01-01T00:00:00.000Z'): () => Date {
+  const start = new Date(startIso).getTime();
+  let tick = 0;
+  return () => new Date(start + tick++ * 1000);
+}
+
+describe('MCP introspection harness', () => {
+  let context: RunContext;
+  let recorder: ArtifactRecorder;
+  let tempRoot: string;
+  let baselineFeatures: FeatureToggles;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), 'mcp-introspection-'));
+    const directories = await ensureRunDirectories(tempRoot);
+    context = {
+      runId: 'test-introspection',
+      rootDir: tempRoot,
+      directories,
+      createTraceId: createTraceIdFactory('introspection-test'),
+    };
+    recorder = new ArtifactRecorder(context, { clock: buildDeterministicClock() });
+    baselineFeatures = getRuntimeFeatures();
+  });
+
+  afterEach(async () => {
+    await configureRuntimeFeatures(baselineFeatures);
+    await server.close().catch(() => {});
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('records tool invocations and restores feature toggles', async () => {
+    const session = new McpSession({
+      context,
+      recorder,
+      featureOverrides: { enableMcpIntrospection: true },
+      clientName: 'introspection-test-client',
+    });
+
+    await session.open();
+    const call = await session.callTool('mcp_info', {});
+    await session.close();
+
+    const restored = getRuntimeFeatures();
+    expect(restored).to.deep.equal(baselineFeatures);
+
+    const outputSnapshot = JSON.parse(await readFile(call.artefacts.outputPath, 'utf8')) as Record<string, unknown>;
+    expect(outputSnapshot).to.have.property('traceId', call.traceId);
+
+    const logContents = await readFile(path.join(context.directories.logs, 'run.log'), 'utf8');
+    expect(logContents).to.contain('"tool":"mcp_info"');
+    expect(logContents).to.contain('"message":"tool_call_completed"');
+  }).timeout(10_000);
+
+  it('runs the introspection stage and generates summary artefacts', async () => {
+    const summary = await runIntrospectionStage({ context, recorder });
+
+    expect(summary.info.server.name).to.equal('mcp-self-fork-orchestrator');
+    expect(summary.capabilities.namespaces).to.be.an('array');
+    expect(summary.reportPath).to.satisfy((p: string) => p.endsWith('step01-introspection.json'));
+
+    const report = JSON.parse(await readFile(summary.reportPath, 'utf8')) as Record<string, unknown>;
+    expect(report).to.have.property('events');
+
+    const resourceIndex = JSON.parse(await readFile(summary.resourceIndexPath, 'utf8')) as {
+      all: unknown[];
+      byPrefix: Array<{ prefix: string; traceId: string }>;
+    };
+    expect(resourceIndex.byPrefix.every((entry) => typeof entry.traceId === 'string')).to.equal(true);
+
+    const eventFiles = await readdir(context.directories.events);
+    expect(eventFiles.length).to.be.greaterThan(0);
+
+    const followUpSeqs = summary.eventProbe.followUp.events.map((evt) => evt.seq);
+    expect(followUpSeqs).to.include(summary.eventProbe.published.seq);
+
+    const logContents = await readFile(path.join(context.directories.logs, 'run.log'), 'utf8');
+    expect(logContents).to.contain('introspection_stage_completed');
+
+    const restored = getRuntimeFeatures();
+    expect(restored).to.deep.equal(baselineFeatures);
+  }).timeout(20_000);
+});
+

--- a/validation_runs/20251007T184620Z/tests/runContext.test.ts
+++ b/validation_runs/20251007T184620Z/tests/runContext.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { expect } from 'chai';
+
+import {
+  createRunContext,
+  createTraceIdFactory,
+  ensureRunDirectories,
+} from '../lib/runContext.js';
+
+/**
+ * The tests focus on the deterministic behaviour of the filesystem helpers and
+ * the trace identifier factory used by the validation harness.
+ */
+describe('runContext utilities', () => {
+  it('creates the expected directory structure when missing', async () => {
+    const scratchRoot = await mkdtemp(path.join(tmpdir(), 'run-context-'));
+    const directories = await ensureRunDirectories(scratchRoot);
+
+    for (const [label, dirPath] of Object.entries(directories)) {
+      const stats = await stat(dirPath);
+      expect(stats.isDirectory(), `${label} should be a directory`).to.equal(true);
+    }
+
+    await rm(scratchRoot, { recursive: true, force: true });
+  });
+
+  it('produces deterministic trace identifiers when the seed is reused', () => {
+    const factoryA = createTraceIdFactory('seed');
+    const factoryB = createTraceIdFactory('seed');
+
+    const tracesA = Array.from({ length: 3 }, () => factoryA());
+    const tracesB = Array.from({ length: 3 }, () => factoryB());
+
+    expect(tracesA).to.deep.equal(tracesB);
+    expect(new Set(tracesA).size).to.equal(tracesA.length);
+  });
+
+  it('initialises the run context relative to the workspace root', async () => {
+    const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'workspace-'));
+    const runId = 'TEST-RUN';
+    const context = await createRunContext({ runId, workspaceRoot, traceSeed: 'trace-seed' });
+
+    expect(context.runId).to.equal(runId);
+    expect(context.rootDir).to.equal(path.join(workspaceRoot, 'validation_runs', runId));
+
+    const trace = context.createTraceId();
+    expect(trace).to.match(/^trace-[0-9a-f]{32}$/);
+
+    for (const dirPath of Object.values(context.directories)) {
+      const stats = await stat(dirPath);
+      expect(stats.isDirectory()).to.equal(true);
+    }
+
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+});

--- a/validation_runs/20251007T184620Z/tests/transactions.test.ts
+++ b/validation_runs/20251007T184620Z/tests/transactions.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect } from 'chai';
+import { mkdtemp, rm, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { ensureRunDirectories, createTraceIdFactory, type RunContext } from '../lib/runContext.js';
+import { ArtifactRecorder } from '../lib/artifactRecorder.js';
+import { runTransactionsStage } from '../lib/transactions.js';
+
+import { getRuntimeFeatures, configureRuntimeFeatures, server } from '../../../src/server.js';
+import type { FeatureToggles } from '../../../src/serverOptions.js';
+
+/**
+ * Deterministic clock helper ensuring generated artefact names remain stable
+ * during tests. Each invocation increases the timestamp by one second so JSON
+ * snapshots keep unique names without relying on real wall-clock time.
+ */
+function buildDeterministicClock(startIso = '2025-03-03T00:00:00.000Z'): () => Date {
+  const start = new Date(startIso).getTime();
+  let tick = 0;
+  return () => new Date(start + tick++ * 1000);
+}
+
+describe('Stage 3 – Transaction, diff/patch and idempotency checks', () => {
+  let context: RunContext;
+  let recorder: ArtifactRecorder;
+  let tempRoot: string;
+  let baselineFeatures: FeatureToggles;
+
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(tmpdir(), 'mcp-transactions-'));
+    const directories = await ensureRunDirectories(tempRoot);
+    context = {
+      runId: 'test-transactions',
+      rootDir: tempRoot,
+      directories,
+      createTraceId: createTraceIdFactory('transactions-test'),
+    };
+    recorder = new ArtifactRecorder(context, { clock: buildDeterministicClock() });
+    baselineFeatures = getRuntimeFeatures();
+  });
+
+  afterEach(async () => {
+    await configureRuntimeFeatures(baselineFeatures);
+    await server.close().catch(() => {});
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('runs the transaction stage and captures diff/patch/lock/idempotency artefacts', async () => {
+    const result = await runTransactionsStage({ context, recorder });
+
+    expect(result.graphId).to.equal('G_TEST');
+    expect(result.calls.length).to.be.at.least(12);
+
+    const toolNames = result.calls.map((entry) => `${entry.toolName}:${entry.scenario ?? 'default'}`);
+    expect(toolNames).to.include.members([
+      'tx_begin:tx_begin_initial',
+      'tx_apply:tx_apply_enrichment',
+      'tx_commit:tx_commit_initial',
+      'graph_diff:graph_diff_post_commit',
+      'graph_diff:graph_diff_patch_plan',
+      'graph_diff:graph_diff_cycle_plan',
+      'graph_patch:graph_patch_success',
+      'graph_patch:graph_patch_invariant_violation',
+      'graph_lock:graph_lock_acquire',
+      'graph_unlock:graph_unlock_release',
+      'tx_begin:tx_begin_idempotency_initial',
+      'tx_begin:tx_begin_idempotency_replay',
+      'tx_rollback:tx_rollback_idempotency_cleanup',
+    ]);
+
+    const invalidPatch = result.calls.find(
+      (entry) => entry.toolName === 'graph_patch' && entry.scenario === 'graph_patch_invariant_violation',
+    );
+    expect(invalidPatch?.response.isError).to.equal(true);
+    expect(invalidPatch?.response.errorCode).to.be.a('string');
+
+    const replayCall = result.calls.find(
+      (entry) => entry.toolName === 'tx_begin' && entry.scenario === 'tx_begin_idempotency_replay',
+    );
+    expect(replayCall?.response.isError).to.equal(false);
+    const structuredReplay = replayCall?.response.structured as { idempotent?: boolean } | undefined;
+    expect(structuredReplay?.idempotent).to.equal(true);
+
+    if (result.finalGraphPath) {
+      const stats = await stat(result.finalGraphPath);
+      expect(stats.isFile()).to.equal(true);
+    } else {
+      expect.fail('expected finalGraphPath to be defined');
+    }
+
+    const report = JSON.parse(await readFile(result.reportPath, 'utf8')) as {
+      metrics: { totalCalls: number; errorCount: number };
+      diff: { changed: boolean; operations: number } | null;
+      patch: { failureCode: string | null };
+      locks: { conflictCode: string | null; lockId: string };
+      idempotency: {
+        identicalPayload: boolean;
+        initialFlag: boolean;
+        replayFlag: boolean;
+        txId: string;
+      };
+    };
+
+    expect(report.metrics.totalCalls).to.equal(result.calls.length);
+    expect(report.metrics.errorCount).to.be.greaterThan(0);
+    expect(report.diff?.changed).to.equal(true);
+    expect((report.diff?.operations ?? 0)).to.be.greaterThan(0);
+    expect(report.patch.failureCode).to.equal('E-PATCH-CYCLE');
+    expect(report.locks.lockId).to.be.a('string').and.to.have.length.greaterThan(0);
+    expect(report.idempotency.identicalPayload).to.equal(true);
+    expect(report.idempotency.initialFlag).to.equal(false);
+    expect(report.idempotency.replayFlag).to.equal(true);
+    expect(report.idempotency.txId).to.be.a('string').and.to.have.length.greaterThan(0);
+  }).timeout(20_000);
+});


### PR DESCRIPTION
## Summary
- implement the Stage 3 transaction validation runner to exercise tx begin/apply/commit, diff/patch planning, cooperative locks, and idempotency reporting
- document the new stage in the validation run README and update the MCP checklist progress log
- add mocha coverage ensuring the Stage 3 harness emits the expected artefacts, metrics, and lock/idempotency behaviour

## Testing
- npm run lint
- node --import tsx ./node_modules/mocha/bin/mocha.js --reporter spec "validation_runs/20251007T184620Z/tests/**/*.test.ts"

------
https://chatgpt.com/codex/tasks/task_e_68e55f5d8e44832fbd44f40d1f97e6ed