### PR TITLE
Implement search status tool and job store wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,12 @@ UNSTRUCTURED_STRATEGY=hi_res
 UNSTRUCTURED_API_KEY=
 # Timeout lors du téléchargement des contenus distants (ms).
 SEARCH_FETCH_TIMEOUT_MS=20000
+# Backend de persistance pour `search.status` (`file` ou `memory`).
+MCP_SEARCH_STATUS_PERSIST=file
+# TTL du journal des jobs de recherche (ms). Défaut : 7 jours.
+MCP_SEARCH_JOB_TTL_MS=604800000
+# Politique d'`fsync` pour le journal JSONL (`always`, `interval`, `never`).
+MCP_SEARCH_JOURNAL_FSYNC=interval
 # Taille maximale de contenu téléchargé (octets).
 SEARCH_FETCH_MAX_BYTES=15000000
 # User-Agent explicite envoyé lors du fetch.

--- a/src/eventStore.ts
+++ b/src/eventStore.ts
@@ -154,10 +154,13 @@ export type EventKind =
   | "AUTOSCALER"
   | "COGNITIVE"
   | "HTTP_ACCESS" // Structured audit log capturing HTTP access (ip/route/status/latency).
+  | "search:job_created"
   | "search:job_started"
+  | "search:job_progress"
   | "search:doc_ingested"
   | "search:error"
-  | "search:job_completed";
+  | "search:job_completed"
+  | "search:job_failed";
 
 export type EventLevel = "info" | "warn" | "error";
 export type EventSource = "orchestrator" | "child" | "system";

--- a/src/http/bootstrap.ts
+++ b/src/http/bootstrap.ts
@@ -6,7 +6,7 @@ import type { StructuredLogger } from "../logger.js";
 import type { EventStore } from "../eventStore.js";
 import type { HttpRuntimeOptions } from "../serverOptions.js";
 import { evaluateHttpReadiness } from "./readiness.js";
-import { IDEMPOTENCY_TTL_OVERRIDE } from "../orchestrator/runtime.js";
+import { IDEMPOTENCY_TTL_OVERRIDE, getSearchJobStoreSnapshot } from "../orchestrator/runtime.js";
 import { FileIdempotencyStore } from "../infra/idempotencyStore.file.js";
 import { loadGraphForge } from "../graph/forgeLoader.js";
 import { readOptionalString } from "../config/env.js";
@@ -108,6 +108,7 @@ export async function prepareHttpRuntime(
         runsRoot,
         eventStore: context.eventStore,
         idempotencyStore,
+        searchJobStore: getSearchJobStoreSnapshot(),
       }),
   };
 

--- a/src/orchestrator/logging.ts
+++ b/src/orchestrator/logging.ts
@@ -35,8 +35,11 @@ const EVENT_KIND_TO_CATEGORY: Record<EventKind, EventCategory> = {
   COGNITIVE: "child",
   HTTP_ACCESS: "graph",
   "search:job_started": "graph",
+  "search:job_created": "graph",
   "search:doc_ingested": "graph",
   "search:error": "graph",
+  "search:job_progress": "graph",
+  "search:job_failed": "graph",
   "search:job_completed": "graph",
 };
 

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -63,6 +63,24 @@ export {
   type SearchJobResult,
   type SearchJobStats,
 } from "./pipeline.js";
+export {
+  type JobBudget,
+  type JobFailure,
+  type JobMeta,
+  type JobProgress,
+  type JobProvenance,
+  type JobRecord,
+  type JobState,
+  type JobStatePatch,
+  type JobStatus,
+  type JobSummary,
+  type ListFilter,
+  type SearchJobStore,
+  type StoredJobMeta,
+  type JsonValue,
+} from "./jobStore.js";
+export { FileSearchJobStore } from "./jobStoreFile.js";
+export { InMemorySearchJobStore } from "./jobStoreMemory.js";
 export { SearxClient, SearxClientError } from "./searxClient.js";
 export type { SearxQueryOptions, SearxQueryResponse } from "./searxClient.js";
 export {

--- a/src/search/jobStore.ts
+++ b/src/search/jobStore.ts
@@ -1,0 +1,212 @@
+/**
+ * JSON-compatible value used for structured metadata persisted alongside job
+ * records. Defining it locally keeps the module self-contained and avoids
+ * leaking `undefined` when the payloads are stringified.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { readonly [key: string]: JsonValue }
+  | readonly JsonValue[];
+
+/**
+ * Enumerates the lifecycle states a search job transitions through while the
+ * orchestrator processes a request. Terminal states (`completed` and `failed`)
+ * are immutable once reached to guarantee reliable replay and observability.
+ */
+export type JobStatus = "pending" | "running" | "completed" | "failed";
+
+/**
+ * Captures the resource ceilings enforced for a job. Explicit `null` values
+ * mean "no limit" which avoids leaking `undefined` when serialising to JSON.
+ */
+export interface JobBudget {
+  readonly maxDurationMs: number | null;
+  readonly maxToolCalls: number | null;
+  readonly maxBytesOut: number | null;
+}
+
+/**
+ * Structured context describing who initiated the job and how it reached the
+ * orchestrator. The payload is intentionally conservative (plain data) so it
+ * can be safely persisted in JSONL logs.
+ */
+export interface JobProvenance {
+  /** Human-readable trigger such as `search.run` or `search.index`. */
+  readonly trigger: string;
+  /** Transport that submitted the request (STDIO, HTTP, scheduler, ...). */
+  readonly transport: string;
+  /** Correlation identifier when available (request id, span id, ...). */
+  readonly requestId: string | null;
+  /** Optional caller identifier when authentication is enabled. */
+  readonly requester: string | null;
+  /** Optional remote endpoint (IP:port) when sourced from HTTP. */
+  readonly remoteAddress: string | null;
+  /**
+   * Additional machine-readable metadata preserved for debugging. The payload
+   * must stay JSON serialisable to keep the job journal append-only.
+   */
+  readonly extra: Readonly<Record<string, JsonValue>>;
+}
+
+/**
+ * Lightweight progress beacon surfaced while the job is running. Each update
+ * overwrites the previous one which keeps the persisted footprint compact.
+ */
+export interface JobProgress {
+  /** High-level pipeline step (searx, download, extract, ingest, ...). */
+  readonly step: string;
+  /** Optional human friendly description for dashboards. */
+  readonly message: string | null;
+  /** Ratio between 0 and 1 when the progress can be quantified. */
+  readonly ratio: number | null;
+  /** Timestamp (ms epoch) at which the progress update was emitted. */
+  readonly updatedAt: number;
+}
+
+/**
+ * Snapshot summarising the outcome of a job once it reaches a terminal state.
+ */
+export interface JobSummary {
+  /** Number of Searx results considered during the run. */
+  readonly consideredResults: number;
+  /** Number of documents successfully fetched. */
+  readonly fetchedDocuments: number;
+  /** Number of documents ingested into downstream stores. */
+  readonly ingestedDocuments: number;
+  /** Number of documents skipped because of idempotence or guards. */
+  readonly skippedDocuments: number;
+  /** Absolute paths to artefacts emitted under `validation_run/`. */
+  readonly artifacts: readonly string[];
+  /** Arbitrary numeric metrics (latencies, percentiles, custom counters). */
+  readonly metrics: Readonly<Record<string, number>>;
+  /** Optional free-form commentary (kept short for dashboards). */
+  readonly notes: string | null;
+}
+
+/**
+ * Structured failure captured when the job enters the `failed` state. The list
+ * is preserved even for successful jobs to retain intermediate non-fatal
+ * issues (e.g. skipped downloads, extractor hiccups).
+ */
+export interface JobFailure {
+  /** Stable error code to assist with analytics and alerting. */
+  readonly code: string;
+  /** Human friendly description already redacted. */
+  readonly message: string;
+  /** Optional pipeline stage where the failure originated. */
+  readonly stage: string | null;
+  /** Timestamp (ms epoch) when the failure was recorded. */
+  readonly occurredAt: number;
+  /** Additional safe-to-log metadata for debugging. */
+  readonly details: JsonValue | null;
+}
+
+/**
+ * Runtime state stored for each job. All timestamps are monotonically
+ * increasing to make GC and dashboards predictable.
+ */
+export interface JobState {
+  readonly status: JobStatus;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly startedAt: number | null;
+  readonly completedAt: number | null;
+  readonly failedAt: number | null;
+  readonly progress: JobProgress | null;
+  readonly summary: JobSummary | null;
+  readonly errors: readonly JobFailure[];
+}
+
+/**
+ * Partial update accepted by {@link SearchJobStore.update}. Properties omitted
+ * from the patch remain untouched. When a value should be cleared the caller
+ * must explicitly provide `null`.
+ */
+export interface JobStatePatch {
+  readonly status?: JobStatus;
+  readonly updatedAt?: number;
+  readonly startedAt?: number | null;
+  readonly completedAt?: number | null;
+  readonly failedAt?: number | null;
+  readonly progress?: JobProgress | null;
+  readonly summary?: JobSummary | null;
+  readonly errors?: readonly JobFailure[];
+}
+
+/**
+ * Metadata persisted for every job. The structure is intentionally compact and
+ * deterministic so it can be hashed to produce the idempotent job id.
+ */
+export interface JobMeta {
+  /** Deterministic identifier derived from the normalised query + options. */
+  readonly id: string;
+  /** Timestamp (ms epoch) at which the request entered the orchestrator. */
+  readonly createdAt: number;
+  /** Raw query provided by the user or upstream caller. */
+  readonly query: string;
+  /** Canonicalised query used for idempotent comparisons. */
+  readonly normalizedQuery: string;
+  /** Optional logical tags (scenario id, campaign, custom labels). */
+  readonly tags: readonly string[];
+  /** Identifier of the authenticated caller when known. */
+  readonly requester: string | null;
+  /** Resource ceilings applied to this job (durations, budgets, ...). */
+  readonly budget: JobBudget;
+  /** Provenance payload preserved alongside the metadata. */
+  readonly provenance: JobProvenance;
+}
+
+/** Snapshot of the metadata returned by {@link SearchJobStore.get}. */
+export type StoredJobMeta = Omit<JobMeta, "provenance">;
+
+/**
+ * Full record returned by the job store. Consumers receive immutable copies to
+ * prevent accidental mutation of the authoritative state kept in the store.
+ */
+export interface JobRecord {
+  readonly meta: StoredJobMeta;
+  readonly state: JobState;
+  readonly provenance: JobProvenance;
+}
+
+/**
+ * Filter accepted by {@link SearchJobStore.list}. When multiple criteria are
+ * provided they are ANDed together.
+ */
+export interface ListFilter {
+  /** Restrict the result set to specific states. */
+  readonly status?: JobStatus | readonly JobStatus[];
+  /** Keep jobs updated on/after this timestamp (ms epoch). */
+  readonly since?: number;
+  /** Keep jobs updated on/before this timestamp (ms epoch). */
+  readonly until?: number;
+  /** Require at least one matching tag. */
+  readonly tag?: string;
+  /** Require all the provided tags to be present. */
+  readonly tags?: readonly string[];
+  /** Maximum number of entries to return (most recent first). */
+  readonly limit?: number;
+}
+
+/** Contract implemented by concrete job store backends. */
+export interface SearchJobStore {
+  /** Persist a brand new job. Must throw when the id already exists. */
+  create(job: JobMeta): Promise<void>;
+  /** Patch the runtime state of an existing job. */
+  update(jobId: string, patch: JobStatePatch): Promise<void>;
+  /** Retrieve a single job record. Returns `null` when unknown. */
+  get(jobId: string): Promise<JobRecord | null>;
+  /**
+   * Enumerate jobs optionally filtered by state, tags or recency. Backends are
+   * free to implement additional optimisations (pagination, streaming, ...).
+   */
+  list(filter?: ListFilter): Promise<JobRecord[]>;
+  /**
+   * Garbage collect expired entries. Implementations return the number of
+   * purged records so callers can expose the information via metrics.
+   */
+  gc(now: number): Promise<number>;
+}

--- a/src/search/jobStoreFile.ts
+++ b/src/search/jobStoreFile.ts
@@ -1,0 +1,678 @@
+import { promises as fs } from "node:fs";
+import { open as openFile, type FileHandle } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  type JobFailure,
+  type JobMeta,
+  type JobProgress,
+  type JobProvenance,
+  type JobRecord,
+  type JobState,
+  type JobStatePatch,
+  type JobStatus,
+  type JobSummary,
+  type ListFilter,
+  type SearchJobStore,
+  type StoredJobMeta,
+} from "./jobStore.js";
+
+/** Default TTL (7 days) applied to terminal jobs before GC purges them. */
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Default interval (in milliseconds) between best-effort fsync operations. */
+const DEFAULT_FSYNC_INTERVAL_MS = 1_000;
+
+/** Guard returning `true` when the provided status is terminal. */
+const isTerminalStatus = (status: JobStatus): boolean =>
+  status === "completed" || status === "failed";
+
+/** Simple async mutex providing coarse-grained critical sections. */
+class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(operation: () => Promise<T> | T): Promise<T> {
+    const release = this.enqueue();
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private enqueue(): () => void {
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.tail;
+    this.tail = previous.then(() => wait);
+    return release;
+  }
+}
+
+/** Configuration accepted by {@link FileSearchJobStore}. */
+export interface FileSearchJobStoreOptions {
+  /** Directory holding the JSONL journal and compaction artefacts. */
+  readonly directory: string;
+  /** Time-to-live applied to terminal jobs during garbage collection. */
+  readonly ttlMs?: number;
+  /** Clock used for deterministic testing. */
+  readonly clock?: () => number;
+  /**
+   * Strategy governing when `fsync` is invoked. `interval` batches disk flushes
+   * behind a timer to amortise I/O costs while still providing durability.
+   */
+  readonly fsyncMode?: "always" | "interval" | "never";
+  /** Interval used when `fsyncMode === "interval"`. */
+  readonly fsyncIntervalMs?: number;
+  /** Optional logger used to surface locking or recovery warnings. */
+  readonly log?: (level: "warn" | "info", message: string) => void;
+}
+
+interface InternalRecord {
+  readonly meta: StoredJobMeta;
+  readonly provenance: JobProvenance;
+  readonly state: JobState;
+}
+
+interface SnapshotEntry {
+  readonly type: "snapshot";
+  readonly job: SerializedRecord;
+}
+
+interface UpdateEntry {
+  readonly type: "update";
+  readonly jobId: string;
+  readonly state: SerializedState;
+}
+
+type JournalEntry = SnapshotEntry | UpdateEntry;
+
+interface SerializedRecord {
+  readonly meta: SerializedMeta;
+  readonly provenance: SerializedProvenance;
+  readonly state: SerializedState;
+}
+
+type SerializedMeta = StoredJobMeta;
+type SerializedProvenance = JobProvenance;
+type SerializedState = JobState;
+
+/** Utility converting unknown inputs to a clean {@link StoredJobMeta}. */
+const normaliseMeta = (meta: JobMeta): StoredJobMeta => ({
+  id: meta.id,
+  createdAt: meta.createdAt,
+  query: meta.query,
+  normalizedQuery: meta.normalizedQuery,
+  tags: [...meta.tags],
+  requester: meta.requester ?? null,
+  budget: {
+    maxDurationMs: meta.budget.maxDurationMs ?? null,
+    maxToolCalls: meta.budget.maxToolCalls ?? null,
+    maxBytesOut: meta.budget.maxBytesOut ?? null,
+  },
+});
+
+/** Remove duplicates and whitespace from tag arrays. */
+const normaliseTags = (tags: readonly string[]): readonly string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of tags) {
+    const tag = raw.trim();
+    if (tag.length === 0) {
+      continue;
+    }
+    if (!seen.has(tag)) {
+      seen.add(tag);
+      result.push(tag);
+    }
+  }
+  return result;
+};
+
+/** Produce a defensive copy of the provided provenance payload. */
+const cloneProvenance = (provenance: JobProvenance): JobProvenance => ({
+  trigger: provenance.trigger,
+  transport: provenance.transport,
+  requestId: provenance.requestId ?? null,
+  requester: provenance.requester ?? null,
+  remoteAddress: provenance.remoteAddress ?? null,
+  extra: { ...(provenance.extra ?? {}) },
+});
+
+/** Deep clone for progress beacons. */
+const cloneProgress = (progress: JobProgress): JobProgress => ({
+  step: progress.step,
+  message: progress.message ?? null,
+  ratio: progress.ratio ?? null,
+  updatedAt: progress.updatedAt,
+});
+
+/** Deep clone for summary payloads. */
+const cloneSummary = (summary: JobSummary): JobSummary => ({
+  consideredResults: summary.consideredResults,
+  fetchedDocuments: summary.fetchedDocuments,
+  ingestedDocuments: summary.ingestedDocuments,
+  skippedDocuments: summary.skippedDocuments,
+  artifacts: [...summary.artifacts],
+  metrics: { ...summary.metrics },
+  notes: summary.notes ?? null,
+});
+
+/** Deep clone for failure entries. */
+const cloneFailure = (failure: JobFailure): JobFailure => ({
+  code: failure.code,
+  message: failure.message,
+  stage: failure.stage ?? null,
+  occurredAt: failure.occurredAt,
+  details: failure.details ?? null,
+});
+
+/**
+ * Serialize a record to a JSON-friendly payload. The structure only contains
+ * primitives, arrays and plain objects to guarantee `JSON.stringify` fidelity.
+ */
+const serialiseRecord = (record: InternalRecord): SerializedRecord => ({
+  meta: {
+    id: record.meta.id,
+    createdAt: record.meta.createdAt,
+    query: record.meta.query,
+    normalizedQuery: record.meta.normalizedQuery,
+    tags: [...record.meta.tags],
+    requester: record.meta.requester,
+    budget: { ...record.meta.budget },
+  },
+  provenance: cloneProvenance(record.provenance),
+  state: serialiseState(record.state),
+});
+
+/** Serialise a job state ensuring nested data is copied defensively. */
+const serialiseState = (state: JobState): JobState => ({
+  status: state.status,
+  createdAt: state.createdAt,
+  updatedAt: state.updatedAt,
+  startedAt: state.startedAt,
+  completedAt: state.completedAt,
+  failedAt: state.failedAt,
+  progress: state.progress ? cloneProgress(state.progress) : null,
+  summary: state.summary ? cloneSummary(state.summary) : null,
+  errors: state.errors.map(cloneFailure),
+});
+
+/** Reconstruct an in-memory record from a snapshot entry. */
+const hydrateRecord = (snapshot: SerializedRecord): InternalRecord => ({
+  meta: {
+    id: snapshot.meta.id,
+    createdAt: snapshot.meta.createdAt,
+    query: snapshot.meta.query,
+    normalizedQuery: snapshot.meta.normalizedQuery,
+    tags: [...snapshot.meta.tags],
+    requester: snapshot.meta.requester,
+    budget: { ...snapshot.meta.budget },
+  },
+  provenance: cloneProvenance(snapshot.provenance),
+  state: serialiseState(snapshot.state),
+});
+
+/**
+ * File-backed job store persisting records in an append-only JSONL journal. The
+ * implementation keeps an in-memory index for quick lookups while flushing
+ * mutations to disk based on the configured fsync policy.
+ */
+export class FileSearchJobStore implements SearchJobStore {
+  private readonly ttlMs: number;
+  private readonly clock: () => number;
+  private readonly fsyncMode: "always" | "interval" | "never";
+  private readonly fsyncIntervalMs: number;
+  private readonly log: (level: "warn" | "info", message: string) => void;
+  private readonly directory: string;
+  private readonly journalPath: string;
+  private readonly lockPath: string;
+  private readonly mutex = new AsyncMutex();
+  private readonly records = new Map<string, InternalRecord>();
+
+  private journalHandle: FileHandle | null = null;
+  private syncTimer: NodeJS.Timeout | null = null;
+  private pendingSync = false;
+  private hasLock = false;
+
+  constructor(options: FileSearchJobStoreOptions) {
+    this.directory = options.directory;
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.clock = options.clock ?? (() => Date.now());
+    this.fsyncMode = options.fsyncMode ?? "interval";
+    this.fsyncIntervalMs = options.fsyncIntervalMs ?? DEFAULT_FSYNC_INTERVAL_MS;
+    this.log = options.log ?? (() => {});
+    this.journalPath = path.join(this.directory, "jobs.active.jsonl");
+    this.lockPath = path.join(this.directory, "jobs.lock");
+  }
+
+  /** Initialise the store by loading the existing journal from disk. */
+  async initialise(): Promise<void> {
+    await fs.mkdir(this.directory, { recursive: true });
+    await this.acquireLock();
+    await this.recoverFromJournal();
+    this.journalHandle = await openFile(this.journalPath, "a");
+    if (this.fsyncMode === "interval") {
+      this.syncTimer = setInterval(() => {
+        void this.flushPendingSync().catch((error) => {
+          this.log("warn", `Failed to fsync job journal: ${String(error)}`);
+        });
+      }, this.fsyncIntervalMs);
+      this.syncTimer.unref();
+    }
+  }
+
+  async create(job: JobMeta): Promise<void> {
+    await this.ensureReady();
+    await this.mutex.runExclusive(async () => {
+      const jobId = job.id.trim();
+      if (jobId.length === 0) {
+        throw new Error("Job id must not be empty");
+      }
+      if (this.records.has(jobId)) {
+        throw new Error(`Job with id ${jobId} already exists`);
+      }
+
+      const meta: StoredJobMeta = {
+        ...normaliseMeta(job),
+        tags: normaliseTags(job.tags),
+      };
+
+      const initialState: JobState = {
+        status: "pending",
+        createdAt: meta.createdAt,
+        updatedAt: meta.createdAt,
+        startedAt: null,
+        completedAt: null,
+        failedAt: null,
+        progress: null,
+        summary: null,
+        errors: [],
+      };
+
+      const provenance = cloneProvenance(job.provenance);
+      const record: InternalRecord = { meta, provenance, state: initialState };
+      this.records.set(jobId, record);
+
+      await this.appendEntry({
+        type: "snapshot",
+        job: serialiseRecord(record),
+      });
+    });
+  }
+
+  async update(jobId: string, patch: JobStatePatch): Promise<void> {
+    await this.ensureReady();
+    await this.mutex.runExclusive(async () => {
+      const record = this.records.get(jobId);
+      if (!record) {
+        throw new Error(`Unknown job id ${jobId}`);
+      }
+      if (isTerminalStatus(record.state.status)) {
+        throw new Error(`Job ${jobId} is immutable after reaching ${record.state.status}`);
+      }
+
+      const nextState = this.applyPatch(record.state, patch);
+      const nextRecord: InternalRecord = {
+        meta: record.meta,
+        provenance: record.provenance,
+        state: nextState,
+      };
+      this.records.set(jobId, nextRecord);
+
+      await this.appendEntry({
+        type: "update",
+        jobId,
+        state: serialiseState(nextState),
+      });
+    });
+  }
+
+  async get(jobId: string): Promise<JobRecord | null> {
+    await this.ensureReady();
+    const record = this.records.get(jobId);
+    if (!record) {
+      return null;
+    }
+    return this.cloneRecord(record);
+  }
+
+  async list(filter: ListFilter = {}): Promise<JobRecord[]> {
+    await this.ensureReady();
+    const { status, since, until, tag, tags, limit } = filter;
+    let statuses: Set<JobStatus> | null = null;
+    if (status !== undefined) {
+      if (typeof status === "string") {
+        statuses = new Set<JobStatus>([status]);
+      } else {
+        statuses = new Set<JobStatus>(status);
+      }
+    }
+    const requiredTags = tags === undefined ? null : new Set(tags);
+
+    const results: JobRecord[] = [];
+    for (const record of this.records.values()) {
+      if (statuses && !statuses.has(record.state.status)) {
+        continue;
+      }
+      if (since !== undefined && record.state.updatedAt < since) {
+        continue;
+      }
+      if (until !== undefined && record.state.updatedAt > until) {
+        continue;
+      }
+      if (tag && !record.meta.tags.includes(tag)) {
+        continue;
+      }
+      if (requiredTags) {
+        const hasAll = [...requiredTags].every((entry) => record.meta.tags.includes(entry));
+        if (!hasAll) {
+          continue;
+        }
+      }
+      results.push(this.cloneRecord(record));
+    }
+
+    results.sort((a, b) => b.state.updatedAt - a.state.updatedAt);
+    if (limit !== undefined && results.length > limit) {
+      return results.slice(0, limit);
+    }
+    return results;
+  }
+
+  async gc(now: number): Promise<number> {
+    await this.ensureReady();
+    return this.mutex.runExclusive(async () => {
+      let purged = 0;
+      for (const [jobId, record] of this.records.entries()) {
+        if (!isTerminalStatus(record.state.status)) {
+          continue;
+        }
+        if (now - record.state.updatedAt < this.ttlMs) {
+          continue;
+        }
+        this.records.delete(jobId);
+        purged += 1;
+      }
+
+      if (purged > 0) {
+        await this.rewriteJournal();
+      }
+
+      return purged;
+    });
+  }
+
+  /** Flush and close resources. Primarily used by tests. */
+  async dispose(): Promise<void> {
+    if (this.syncTimer) {
+      clearInterval(this.syncTimer);
+      this.syncTimer = null;
+    }
+    await this.flushPendingSync();
+    if (this.journalHandle) {
+      await this.journalHandle.close();
+      this.journalHandle = null;
+    }
+    if (this.hasLock) {
+      await fs.rm(this.lockPath, { force: true });
+      this.hasLock = false;
+    }
+  }
+
+  private async ensureReady(): Promise<void> {
+    if (!this.journalHandle) {
+      await this.initialise();
+    }
+  }
+
+  private cloneRecord(record: InternalRecord): JobRecord {
+    return {
+      meta: {
+        id: record.meta.id,
+        createdAt: record.meta.createdAt,
+        query: record.meta.query,
+        normalizedQuery: record.meta.normalizedQuery,
+        tags: [...record.meta.tags],
+        requester: record.meta.requester,
+        budget: { ...record.meta.budget },
+      },
+      provenance: cloneProvenance(record.provenance),
+      state: serialiseState(record.state),
+    };
+  }
+
+  private async appendEntry(entry: JournalEntry): Promise<void> {
+    if (!this.journalHandle) {
+      throw new Error("Job journal is not initialised");
+    }
+    const payload = `${JSON.stringify(entry)}\n`;
+    await this.journalHandle.write(payload);
+    switch (this.fsyncMode) {
+      case "always":
+        await this.journalHandle.sync();
+        break;
+      case "interval":
+        this.pendingSync = true;
+        break;
+      case "never":
+        break;
+    }
+  }
+
+  private async flushPendingSync(): Promise<void> {
+    if (!this.pendingSync) {
+      return;
+    }
+    if (!this.journalHandle) {
+      return;
+    }
+    try {
+      await this.journalHandle.sync();
+    } finally {
+      this.pendingSync = false;
+    }
+  }
+
+  private async rewriteJournal(): Promise<void> {
+    if (!this.journalHandle) {
+      throw new Error("Job journal is not initialised");
+    }
+    await this.flushPendingSync();
+    await this.journalHandle.close();
+    this.journalHandle = null;
+
+    const tempPath = path.join(this.directory, `jobs.compacted.${Date.now()}.jsonl`);
+    const handle = await openFile(tempPath, "w");
+    try {
+      const sorted = [...this.records.values()].sort(
+        (a, b) => a.state.updatedAt - b.state.updatedAt,
+      );
+      for (const record of sorted) {
+        const entry: SnapshotEntry = { type: "snapshot", job: serialiseRecord(record) };
+        await handle.write(`${JSON.stringify(entry)}\n`);
+      }
+      if (this.fsyncMode !== "never") {
+        await handle.sync();
+      }
+    } finally {
+      await handle.close();
+    }
+
+    await fs.rename(tempPath, this.journalPath);
+    this.journalHandle = await openFile(this.journalPath, "a");
+  }
+
+  private async recoverFromJournal(): Promise<void> {
+    try {
+      const content = await fs.readFile(this.journalPath, "utf8");
+      if (content.length === 0) {
+        return;
+      }
+      const lines = content.split(/\r?\n/);
+      for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (line.length === 0) {
+          continue;
+        }
+        try {
+          const parsed = JSON.parse(line) as JournalEntry;
+          if (parsed.type === "snapshot") {
+            const record = hydrateRecord(parsed.job);
+            this.records.set(record.meta.id, record);
+          } else if (parsed.type === "update") {
+            const record = this.records.get(parsed.jobId);
+            if (!record) {
+              throw new Error(`Missing base record for job ${parsed.jobId}`);
+            }
+            this.records.set(parsed.jobId, {
+              meta: record.meta,
+              provenance: record.provenance,
+              state: serialiseState(parsed.state),
+            });
+          }
+        } catch (error) {
+          this.log(
+            "warn",
+            `Failed to parse job journal entry: ${(error as Error).message ?? String(error)}`,
+          );
+        }
+      }
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private applyPatch(current: JobState, patch: JobStatePatch): JobState {
+    if (Object.prototype.hasOwnProperty.call(patch, "createdAt")) {
+      throw new Error("createdAt is immutable");
+    }
+
+    const updatedAt = patch.updatedAt ?? this.clock();
+    if (!Number.isFinite(updatedAt)) {
+      throw new Error("updatedAt must be a finite number");
+    }
+    if (updatedAt < current.updatedAt) {
+      throw new Error("updatedAt must be monotonically increasing");
+    }
+
+    const nextStatus = patch.status ?? current.status;
+    if (nextStatus !== current.status && !this.isValidTransition(current.status, nextStatus)) {
+      throw new Error(`Invalid status transition ${current.status} → ${nextStatus}`);
+    }
+
+    const startedAt = this.resolveTimestamp(patch.startedAt, current.startedAt, current.createdAt, updatedAt);
+    const completedAt = this.resolveTimestamp(
+      patch.completedAt,
+      current.completedAt,
+      current.createdAt,
+      updatedAt,
+    );
+    const failedAt = this.resolveTimestamp(patch.failedAt, current.failedAt, current.createdAt, updatedAt);
+
+    if (nextStatus === "running" && startedAt === null) {
+      throw new Error("running jobs must have a startedAt timestamp");
+    }
+    if (nextStatus === "completed" && completedAt === null) {
+      throw new Error("completed jobs must have a completedAt timestamp");
+    }
+    if (nextStatus === "failed" && failedAt === null) {
+      throw new Error("failed jobs must have a failedAt timestamp");
+    }
+
+    if (isTerminalStatus(nextStatus) && !isTerminalStatus(current.status)) {
+      // Allow updating summary/errors alongside the transition.
+    }
+
+    return {
+      status: nextStatus,
+      createdAt: current.createdAt,
+      updatedAt,
+      startedAt,
+      completedAt,
+      failedAt,
+      progress:
+        patch.progress === undefined
+          ? current.progress
+          : patch.progress === null
+          ? null
+          : cloneProgress(patch.progress),
+      summary:
+        patch.summary === undefined
+          ? current.summary
+          : patch.summary === null
+          ? null
+          : cloneSummary(patch.summary),
+      errors:
+        patch.errors === undefined
+          ? current.errors
+          : patch.errors.map(cloneFailure),
+    };
+  }
+
+  private resolveTimestamp(
+    candidate: number | null | undefined,
+    previous: number | null,
+    lowerBound: number,
+    fallback: number,
+  ): number | null {
+    if (candidate === undefined) {
+      if (previous !== null) {
+        return previous;
+      }
+      candidate = fallback;
+    }
+    if (candidate === null) {
+      return null;
+    }
+    if (!Number.isFinite(candidate)) {
+      throw new Error("timestamps must be finite numbers");
+    }
+    if (candidate < lowerBound) {
+      throw new Error("timestamps must be greater than or equal to createdAt");
+    }
+    if (previous !== null && candidate < previous) {
+      throw new Error("timestamps must be monotonically increasing");
+    }
+    return candidate;
+  }
+
+  private isValidTransition(from: JobStatus, to: JobStatus): boolean {
+    if (from === to) {
+      return true;
+    }
+    switch (from) {
+      case "pending":
+        return to === "running" || to === "failed";
+      case "running":
+        return to === "completed" || to === "failed";
+      default:
+        return false;
+    }
+  }
+
+  private async acquireLock(): Promise<void> {
+    try {
+      const handle = await openFile(this.lockPath, "wx");
+      await handle.write(`${process.pid}`);
+      await handle.close();
+      this.hasLock = true;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        this.log(
+          "warn",
+          "Job journal lock already exists. Continuing without exclusive ownership.",
+        );
+        this.hasLock = false;
+        return;
+      }
+      throw error;
+    }
+  }
+}
+

--- a/src/search/jobStoreMemory.ts
+++ b/src/search/jobStoreMemory.ts
@@ -1,0 +1,401 @@
+import {
+  type JobBudget,
+  type JobFailure,
+  type JobMeta,
+  type JobProgress,
+  type JobProvenance,
+  type JobRecord,
+  type JobState,
+  type JobStatePatch,
+  type JobStatus,
+  type JobSummary,
+  type ListFilter,
+  type SearchJobStore,
+  type StoredJobMeta,
+} from "./jobStore.js";
+
+/** Default TTL (7 days) applied when the caller does not provide one. */
+const DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Guard returning `true` when the job status is terminal. */
+const isTerminalStatus = (status: JobStatus): boolean =>
+  status === "completed" || status === "failed";
+
+/** Simple mutex used to provide coarse grained synchronisation. */
+class AsyncMutex {
+  private tail: Promise<void> = Promise.resolve();
+
+  async runExclusive<T>(operation: () => Promise<T> | T): Promise<T> {
+    const release = this.enqueue();
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private enqueue(): () => void {
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const previous = this.tail;
+    this.tail = previous.then(() => wait);
+    return release;
+  }
+}
+
+/**
+ * Options controlling the behaviour of {@link InMemorySearchJobStore}.
+ */
+export interface InMemorySearchJobStoreOptions {
+  /** Time to keep terminal jobs before `gc` purges them. */
+  readonly ttlMs?: number;
+  /** Clock used for deterministic testing. */
+  readonly clock?: () => number;
+}
+
+interface InternalRecord {
+  readonly meta: StoredJobMeta;
+  readonly provenance: JobProvenance;
+  readonly state: JobState;
+}
+
+/** Utility converting unknown inputs to a clean `JobBudget`. */
+const normaliseBudget = (budget: JobBudget | undefined): JobBudget => ({
+  maxDurationMs: budget?.maxDurationMs ?? null,
+  maxToolCalls: budget?.maxToolCalls ?? null,
+  maxBytesOut: budget?.maxBytesOut ?? null,
+});
+
+/** Remove duplicates and whitespace from tag arrays. */
+const normaliseTags = (tags: readonly string[]): readonly string[] => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of tags) {
+    const tag = raw.trim();
+    if (tag.length === 0) {
+      continue;
+    }
+    if (!seen.has(tag)) {
+      seen.add(tag);
+      result.push(tag);
+    }
+  }
+  return result;
+};
+
+/** Produce a defensive copy of the provided provenance payload. */
+const cloneProvenance = (provenance: JobProvenance): JobProvenance => ({
+  trigger: provenance.trigger,
+  transport: provenance.transport,
+  requestId: provenance.requestId ?? null,
+  requester: provenance.requester ?? null,
+  remoteAddress: provenance.remoteAddress ?? null,
+  extra: { ...(provenance.extra ?? {}) },
+});
+
+/** Deep clone for progress beacons. */
+const cloneProgress = (progress: JobProgress): JobProgress => ({
+  step: progress.step,
+  message: progress.message ?? null,
+  ratio: progress.ratio ?? null,
+  updatedAt: progress.updatedAt,
+});
+
+/** Deep clone for summary payloads. */
+const cloneSummary = (summary: JobSummary): JobSummary => ({
+  consideredResults: summary.consideredResults,
+  fetchedDocuments: summary.fetchedDocuments,
+  ingestedDocuments: summary.ingestedDocuments,
+  skippedDocuments: summary.skippedDocuments,
+  artifacts: [...summary.artifacts],
+  metrics: { ...summary.metrics },
+  notes: summary.notes ?? null,
+});
+
+/** Deep clone for failure entries. */
+const cloneFailure = (failure: JobFailure): JobFailure => ({
+  code: failure.code,
+  message: failure.message,
+  stage: failure.stage ?? null,
+  occurredAt: failure.occurredAt,
+  details: failure.details ?? null,
+});
+
+/**
+ * In-memory job store primarily used for tests and local development. All
+ * operations perform defensive cloning to avoid leaking mutable references.
+ */
+export class InMemorySearchJobStore implements SearchJobStore {
+  private readonly ttlMs: number;
+  private readonly clock: () => number;
+  private readonly mutex = new AsyncMutex();
+  private readonly records = new Map<string, InternalRecord>();
+
+  constructor(options: InMemorySearchJobStoreOptions = {}) {
+    this.ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+    this.clock = options.clock ?? (() => Date.now());
+  }
+
+  async create(job: JobMeta): Promise<void> {
+    await this.mutex.runExclusive(async () => {
+      const jobId = job.id.trim();
+      if (jobId.length === 0) {
+        throw new Error("Job id must not be empty");
+      }
+      if (this.records.has(jobId)) {
+        throw new Error(`Job with id ${jobId} already exists`);
+      }
+
+      const provenance = cloneProvenance(job.provenance);
+      const meta: StoredJobMeta = {
+        id: jobId,
+        createdAt: job.createdAt,
+        query: job.query,
+        normalizedQuery: job.normalizedQuery,
+        tags: normaliseTags(job.tags),
+        requester: job.requester ?? null,
+        budget: normaliseBudget(job.budget),
+      };
+
+      const initialState: JobState = {
+        status: "pending",
+        createdAt: meta.createdAt,
+        updatedAt: meta.createdAt,
+        startedAt: null,
+        completedAt: null,
+        failedAt: null,
+        progress: null,
+        summary: null,
+        errors: [],
+      };
+
+      this.records.set(jobId, {
+        meta,
+        provenance,
+        state: initialState,
+      });
+    });
+  }
+
+  async update(jobId: string, patch: JobStatePatch): Promise<void> {
+    await this.mutex.runExclusive(async () => {
+      const record = this.records.get(jobId);
+      if (!record) {
+        throw new Error(`Unknown job id ${jobId}`);
+      }
+
+      if (isTerminalStatus(record.state.status)) {
+        throw new Error(`Job ${jobId} is immutable after reaching ${record.state.status}`);
+      }
+
+      const nextState = this.applyPatch(record.state, patch);
+      this.records.set(jobId, {
+        meta: record.meta,
+        provenance: record.provenance,
+        state: nextState,
+      });
+    });
+  }
+
+  async get(jobId: string): Promise<JobRecord | null> {
+    const record = this.records.get(jobId);
+    if (!record) {
+      return null;
+    }
+    return this.cloneRecord(record);
+  }
+
+  async list(filter: ListFilter = {}): Promise<JobRecord[]> {
+    const { status, since, until, tag, tags, limit } = filter;
+    let statuses: Set<JobStatus> | null = null;
+    if (status !== undefined) {
+      if (typeof status === "string") {
+        statuses = new Set<JobStatus>([status]);
+      } else {
+        statuses = new Set<JobStatus>(status);
+      }
+    }
+    const requiredTags = tags === undefined ? null : new Set(tags);
+
+    const results: JobRecord[] = [];
+    for (const record of this.records.values()) {
+      if (statuses && !statuses.has(record.state.status)) {
+        continue;
+      }
+      if (since !== undefined && record.state.updatedAt < since) {
+        continue;
+      }
+      if (until !== undefined && record.state.updatedAt > until) {
+        continue;
+      }
+      if (tag && !record.meta.tags.includes(tag)) {
+        continue;
+      }
+      if (requiredTags) {
+        const hasAll = [...requiredTags].every((entry) => record.meta.tags.includes(entry));
+        if (!hasAll) {
+          continue;
+        }
+      }
+      results.push(this.cloneRecord(record));
+    }
+
+    results.sort((a, b) => b.state.updatedAt - a.state.updatedAt);
+    if (limit !== undefined && results.length > limit) {
+      return results.slice(0, limit);
+    }
+    return results;
+  }
+
+  async gc(now: number): Promise<number> {
+    return this.mutex.runExclusive(async () => {
+      let purged = 0;
+      for (const [jobId, record] of this.records.entries()) {
+        if (!isTerminalStatus(record.state.status)) {
+          continue;
+        }
+        if (now - record.state.updatedAt < this.ttlMs) {
+          continue;
+        }
+        this.records.delete(jobId);
+        purged += 1;
+      }
+      return purged;
+    });
+  }
+
+  private cloneRecord(record: InternalRecord): JobRecord {
+    return {
+      meta: {
+        id: record.meta.id,
+        createdAt: record.meta.createdAt,
+        query: record.meta.query,
+        normalizedQuery: record.meta.normalizedQuery,
+        tags: [...record.meta.tags],
+        requester: record.meta.requester,
+        budget: { ...record.meta.budget },
+      },
+      provenance: cloneProvenance(record.provenance),
+      state: this.cloneState(record.state),
+    };
+  }
+
+  private cloneState(state: JobState): JobState {
+    return {
+      status: state.status,
+      createdAt: state.createdAt,
+      updatedAt: state.updatedAt,
+      startedAt: state.startedAt,
+      completedAt: state.completedAt,
+      failedAt: state.failedAt,
+      progress: state.progress ? cloneProgress(state.progress) : null,
+      summary: state.summary ? cloneSummary(state.summary) : null,
+      errors: state.errors.map(cloneFailure),
+    };
+  }
+
+  private applyPatch(current: JobState, patch: JobStatePatch): JobState {
+    if (Object.prototype.hasOwnProperty.call(patch, "createdAt")) {
+      throw new Error("createdAt is immutable");
+    }
+
+    const updatedAt = patch.updatedAt ?? this.clock();
+    if (!Number.isFinite(updatedAt)) {
+      throw new Error("updatedAt must be a finite number");
+    }
+    if (updatedAt < current.updatedAt) {
+      throw new Error("updatedAt must be monotonically increasing");
+    }
+
+    const nextStatus = patch.status ?? current.status;
+    if (nextStatus !== current.status && !this.isValidTransition(current.status, nextStatus)) {
+      throw new Error(`Invalid status transition ${current.status} → ${nextStatus}`);
+    }
+
+    const startedAt = this.resolveTimestamp(patch.startedAt, current.startedAt, current.createdAt, updatedAt);
+    const completedAt = this.resolveTimestamp(patch.completedAt, current.completedAt, current.createdAt, updatedAt);
+    const failedAt = this.resolveTimestamp(patch.failedAt, current.failedAt, current.createdAt, updatedAt);
+
+    if (nextStatus === "running" && startedAt === null) {
+      throw new Error("running jobs must have a startedAt timestamp");
+    }
+    if (nextStatus === "completed" && completedAt === null) {
+      throw new Error("completed jobs must have a completedAt timestamp");
+    }
+    if (nextStatus === "failed" && failedAt === null) {
+      throw new Error("failed jobs must have a failedAt timestamp");
+    }
+
+    if (isTerminalStatus(nextStatus) && !isTerminalStatus(current.status)) {
+      // Allow updating summary/errors alongside the transition.
+    }
+
+    return {
+      status: nextStatus,
+      createdAt: current.createdAt,
+      updatedAt,
+      startedAt,
+      completedAt,
+      failedAt,
+      progress:
+        patch.progress === undefined
+          ? current.progress
+          : patch.progress === null
+          ? null
+          : cloneProgress(patch.progress),
+      summary:
+        patch.summary === undefined
+          ? current.summary
+          : patch.summary === null
+          ? null
+          : cloneSummary(patch.summary),
+      errors:
+        patch.errors === undefined
+          ? current.errors
+          : patch.errors.map(cloneFailure),
+    };
+  }
+
+  private resolveTimestamp(
+    candidate: number | null | undefined,
+    previous: number | null,
+    lowerBound: number,
+    fallback: number,
+  ): number | null {
+    if (candidate === undefined) {
+      if (previous !== null) {
+        return previous;
+      }
+      candidate = fallback;
+    }
+    if (candidate === null) {
+      return null;
+    }
+    if (!Number.isFinite(candidate)) {
+      throw new Error("timestamps must be finite numbers");
+    }
+    if (candidate < lowerBound) {
+      throw new Error("timestamps must be greater than or equal to createdAt");
+    }
+    if (previous !== null && candidate < previous) {
+      throw new Error("timestamps must be monotonically increasing");
+    }
+    return candidate;
+  }
+
+  private isValidTransition(from: JobStatus, to: JobStatus): boolean {
+    if (from === to) {
+      return true;
+    }
+    switch (from) {
+      case "pending":
+        return to === "running" || to === "failed";
+      case "running":
+        return to === "completed" || to === "failed";
+      default:
+        return false;
+    }
+  }
+}

--- a/src/tools/search_status.ts
+++ b/src/tools/search_status.ts
@@ -12,9 +12,12 @@ import type {
 } from "../mcp/registry.js";
 import {
   SearchStatusInputSchema,
+  SearchStatusInputShape,
+  SearchStatusJobRecord,
   SearchStatusOutputSchema,
 } from "../rpc/searchSchemas.js";
 import type { SearchStatusInput, SearchStatusOutput } from "../rpc/searchSchemas.js";
+import type { JobRecord, JobStatus, ListFilter, SearchJobStore } from "../search/jobStore.js";
 import { buildToolSuccessResult } from "./shared.js";
 
 /** Canonical façade identifier registered with the MCP server. */
@@ -25,7 +28,7 @@ export const SearchStatusManifestDraft: ToolManifestDraft = {
   name: SEARCH_STATUS_TOOL_NAME,
   title: "Statut des recherches",
   description:
-    "Retourne l'état d'un job de recherche si la persistance est activée. Actuellement renvoie une information d'indisponibilité. Exemple : search.status {\"job_id\":\"abc123\"}",
+    "Retourne l'état détaillé d'un job de recherche ou liste les exécutions récentes selon des filtres (statut, tags, période). Exemple : search.status {\"status\":\"running\"}",
   kind: "dynamic",
   category: "runtime",
   tags: ["search", "web", "ops"],
@@ -37,37 +40,189 @@ export const SearchStatusManifestDraft: ToolManifestDraft = {
   },
 };
 
+/** Default maximum number of job records returned when filters omit `limit`. */
+const DEFAULT_SEARCH_STATUS_LIMIT = 25;
+
 /** Dependencies injected when binding the façade. */
 export interface SearchStatusToolContext {
   readonly logger: StructuredLogger;
+  readonly jobStore: SearchJobStore | null;
 }
 
 type RpcExtra = RequestHandlerExtra<ServerRequest, ServerNotification>;
 
+function dedupeStatuses(status: JobStatus | readonly JobStatus[]): JobStatus | readonly JobStatus[] {
+  if (!Array.isArray(status)) {
+    return status;
+  }
+  const unique = Array.from(new Set(status));
+  return unique.length === 1 ? unique[0]! : unique;
+}
+
+function normaliseTags(values: readonly string[] | undefined): string[] | undefined {
+  if (!values) {
+    return undefined;
+  }
+  const trimmed = Array.from(new Set(values.map((value) => value.trim()).filter((value) => value.length > 0)));
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function buildListFilter(input: SearchStatusInput): ListFilter {
+  const tag = input.tag?.trim();
+  const tags = normaliseTags(input.tags);
+  return {
+    limit: input.limit ?? DEFAULT_SEARCH_STATUS_LIMIT,
+    ...(input.status !== undefined ? { status: dedupeStatuses(input.status) } : {}),
+    ...(tag && tag.length > 0 ? { tag } : {}),
+    ...(tags ? { tags } : {}),
+    ...(input.since !== undefined ? { since: input.since } : {}),
+    ...(input.until !== undefined ? { until: input.until } : {}),
+  } satisfies ListFilter;
+}
+
+function serialiseJobRecord(record: JobRecord): SearchStatusJobRecord {
+  const { meta, state, provenance } = record;
+  return {
+    job_id: meta.id,
+    meta: {
+      id: meta.id,
+      created_at: meta.createdAt,
+      query: meta.query,
+      normalized_query: meta.normalizedQuery,
+      tags: [...meta.tags],
+      requester: meta.requester ?? null,
+      budget: {
+        max_duration_ms: meta.budget.maxDurationMs ?? null,
+        max_tool_calls: meta.budget.maxToolCalls ?? null,
+        max_bytes_out: meta.budget.maxBytesOut ?? null,
+      },
+    },
+    state: {
+      status: state.status,
+      created_at: state.createdAt,
+      updated_at: state.updatedAt,
+      started_at: state.startedAt ?? null,
+      completed_at: state.completedAt ?? null,
+      failed_at: state.failedAt ?? null,
+      progress: state.progress
+        ? {
+            step: state.progress.step,
+            message: state.progress.message ?? null,
+            ratio: state.progress.ratio ?? null,
+            updated_at: state.progress.updatedAt,
+          }
+        : null,
+      summary: state.summary
+        ? {
+            considered_results: state.summary.consideredResults,
+            fetched_documents: state.summary.fetchedDocuments,
+            ingested_documents: state.summary.ingestedDocuments,
+            skipped_documents: state.summary.skippedDocuments,
+            artifacts: [...state.summary.artifacts],
+            metrics: { ...state.summary.metrics },
+            notes: state.summary.notes ?? null,
+          }
+        : null,
+      errors: state.errors.map((failure) => ({
+        code: failure.code,
+        message: failure.message,
+        stage: failure.stage ?? null,
+        occurred_at: failure.occurredAt,
+        details: failure.details ?? null,
+      })),
+    },
+    provenance: {
+      trigger: provenance.trigger,
+      transport: provenance.transport,
+      request_id: provenance.requestId ?? null,
+      requester: provenance.requester ?? null,
+      remote_address: provenance.remoteAddress ?? null,
+      extra: { ...provenance.extra },
+    },
+  } satisfies SearchStatusJobRecord;
+}
+
 /**
- * Factory returning the handler for the `search.status` façade. The current
- * implementation surfaces a deterministic not-implemented response while the
- * persistence layer is under construction.
+ * Factory returning the handler for the `search.status` façade. The handler
+ * inspects the configured job store and either retrieves a single job or lists
+ * matching records while guaranteeing that the structured payload matches the
+ * published schema (no `undefined`, camelCase → snake_case conversion).
  */
 export function createSearchStatusHandler(context: SearchStatusToolContext): ToolImplementation {
   return async (input: unknown, extra: RpcExtra): Promise<CallToolResult> => {
     const parsed: SearchStatusInput = SearchStatusInputSchema.parse(input);
     const rpcContext = getJsonRpcContext();
     const traceContext = getActiveTraceContext();
-
-    const payload: SearchStatusOutput = SearchStatusOutputSchema.parse({
-      ok: false,
-      code: "not_implemented" as const,
-      message: "la persistance des jobs de recherche n'est pas encore disponible",
-    });
-
-    context.logger.warn("search_status_not_implemented", {
+    const baseLogContext = {
       request_id: rpcContext?.requestId ?? extra.requestId ?? null,
       trace_id: traceContext?.traceId ?? null,
       job_id: parsed.job_id ?? null,
-    });
+    } as const;
 
-    return buildToolSuccessResult(JSON.stringify({ tool: SEARCH_STATUS_TOOL_NAME, result: payload }, null, 2), payload);
+    if (!context.jobStore) {
+      const payload: SearchStatusOutput = SearchStatusOutputSchema.parse({
+        ok: false,
+        code: "persistence_unavailable" as const,
+        message: "la persistance des jobs de recherche est désactivée ou indisponible",
+      });
+      context.logger.warn("search_status_persistence_unavailable", baseLogContext);
+      return buildToolSuccessResult(
+        JSON.stringify({ tool: SEARCH_STATUS_TOOL_NAME, result: payload }, null, 2),
+        payload,
+      );
+    }
+
+    if (parsed.job_id) {
+      const record = await context.jobStore.get(parsed.job_id);
+      if (!record) {
+        const payload: SearchStatusOutput = SearchStatusOutputSchema.parse({
+          ok: false,
+          code: "not_found" as const,
+          message: `aucun job trouvé pour l'identifiant ${parsed.job_id}`,
+        });
+        context.logger.warn("search_status_job_not_found", baseLogContext);
+        return buildToolSuccessResult(
+          JSON.stringify({ tool: SEARCH_STATUS_TOOL_NAME, result: payload }, null, 2),
+          payload,
+        );
+      }
+
+      const payload: SearchStatusOutput = SearchStatusOutputSchema.parse({
+        ok: true,
+        result: serialiseJobRecord(record),
+      });
+      context.logger.info("search_status_job_resolved", {
+        ...baseLogContext,
+        status: record.state.status,
+      });
+      return buildToolSuccessResult(
+        JSON.stringify({ tool: SEARCH_STATUS_TOOL_NAME, result: payload }, null, 2),
+        payload,
+      );
+    }
+
+    const filter = buildListFilter(parsed);
+    const records = await context.jobStore.list(filter);
+    const payload: SearchStatusOutput = SearchStatusOutputSchema.parse({
+      ok: true,
+      result: records.map(serialiseJobRecord),
+    });
+    context.logger.info("search_status_list_resolved", {
+      ...baseLogContext,
+      filters: {
+        ...(filter.status ? { status: filter.status } : {}),
+        ...(filter.tag ? { tag: filter.tag } : {}),
+        ...(filter.tags ? { tags: filter.tags } : {}),
+        ...(filter.since ? { since: filter.since } : {}),
+        ...(filter.until ? { until: filter.until } : {}),
+        limit: filter.limit ?? DEFAULT_SEARCH_STATUS_LIMIT,
+      },
+      results: records.length,
+    });
+    return buildToolSuccessResult(
+      JSON.stringify({ tool: SEARCH_STATUS_TOOL_NAME, result: payload }, null, 2),
+      payload,
+    );
   };
 }
 
@@ -77,7 +232,7 @@ export async function registerSearchStatusTool(
   context: SearchStatusToolContext,
 ): Promise<ToolManifest> {
   return await registry.register(SearchStatusManifestDraft, createSearchStatusHandler(context), {
-    inputSchema: SearchStatusInputSchema.shape,
+    inputSchema: SearchStatusInputShape,
     annotations: { intent: SEARCH_STATUS_TOOL_NAME },
     meta: {
       help: 'search.status {"job_id":"search:job:123"}',

--- a/tests/http/bootstrap.runtime.test.ts
+++ b/tests/http/bootstrap.runtime.test.ts
@@ -41,6 +41,21 @@ async function createPersistentIdempotencyStore(): Promise<FileIdempotencyStore>
 }
 
 describe("http/bootstrap", () => {
+  let originalSearchPersist: string | undefined;
+
+  beforeEach(() => {
+    originalSearchPersist = process.env.MCP_SEARCH_STATUS_PERSIST;
+    process.env.MCP_SEARCH_STATUS_PERSIST = "memory";
+  });
+
+  afterEach(() => {
+    if (originalSearchPersist === undefined) {
+      delete process.env.MCP_SEARCH_STATUS_PERSIST;
+    } else {
+      process.env.MCP_SEARCH_STATUS_PERSIST = originalSearchPersist;
+    }
+  });
+
   it("prepares idempotency and readiness wiring for stateless HTTP", async () => {
     const entries: LogEntry[] = [];
     const logger = new StructuredLogger({ onEntry: (entry) => entries.push(entry) });

--- a/tests/search/status.tool.test.ts
+++ b/tests/search/status.tool.test.ts
@@ -1,0 +1,218 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import type {
+  RequestHandlerExtra,
+  ServerNotification,
+  ServerRequest,
+} from "@modelcontextprotocol/sdk/shared/protocol.js";
+
+import { StructuredLogger } from "../../src/logger.js";
+import { InMemorySearchJobStore } from "../../src/search/jobStoreMemory.js";
+import type { SearchJobStore } from "../../src/search/jobStore.js";
+import { createSearchStatusHandler, SEARCH_STATUS_TOOL_NAME } from "../../src/tools/search_status.js";
+
+function createExtras(requestId: string): RequestHandlerExtra<ServerRequest, ServerNotification> {
+  const controller = new AbortController();
+  return {
+    signal: controller.signal,
+    requestId,
+    sendNotification: async () => {
+      throw new Error("unexpected notification during search_status tests");
+    },
+    sendRequest: async () => {
+      throw new Error("unexpected nested request during search_status tests");
+    },
+  } as RequestHandlerExtra<ServerRequest, ServerNotification>;
+}
+
+function createJobStore(clock: () => number = () => Date.now()): SearchJobStore {
+  return new InMemorySearchJobStore({ ttlMs: 86_400_000, clock });
+}
+
+describe("search.status tool", () => {
+  it("signale l'indisponibilité lorsque la persistance est inactive", async () => {
+    const logger = new StructuredLogger();
+    const handler = createSearchStatusHandler({ logger, jobStore: null });
+    const extras = createExtras("req-search-status-1");
+
+    const result = await handler({ job_id: "search:job:demo" }, extras);
+    expect(result.isError).to.equal(false);
+    expect(result.structuredContent).to.deep.equal({
+      ok: false,
+      code: "persistence_unavailable",
+      message: "la persistance des jobs de recherche est désactivée ou indisponible",
+    });
+    const textPayload = result.content?.[0]?.text ?? "";
+    expect(textPayload).to.include(SEARCH_STATUS_TOOL_NAME);
+    expect(textPayload).to.include("persistence_unavailable");
+  });
+
+  it("retourne un job complet lorsqu'il est présent dans le store", async () => {
+    let now = 1_730_000_000_000;
+    const clock = () => (now += 25);
+    const jobStore = createJobStore(clock);
+    const logger = new StructuredLogger();
+    const handler = createSearchStatusHandler({ logger, jobStore });
+    const extras = createExtras("req-search-status-2");
+
+    await jobStore.create({
+      id: "search:job:demo",
+      createdAt: now,
+      query: "recherche orchestrateur",
+      normalizedQuery: "recherche orchestrateur",
+      tags: ["ops", "demo"],
+      requester: "alice@example.com",
+      budget: { maxDurationMs: 120_000, maxToolCalls: null, maxBytesOut: null },
+      provenance: {
+        trigger: "search.run",
+        transport: "stdio",
+        requestId: "req-demo-1",
+        requester: "alice@example.com",
+        remoteAddress: null,
+        extra: { scenario: "unit-test" },
+      },
+    });
+
+    await jobStore.update("search:job:demo", {
+      status: "running",
+      startedAt: now + 10,
+      updatedAt: now + 10,
+      progress: {
+        step: "initialising",
+        message: "initialisation du pipeline",
+        ratio: 0.1,
+        updatedAt: now + 10,
+      },
+    });
+
+    await jobStore.update("search:job:demo", {
+      status: "completed",
+      completedAt: now + 40,
+      updatedAt: now + 40,
+      progress: null,
+      summary: {
+        consideredResults: 6,
+        fetchedDocuments: 4,
+        ingestedDocuments: 3,
+        skippedDocuments: 1,
+        artifacts: ["validation_run/search/jobs/demo-summary.json"],
+        metrics: { total_duration_ms: 32 },
+        notes: null,
+      },
+      errors: [
+        {
+          code: "download_timeout",
+          message: "timeout sur https://example.com/slow",
+          stage: "fetch",
+          occurredAt: now + 30,
+          details: { url: "https://example.com/slow" },
+        },
+      ],
+    });
+
+    const result = await handler({ job_id: "search:job:demo" }, extras);
+    expect(result.isError).to.equal(false);
+    const payload = result.structuredContent as {
+      ok: true;
+      result: Record<string, unknown>;
+    };
+    expect(payload.ok).to.equal(true);
+    const record = payload.result as Record<string, any>;
+    expect(record.job_id).to.equal("search:job:demo");
+    expect(record.meta.tags).to.deep.equal(["ops", "demo"]);
+    expect(record.state.status).to.equal("completed");
+    expect(record.state.summary.metrics.total_duration_ms).to.equal(32);
+    expect(record.state.errors).to.have.lengthOf(1);
+    expect(record.provenance.extra.scenario).to.equal("unit-test");
+    expect(() => JSON.parse(result.content?.[0]?.text ?? "")).to.not.throw();
+  });
+
+  it("filtre les jobs selon statut et tags", async () => {
+    let now = 1_740_000_000_000;
+    const clock = () => (now += 50);
+    const jobStore = createJobStore(clock);
+    const logger = new StructuredLogger();
+    const handler = createSearchStatusHandler({ logger, jobStore });
+    const extras = createExtras("req-search-status-3");
+
+    await jobStore.create({
+      id: "search:job:alpha",
+      createdAt: now,
+      query: "observabilité",
+      normalizedQuery: "observabilite",
+      tags: ["ops"],
+      requester: null,
+      budget: { maxDurationMs: null, maxToolCalls: null, maxBytesOut: null },
+      provenance: {
+        trigger: "search.index",
+        transport: "http",
+        requestId: "req-alpha",
+        requester: null,
+        remoteAddress: "127.0.0.1",
+        extra: {},
+      },
+    });
+    await jobStore.update("search:job:alpha", {
+      status: "running",
+      startedAt: now + 5,
+      updatedAt: now + 5,
+      progress: {
+        step: "fetch",
+        message: "récupération des documents",
+        ratio: 0.4,
+        updatedAt: now + 5,
+      },
+    });
+
+    await jobStore.create({
+      id: "search:job:beta",
+      createdAt: now + 100,
+      query: "dashboard streaming",
+      normalizedQuery: "dashboard streaming",
+      tags: ["ops", "dashboard"],
+      requester: null,
+      budget: { maxDurationMs: null, maxToolCalls: null, maxBytesOut: null },
+      provenance: {
+        trigger: "search.run",
+        transport: "stdio",
+        requestId: "req-beta",
+        requester: "operator",
+        remoteAddress: null,
+        extra: {},
+      },
+    });
+    await jobStore.update("search:job:beta", {
+      status: "running",
+      startedAt: now + 120,
+      updatedAt: now + 120,
+      progress: {
+        step: "extract",
+        message: null,
+        ratio: 0.6,
+        updatedAt: now + 120,
+      },
+    });
+    await jobStore.update("search:job:beta", {
+      status: "completed",
+      completedAt: now + 170,
+      updatedAt: now + 170,
+      summary: {
+        consideredResults: 3,
+        fetchedDocuments: 3,
+        ingestedDocuments: 2,
+        skippedDocuments: 1,
+        artifacts: [],
+        metrics: { total_duration_ms: 45 },
+        notes: "ingestion partielle",
+      },
+      errors: [],
+    });
+
+    const result = await handler({ status: "completed", tag: "dashboard" }, extras);
+    expect(result.isError).to.equal(false);
+    const payload = result.structuredContent as { ok: true; result: Array<Record<string, any>> };
+    expect(payload.result).to.have.lengthOf(1);
+    expect(payload.result[0]!.job_id).to.equal("search:job:beta");
+    expect(payload.result[0]!.meta.tags).to.include("dashboard");
+  });
+});

--- a/tests/unit/search/jobStore.file.test.ts
+++ b/tests/unit/search/jobStore.file.test.ts
@@ -1,0 +1,213 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { expect } from "chai";
+
+import { FileSearchJobStore } from "../../../src/search/jobStoreFile.js";
+import {
+  type JobFailure,
+  type JobMeta,
+  type JobSummary,
+} from "../../../src/search/jobStore.js";
+
+const buildJobMeta = (id: string, createdAt: number, overrides: Partial<JobMeta> = {}): JobMeta => {
+  const baseBudget = overrides.budget ?? {
+    maxDurationMs: null,
+    maxToolCalls: null,
+    maxBytesOut: null,
+  };
+
+  const baseMeta: JobMeta = {
+    id,
+    createdAt,
+    query: overrides.query ?? "distributed systems",
+    normalizedQuery: overrides.normalizedQuery ?? "distributed systems",
+    tags: overrides.tags ?? ["alpha"],
+    requester: overrides.requester ?? "tester",
+    budget: baseBudget,
+    provenance: overrides.provenance ?? {
+      trigger: "search.run",
+      transport: "stdio",
+      requestId: "req-1",
+      requester: "tester",
+      remoteAddress: null,
+      extra: {},
+    },
+  };
+
+  return {
+    ...baseMeta,
+    ...overrides,
+    budget: baseBudget,
+    provenance: {
+      trigger: baseMeta.provenance.trigger,
+      transport: baseMeta.provenance.transport,
+      requestId: baseMeta.provenance.requestId,
+      requester: baseMeta.provenance.requester,
+      remoteAddress: baseMeta.provenance.remoteAddress,
+      extra: { ...baseMeta.provenance.extra },
+    },
+  };
+};
+
+const createTempDirectory = async (): Promise<string> => {
+  const dir = await fs.mkdtemp(path.join(tmpdir(), "search-job-store-file-"));
+  return dir;
+};
+
+describe("search/jobStoreFile", () => {
+  const directories: string[] = [];
+  const stores: FileSearchJobStore[] = [];
+
+  afterEach(async () => {
+    for (const store of stores.splice(0)) {
+      await store.dispose();
+    }
+    for (const dir of directories.splice(0)) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists jobs to disk and recovers them on restart", async () => {
+    const dir = await createTempDirectory();
+    directories.push(dir);
+
+    let clockNow = 1_700_100_000_000;
+    const store = new FileSearchJobStore({
+      directory: dir,
+      clock: () => clockNow,
+      fsyncMode: "always",
+    });
+    stores.push(store);
+
+    await store.initialise();
+    await store.create(
+      buildJobMeta("job-durable", clockNow, {
+        tags: [" durability ", "durability", "beta"],
+        provenance: {
+          trigger: "search.run",
+          transport: "http",
+          requestId: "req-42",
+          requester: "alice",
+          remoteAddress: "127.0.0.1:9000",
+          extra: { mode: "unit" },
+        },
+      }),
+    );
+
+    clockNow += 10;
+    await store.update("job-durable", {
+      status: "running",
+      startedAt: clockNow,
+      updatedAt: clockNow,
+      progress: {
+        step: "download",
+        message: "fetching",
+        ratio: 0.2,
+        updatedAt: clockNow,
+      },
+    });
+
+    await store.dispose();
+
+    const recovered = new FileSearchJobStore({ directory: dir, clock: () => clockNow });
+    stores.push(recovered);
+    await recovered.initialise();
+
+    const record = await recovered.get("job-durable");
+    expect(record?.state.status).to.equal("running");
+    expect(record?.state.progress?.step).to.equal("download");
+    expect(record?.meta.tags).to.deep.equal(["durability", "beta"]);
+    expect(record?.provenance.remoteAddress).to.equal("127.0.0.1:9000");
+  });
+
+  it("compacts the journal after TTL-based garbage collection", async () => {
+    const dir = await createTempDirectory();
+    directories.push(dir);
+
+    let clockNow = 1_700_200_000_000;
+    const store = new FileSearchJobStore({
+      directory: dir,
+      clock: () => clockNow,
+      ttlMs: 100,
+      fsyncMode: "always",
+    });
+    stores.push(store);
+
+    await store.initialise();
+
+    await store.create(buildJobMeta("job-expired", clockNow));
+    clockNow += 1;
+    await store.update("job-expired", {
+      status: "running",
+      startedAt: clockNow,
+      updatedAt: clockNow,
+    });
+    clockNow += 4;
+    const summary: JobSummary = {
+      consideredResults: 3,
+      fetchedDocuments: 2,
+      ingestedDocuments: 1,
+      skippedDocuments: 0,
+      artifacts: ["validation_run/search/jobs/job-expired.json"],
+      metrics: { "latency.p95": 800 },
+      notes: "completed",
+    };
+    const errors: JobFailure[] = [
+      {
+        code: "FETCH_TIMEOUT",
+        message: "timeout",
+        stage: "download",
+        occurredAt: clockNow,
+        details: { attempt: 1 },
+      },
+    ];
+    await store.update("job-expired", {
+      status: "completed",
+      completedAt: clockNow,
+      updatedAt: clockNow,
+      summary,
+      errors,
+    });
+
+    const beforeStat = await fs.stat(path.join(dir, "jobs.active.jsonl"));
+
+    clockNow += 200;
+    const purged = await store.gc(clockNow);
+    expect(purged).to.equal(1);
+
+    const journalPath = path.join(dir, "jobs.active.jsonl");
+    const afterStat = await fs.stat(journalPath);
+    expect(afterStat.mtimeMs).to.be.at.least(beforeStat.mtimeMs);
+    expect(afterStat.size).to.be.at.most(beforeStat.size);
+
+    const content = await fs.readFile(journalPath, "utf8");
+    expect(content.trim()).to.equal("");
+  });
+
+  it("surfaces a warning when the lock file already exists", async () => {
+    const dir = await createTempDirectory();
+    directories.push(dir);
+
+    const captured: string[] = [];
+    const storeA = new FileSearchJobStore({ directory: dir, fsyncMode: "never" });
+    stores.push(storeA);
+    await storeA.initialise();
+
+    const storeB = new FileSearchJobStore({
+      directory: dir,
+      fsyncMode: "never",
+      log: (level, message) => {
+        if (level === "warn") {
+          captured.push(message);
+        }
+      },
+    });
+    stores.push(storeB);
+    await storeB.initialise();
+
+    expect(captured.some((entry) => entry.includes("lock already exists"))).to.equal(true);
+  });
+});
+

--- a/tests/unit/search/jobStore.memory.test.ts
+++ b/tests/unit/search/jobStore.memory.test.ts
@@ -1,0 +1,314 @@
+import { expect } from "chai";
+
+import {
+  InMemorySearchJobStore,
+  type InMemorySearchJobStoreOptions,
+} from "../../../src/search/jobStoreMemory.js";
+import {
+  type JobFailure,
+  type JobMeta,
+  type JobProgress,
+  type JobSummary,
+} from "../../../src/search/jobStore.js";
+
+/**
+ * Helper returning deterministic metadata for the tests. Individual scenarios
+ * override the pieces that need to vary (timestamps, tags, ...).
+ */
+const buildJobMeta = (id: string, createdAt: number, overrides: Partial<JobMeta> = {}): JobMeta => {
+  const baseBudget = overrides.budget ?? {
+    maxDurationMs: null,
+    maxToolCalls: null,
+    maxBytesOut: null,
+  };
+
+  const baseMeta: JobMeta = {
+    id,
+    createdAt,
+    query: overrides.query ?? "rust concurrency",
+    normalizedQuery: overrides.normalizedQuery ?? "rust concurrency",
+    tags: overrides.tags ?? ["alpha"],
+    requester: overrides.requester ?? "tester",
+    budget: baseBudget,
+    provenance: overrides.provenance ?? {
+      trigger: "search.run",
+      transport: "stdio",
+      requestId: "req-1",
+      requester: "tester",
+      remoteAddress: null,
+      extra: {},
+    },
+  };
+
+  return {
+    ...baseMeta,
+    ...overrides,
+    budget: baseBudget,
+    provenance: {
+      trigger: baseMeta.provenance.trigger,
+      transport: baseMeta.provenance.transport,
+      requestId: baseMeta.provenance.requestId,
+      requester: baseMeta.provenance.requester,
+      remoteAddress: baseMeta.provenance.remoteAddress,
+      extra: { ...baseMeta.provenance.extra },
+    },
+  };
+};
+
+const createStore = (options: InMemorySearchJobStoreOptions = {}): InMemorySearchJobStore =>
+  new InMemorySearchJobStore({
+    ttlMs: options.ttlMs,
+    clock: options.clock,
+  });
+
+describe("search/jobStoreMemory", () => {
+  it("creates a job and returns an immutable snapshot", async () => {
+    const createdAt = 1_700_000_000_000;
+    const store = createStore();
+    const job = buildJobMeta("job-1", createdAt, {
+      tags: [" alpha ", "alpha", "beta"],
+      provenance: {
+        trigger: "search.run",
+        transport: "stdio",
+        requestId: "req-42",
+        requester: "alice",
+        remoteAddress: "127.0.0.1:8080",
+        extra: { scenario: "unit" },
+      },
+    });
+
+    await store.create(job);
+    const record = await store.get("job-1");
+    expect(record).to.not.equal(null);
+    expect(record?.meta.id).to.equal("job-1");
+    expect(record?.meta.tags).to.deep.equal(["alpha", "beta"]);
+    expect(record?.state.status).to.equal("pending");
+    expect(record?.state.createdAt).to.equal(createdAt);
+    expect(record?.provenance.requestId).to.equal("req-42");
+
+    if (!record) {
+      throw new Error("record should not be null");
+    }
+    const snapshot = await store.get("job-1");
+    expect(snapshot).to.not.equal(record);
+  });
+
+  it("rejects duplicate job identifiers", async () => {
+    const store = createStore();
+    const createdAt = 1_700_000_001_000;
+    await store.create(buildJobMeta("dup", createdAt));
+
+    try {
+      await store.create(buildJobMeta("dup", createdAt + 1));
+      expect.fail("second creation should throw");
+    } catch (error) {
+      expect((error as Error).message).to.include("already exists");
+    }
+  });
+
+  it("enforces valid status transitions and timestamps", async () => {
+    let now = 1_700_000_010_000;
+    const store = createStore({ clock: () => now });
+    await store.create(buildJobMeta("job-transition", now));
+
+    await store.update("job-transition", {
+      status: "running",
+      updatedAt: now + 1,
+      startedAt: now + 1,
+      progress: {
+        step: "download",
+        message: "fetching",
+        ratio: 0.1,
+        updatedAt: now + 1,
+      },
+    });
+
+    const summary: JobSummary = {
+      consideredResults: 5,
+      fetchedDocuments: 3,
+      ingestedDocuments: 2,
+      skippedDocuments: 1,
+      artifacts: ["validation_run/search/jobs/job-transition.json"],
+      metrics: { "latency.p95": 1200 },
+      notes: "completed without retries",
+    };
+    const errors: JobFailure[] = [
+      {
+        code: "FETCH_TIMEOUT",
+        message: "timeout while fetching example.com",
+        stage: "fetch",
+        occurredAt: now + 2,
+        details: { url: "https://example.com" },
+      },
+    ];
+
+    await store.update("job-transition", {
+      status: "completed",
+      updatedAt: now + 5,
+      completedAt: now + 5,
+      summary,
+      errors,
+    });
+
+    const record = await store.get("job-transition");
+    expect(record?.state.status).to.equal("completed");
+    expect(record?.state.summary).to.deep.equal(summary);
+    expect(record?.state.errors).to.deep.equal(errors);
+
+    try {
+      await store.update("job-transition", { status: "running", updatedAt: now + 6 });
+      expect.fail("terminal jobs must be immutable");
+    } catch (error) {
+      expect((error as Error).message).to.include("immutable");
+    }
+  });
+
+  it("filters jobs by status, tags and recency", async () => {
+    let now = 1_700_000_020_000;
+    const store = createStore({ clock: () => now });
+
+    await store.create(buildJobMeta("job-a", now, { tags: ["alpha"] }));
+    await store.create(buildJobMeta("job-b", now + 1, { tags: ["beta"] }));
+    await store.create(buildJobMeta("job-c", now + 2, { tags: ["alpha", "gamma"] }));
+
+    await store.update("job-a", {
+      status: "running",
+      updatedAt: now + 3,
+      startedAt: now + 3,
+    });
+    await store.update("job-b", {
+      status: "failed",
+      updatedAt: now + 4,
+      failedAt: now + 4,
+      errors: [
+        {
+          code: "EXTRACT_ERROR",
+          message: "extractor crashed",
+          stage: "extract",
+          occurredAt: now + 4,
+          details: null,
+        },
+      ],
+    });
+    await store.update("job-c", {
+      status: "running",
+      updatedAt: now + 4,
+      startedAt: now + 4,
+    });
+    await store.update("job-c", {
+      status: "completed",
+      updatedAt: now + 5,
+      completedAt: now + 5,
+      summary: {
+        consideredResults: 2,
+        fetchedDocuments: 1,
+        ingestedDocuments: 1,
+        skippedDocuments: 0,
+        artifacts: [],
+        metrics: {},
+        notes: null,
+      },
+    });
+
+    const byStatus = await store.list({ status: "completed" });
+    expect(byStatus).to.have.lengthOf(1);
+    expect(byStatus[0]?.meta.id).to.equal("job-c");
+
+    const byTag = await store.list({ tag: "alpha" });
+    expect(byTag.map((entry) => entry.meta.id)).to.deep.equal(["job-c", "job-a"]);
+
+    const recent = await store.list({ since: now + 4 });
+    expect(recent.map((entry) => entry.meta.id)).to.deep.equal(["job-c", "job-b"]);
+
+    const limited = await store.list({ limit: 2 });
+    expect(limited.map((entry) => entry.meta.id)).to.deep.equal(["job-c", "job-b"]);
+  });
+
+  it("garbage collects terminal jobs beyond the TTL", async () => {
+    let now = 1_700_000_030_000;
+    const store = createStore({ ttlMs: 10, clock: () => now });
+
+    await store.create(buildJobMeta("job-old", now));
+    await store.create(buildJobMeta("job-fresh", now));
+
+    await store.update("job-old", {
+      status: "running",
+      updatedAt: now + 1,
+      startedAt: now + 1,
+    });
+    await store.update("job-old", {
+      status: "completed",
+      updatedAt: now + 2,
+      completedAt: now + 2,
+      summary: {
+        consideredResults: 1,
+        fetchedDocuments: 1,
+        ingestedDocuments: 1,
+        skippedDocuments: 0,
+        artifacts: [],
+        metrics: {},
+        notes: null,
+      },
+    });
+
+    await store.update("job-fresh", {
+      status: "failed",
+      updatedAt: now + 8,
+      failedAt: now + 8,
+      errors: [
+        {
+          code: "DOWNLOAD_ERROR",
+          message: "network reset",
+          stage: "fetch",
+          occurredAt: now + 8,
+          details: null,
+        },
+      ],
+    });
+
+    now += 12;
+    const purged = await store.gc(now);
+    expect(purged).to.equal(1);
+    expect(await store.get("job-old")).to.equal(null);
+    expect(await store.get("job-fresh")).to.not.equal(null);
+  });
+
+  it("serialises concurrent updates to maintain consistency", async () => {
+    let now = 1_700_000_040_000;
+    const store = createStore({ clock: () => now });
+    await store.create(buildJobMeta("job-concurrent", now));
+    await store.update("job-concurrent", {
+      status: "running",
+      updatedAt: now + 1,
+      startedAt: now + 1,
+    });
+
+    const updates = Array.from({ length: 5 }, (_, index) => {
+      const progress: JobProgress = {
+        step: index % 2 === 0 ? "download" : "extract",
+        message: `stage-${index}`,
+        ratio: index / 5,
+        updatedAt: now + 2 + index,
+      };
+      now += 1;
+      return store.update("job-concurrent", {
+        updatedAt: now,
+        progress,
+      });
+    });
+
+    await Promise.all(updates);
+    const record = await store.get("job-concurrent");
+    expect(record?.state.progress?.message).to.equal("stage-4");
+    expect(record?.state.progress?.step).to.equal("download");
+  });
+
+  it("defaults startedAt to the update timestamp when omitted", async () => {
+    const store = createStore();
+    await store.create(buildJobMeta("job-missing-start", 1_700_000_050_000));
+
+    await store.update("job-missing-start", { status: "running", updatedAt: 1_700_000_050_001 });
+    const record = await store.get("job-missing-start");
+    expect(record?.state.startedAt).to.equal(1_700_000_050_001);
+  });
+});


### PR DESCRIPTION
## Summary
- expose the `search.status` facade with filterable inputs, durable job serialization, and clear error codes when persistence is unavailable
- add environment-driven configuration for the search job store, wire instantiation into the orchestrator runtime, and expand logging/event mappings for new job lifecycle events
- cover the new behaviour with unit tests for the server options reader and the `search.status` tool

## Testing
- npm run build
- TSX_EXTENSIONS=ts node --import tsx ./node_modules/mocha/bin/mocha.js --reporter tap --file tests/setup.ts tests/serverOptions.parse.test.ts tests/search/status.tool.test.ts

------
https://chatgpt.com/codex/tasks/task_e_6906f344bc84832fb8c5beb63bb71c85